### PR TITLE
Mount volumes as host user

### DIFF
--- a/armory/baseline_models/pytorch/imagenet.py
+++ b/armory/baseline_models/pytorch/imagenet.py
@@ -7,11 +7,11 @@ import torch
 from torch import nn
 from torchvision import models
 
-from armory import paths
+from armory.paths import DockerPaths
 
 
 logger = logging.getLogger(__name__)
-os.environ["TORCH_HOME"] = os.path.join(paths.DATASETS, "pytorch", "models")
+os.environ["TORCH_HOME"] = os.path.join(DockerPaths().dataset_dir, "pytorch", "models")
 
 
 def resnet50(pretrained=True):

--- a/armory/data/datasets.py
+++ b/armory/data/datasets.py
@@ -12,10 +12,9 @@ import tensorflow as tf
 import tensorflow_datasets as tfds
 
 from armory.data.utils import curl, download_file_from_s3
-from armory import paths
+from armory.paths import DockerPaths
 
 os.environ["KMP_WARNINGS"] = "0"
-
 
 logger = logging.getLogger(__name__)
 
@@ -25,12 +24,14 @@ def _in_memory_dataset_tfds(
 ) -> (np.ndarray, np.ndarray, np.ndarray, np.ndarray):
     default_graph = tf.compat.v1.keras.backend.get_session().graph
 
+    docker_paths = DockerPaths()
+
     train_x, train_y = tfds.load(
         dataset_name,
         batch_size=-1,
         split="train",
         as_supervised=True,
-        data_dir=paths.DATASETS,
+        data_dir=docker_paths.dataset_dir,
     )
 
     test_x, test_y = tfds.load(
@@ -38,7 +39,7 @@ def _in_memory_dataset_tfds(
         batch_size=-1,
         split="test",
         as_supervised=True,
-        data_dir=paths.DATASETS,
+        data_dir=docker_paths.dataset_dir,
     )
 
     train_x = tfds.as_numpy(train_x, graph=default_graph)
@@ -80,7 +81,8 @@ def cifar10_data(
 
 
 def digit(
-    zero_pad: bool = False, rootdir: str = os.path.join(paths.DATASETS, "external"),
+    zero_pad: bool = False,
+    rootdir: str = os.path.join(DockerPaths().dataset_dir, "external"),
 ) -> (np.ndarray, np.ndarray, np.ndarray, np.ndarray):
     """
     An audio dataset of spoken digits:
@@ -157,7 +159,7 @@ def digit(
 
 def imagenet_adversarial(
     preprocessing_fn: Callable = None,
-    dirpath: str = os.path.join(paths.DATASETS, "external", "imagenet_adv"),
+    dirpath: str = os.path.join(DockerPaths().dataset_dir, "external", "imagenet_adv"),
 ) -> (np.ndarray, np.ndarray, np.ndarray):
     """
     ILSVRC12 adversarial image dataset for ResNet50

--- a/armory/data/datasets.py
+++ b/armory/data/datasets.py
@@ -20,18 +20,16 @@ logger = logging.getLogger(__name__)
 
 
 def _in_memory_dataset_tfds(
-    dataset_name: str, preprocessing_fn: Callable
+    dataset_name: str, dataset_dir: str, preprocessing_fn: Callable,
 ) -> (np.ndarray, np.ndarray, np.ndarray, np.ndarray):
     default_graph = tf.compat.v1.keras.backend.get_session().graph
-
-    docker_paths = DockerPaths()
 
     train_x, train_y = tfds.load(
         dataset_name,
         batch_size=-1,
         split="train",
         as_supervised=True,
-        data_dir=docker_paths.dataset_dir,
+        data_dir=dataset_dir,
     )
 
     test_x, test_y = tfds.load(
@@ -39,7 +37,7 @@ def _in_memory_dataset_tfds(
         batch_size=-1,
         split="test",
         as_supervised=True,
-        data_dir=docker_paths.dataset_dir,
+        data_dir=dataset_dir,
     )
 
     train_x = tfds.as_numpy(train_x, graph=default_graph)
@@ -55,7 +53,7 @@ def _in_memory_dataset_tfds(
 
 
 def mnist_data(
-    preprocessing_fn: Callable = None,
+    dataset_dir: str = None, preprocessing_fn: Callable = None,
 ) -> (np.ndarray, np.ndarray, np.ndarray, np.ndarray):
     """
     Handwritten digits dataset:
@@ -64,11 +62,15 @@ def mnist_data(
     returns:
         train_x, train_y, test_x, test_y
     """
-    return _in_memory_dataset_tfds("mnist:3.0.0", preprocessing_fn=preprocessing_fn)
+    if not dataset_dir:
+        dataset_dir = DockerPaths().dataset_dir
+    return _in_memory_dataset_tfds(
+        "mnist:3.0.0", dataset_dir=dataset_dir, preprocessing_fn=preprocessing_fn
+    )
 
 
 def cifar10_data(
-    preprocessing_fn: Callable = None,
+    dataset_dir: str = None, preprocessing_fn: Callable = None,
 ) -> (np.ndarray, np.ndarray, np.ndarray, np.ndarray):
     """
     Ten class image dataset:
@@ -77,12 +79,15 @@ def cifar10_data(
     returns:
         train_x, train_y, test_x, test_y
     """
-    return _in_memory_dataset_tfds("cifar10:3.0.0", preprocessing_fn=preprocessing_fn)
+    if not dataset_dir:
+        dataset_dir = DockerPaths().dataset_dir
+    return _in_memory_dataset_tfds(
+        "cifar10:3.0.0", dataset_dir=dataset_dir, preprocessing_fn=preprocessing_fn
+    )
 
 
 def digit(
-    zero_pad: bool = False,
-    rootdir: str = os.path.join(DockerPaths().dataset_dir, "external"),
+    zero_pad: bool = False, dataset_dir: str = None,
 ) -> (np.ndarray, np.ndarray, np.ndarray, np.ndarray):
     """
     An audio dataset of spoken digits:
@@ -95,16 +100,20 @@ def digit(
 
     :param zero_pad: Boolean to pad the audio samples to the same length
         if `True`, this returns `audio` arrays as 2D np.int16 arrays
-    :param rootdir: Directory where the dataset is stored
+    :param dataset_dir: Directory where cached datasets are stored
     :return: Train/Test arrays of audio and labels. Sample Rate is 8000 Hz
     """
     from scipy.io import wavfile
+
+    if not dataset_dir:
+        dataset_dir = DockerPaths().dataset_dir
+
+    rootdir = os.path.join(dataset_dir, "external")
 
     url = "https://github.com/Jakobovski/free-spoken-digit-dataset/archive/v1.0.8.zip"
     zip_file = "free-spoken-digit-dataset-1.0.8.zip"
     subdir = "free-spoken-digit-dataset-1.0.8/recordings"
 
-    # TODO: Refactor as a decorator for external downloads
     dirpath = os.path.join(rootdir, subdir)
     if not os.path.isdir(dirpath):
         zip_filepath = os.path.join(rootdir, zip_file)
@@ -158,8 +167,7 @@ def digit(
 
 
 def imagenet_adversarial(
-    preprocessing_fn: Callable = None,
-    dirpath: str = os.path.join(DockerPaths().dataset_dir, "external", "imagenet_adv"),
+    dataset_dir: str = None, preprocessing_fn: Callable = None,
 ) -> (np.ndarray, np.ndarray, np.ndarray):
     """
     ILSVRC12 adversarial image dataset for ResNet50
@@ -170,8 +178,8 @@ def imagenet_adversarial(
         Attack step size = 2
         Targeted = True
 
+    :param dataset_dir: Directory where cached datasets are stored
     :param preprocessing_fn: Callable function to preprocess inputs
-    :param dirpath: Directory where the dataset is stored
     :return: (Adversarial_images, Labels)
     """
 
@@ -195,8 +203,12 @@ def imagenet_adversarial(
         label = tf.cast(example["label"], tf.int32)
         return clean_img, adv_img, label
 
+    if not dataset_dir:
+        dataset_dir = DockerPaths().dataset_dir
+
     num_images = 1000
     filename = "ILSVRC12_ResNet50_PGD_adversarial_dataset_v0.1.tfrecords"
+    dirpath = os.path.join(dataset_dir, "external", "imagenet_adv")
     output_filepath = os.path.join(dirpath, filename)
 
     os.makedirs(dirpath, exist_ok=True)

--- a/armory/docker/management.py
+++ b/armory/docker/management.py
@@ -7,7 +7,7 @@ import os
 
 import docker
 
-from armory import paths
+from armory.paths import HostPaths, DockerPaths
 
 
 logger = logging.getLogger(__name__)
@@ -21,17 +21,22 @@ class ArmoryInstance(object):
     def __init__(
         self, image_name, runtime: str = "runc", envs: dict = None, ports: dict = None
     ):
-        self.docker_client = docker.from_env()
+        host_paths = HostPaths()
+        docker_paths = DockerPaths()
+        self.docker_client = docker.from_env(version="auto")
 
-        os.makedirs(paths.OUTPUTS, exist_ok=True)
         container_args = {
             "runtime": runtime,
             "remove": True,
             "detach": True,
             "volumes": {
-                paths.CWD: {"bind": "/workspace", "mode": "rw"},
-                paths.USER_ARMORY: {"bind": "/.armory", "mode": "rw"},
-                paths.USER_KERAS: {"bind": "/.keras", "mode": "rw"},
+                host_paths.cwd: {"bind": "/workspace", "mode": "rw"},
+                host_paths.armory_dir: {"bind": docker_paths.armory_dir, "mode": "rw"},
+                host_paths.dataset_dir: {
+                    "bind": docker_paths.dataset_dir,
+                    "mode": "rw",
+                },
+                host_paths.output_dir: {"bind": docker_paths.output_dir, "mode": "rw"},
             },
         }
         if ports is not None:

--- a/armory/docker/management.py
+++ b/armory/docker/management.py
@@ -46,7 +46,8 @@ class ArmoryInstance(object):
         # directoriy permissions via uid and gid.
         if os.name != "nt":
             user_id = os.getuid()
-            container_args["user"] = f"{user_id}:{user_id}"
+            group_id = os.getgid()
+            container_args["user"] = f"{user_id}:{group_id}"
 
         if envs:
             container_args["environment"] = envs

--- a/armory/docker/management.py
+++ b/armory/docker/management.py
@@ -30,12 +30,18 @@ class ArmoryInstance(object):
             "detach": True,
             "volumes": {
                 paths.CWD: {"bind": "/workspace", "mode": "rw"},
-                paths.USER_ARMORY: {"bind": "/root/.armory", "mode": "rw"},
-                paths.USER_KERAS: {"bind": "/root/.keras", "mode": "rw"},
+                paths.USER_ARMORY: {"bind": "/.armory", "mode": "rw"},
+                paths.USER_KERAS: {"bind": "/.keras", "mode": "rw"},
             },
         }
         if ports is not None:
             container_args["ports"] = ports
+
+        # Windows docker does not require syncronizing file and
+        # directoriy permissions via uid and gid.
+        if os.name != "nt":
+            user_id = os.getuid()
+            container_args["user"] = f"{user_id}:{user_id}"
 
         if envs:
             container_args["environment"] = envs
@@ -55,7 +61,8 @@ class ArmoryInstance(object):
             print(out.decode())
 
     def __del__(self):
-        if hasattr(self, "docker_container"):  # needed if there is an error in __init__
+        # Needed if there is an error in __init__
+        if hasattr(self, "docker_container"):
             self.docker_container.stop()
 
 

--- a/armory/eval/evaluator.py
+++ b/armory/eval/evaluator.py
@@ -17,18 +17,21 @@ from armory.docker.management import ManagementInstance
 from armory.utils.configuration import load_config
 from armory.utils import external_repo
 from armory.utils.printing import bold, red
-from armory import paths
+from armory.paths import HostPaths, DockerPaths
 
 logger = logging.getLogger(__name__)
 
 
 class Evaluator(object):
     def __init__(self, config_path: str, container_config_name="eval-config.json"):
+        self.host_paths = HostPaths()
+        self.docker_paths = DockerPaths()
+
         self.extra_env_vars = None
         self.config = load_config(config_path)
-        self.tmp_config = os.path.join(paths.TMP, container_config_name)
-        self.unix_config_path = Path(
-            os.path.join(paths.DOCKER_TMP, container_config_name)
+        self.tmp_config = os.path.join(self.host_paths.tmp_dir, container_config_name)
+        self.docker_config_path = Path(
+            os.path.join(self.docker_paths.tmp_dir, container_config_name)
         ).as_posix()
 
         kwargs = dict(runtime="runc")
@@ -67,20 +70,20 @@ class Evaluator(object):
         }
 
     def _write_tmp(self):
-        os.makedirs(paths.TMP, exist_ok=True)
+        os.makedirs(self.host_paths.tmp_dir, exist_ok=True)
         if os.path.exists(self.tmp_config):
-            logger.warning(f"Overwriting {self.tmp_config}!")
+            logger.warning(f"Overwriting previous temp config: {self.tmp_config}...")
         with open(self.tmp_config, "w") as f:
             json.dump(self.config, f)
 
     def _delete_tmp(self):
-        if os.path.exists(paths.EXTERNAL_REPOS):
+        if os.path.exists(self.host_paths.external_repo_dir):
             try:
-                shutil.rmtree(paths.EXTERNAL_REPOS)
+                shutil.rmtree(self.host_paths.external_repo_dir)
             except OSError as e:
                 if not isinstance(e, FileNotFoundError):
                     logger.exception(
-                        f"Error removing external repo {paths.EXTERNAL_REPOS}"
+                        f"Error removing external repo {self.host_paths.external_repo_dir}"
                     )
         try:
             os.remove(self.tmp_config)
@@ -130,20 +133,28 @@ class Evaluator(object):
     def _run_config(self, runner) -> None:
         logger.info(bold(red("Running evaluation script")))
         runner.exec_cmd(
-            f"python -m {self.config['evaluation']['eval_file']} {self.unix_config_path}"
+            f"python -m {self.config['evaluation']['eval_file']} {self.docker_config_path}"
         )
 
     def _run_interactive_bash(self, runner) -> None:
+        if os.name != "nt":
+            user_id = os.getuid()
+        else:
+            user_id = 0
         lines = [
             "Container ready for interactive use.",
             bold(
                 "*** In a new terminal, run the following to attach to the container:"
             ),
-            bold(red(f"    docker exec -itu0 {runner.docker_container.short_id} bash")),
+            bold(
+                red(
+                    f"    docker exec -itu{user_id} {runner.docker_container.short_id} bash"
+                )
+            ),
             bold("*** To run your script in the container:"),
             bold(
                 red(
-                    f"    python -m {self.config['evaluation']['eval_file']} {self.unix_config_path}"
+                    f"    python -m {self.config['evaluation']['eval_file']} {self.docker_config_path}"
                 )
             ),
             bold("*** To gracefully shut down container, press: Ctrl-C"),

--- a/armory/eval/evaluator.py
+++ b/armory/eval/evaluator.py
@@ -139,8 +139,10 @@ class Evaluator(object):
     def _run_interactive_bash(self, runner) -> None:
         if os.name != "nt":
             user_id = os.getuid()
+            group_id = os.getgid()
         else:
             user_id = 0
+            group_id = 0
         lines = [
             "Container ready for interactive use.",
             bold(
@@ -148,7 +150,7 @@ class Evaluator(object):
             ),
             bold(
                 red(
-                    f"    docker exec -itu{user_id} {runner.docker_container.short_id} bash"
+                    f"    docker exec -it -u {user_id}:{group_id} {runner.docker_container.short_id} bash"
                 )
             ),
             bold("*** To run your script in the container:"),

--- a/armory/eval/evaluator.py
+++ b/armory/eval/evaluator.py
@@ -27,6 +27,11 @@ class Evaluator(object):
         self.host_paths = HostPaths()
         self.docker_paths = DockerPaths()
 
+        if os.name != "nt":
+            self.user_id, self.group_id = os.getuid(), os.getgid()
+        else:
+            self.user_id, self.group_id = 0, 0
+
         self.extra_env_vars = None
         self.config = load_config(config_path)
         self.tmp_config = os.path.join(self.host_paths.tmp_dir, container_config_name)
@@ -137,12 +142,6 @@ class Evaluator(object):
         )
 
     def _run_interactive_bash(self, runner) -> None:
-        if os.name != "nt":
-            user_id = os.getuid()
-            group_id = os.getgid()
-        else:
-            user_id = 0
-            group_id = 0
         lines = [
             "Container ready for interactive use.",
             bold(
@@ -150,7 +149,7 @@ class Evaluator(object):
             ),
             bold(
                 red(
-                    f"    docker exec -it -u {user_id}:{group_id} {runner.docker_container.short_id} bash"
+                    f"    docker exec -it -u {self.user_id}:{self.group_id} {runner.docker_container.short_id} bash"
                 )
             ),
             bold("*** To run your script in the container:"),
@@ -166,14 +165,15 @@ class Evaluator(object):
         while True:
             time.sleep(1)
 
-    @staticmethod
-    def _run_jupyter(runner, host_port=8888) -> None:
+    def _run_jupyter(self, runner, host_port=8888) -> None:
         lines = [
             "About to launch jupyter.",
             bold("*** To connect to jupyter, please open the following in a browser:"),
             bold(red(f"    http://127.0.0.1:{host_port}")),
             bold("*** To connect on the command line as well, in a new terminal, run:"),
-            bold(f"    docker exec -itu0 {runner.docker_container.short_id} bash"),
+            bold(
+                f"    docker exec -it -u {self.user_id}:{self.group_id} {runner.docker_container.short_id} bash"
+            ),
             bold("*** To gracefully shut down container, press: Ctrl-C"),
             "",
             "Jupyter notebook log:",

--- a/armory/eval_scripts/carlini_wagner_attack_targeted.py
+++ b/armory/eval_scripts/carlini_wagner_attack_targeted.py
@@ -13,8 +13,7 @@ import numpy as np
 
 from armory.data import datasets
 from armory.eval import plot
-from armory import paths
-
+from armory.paths import DockerPaths
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
@@ -52,6 +51,8 @@ def evaluate_classifier(config_path: str) -> None:
     """
     Evaluate a config file for classiifcation robustness against attack.
     """
+    docker_paths = DockerPaths()
+
     with open(config_path, "r") as fp:
         config = json.load(fp)
 
@@ -153,7 +154,7 @@ def evaluate_classifier(config_path: str) -> None:
 
     logger.info("Saving json output...")
     filepath = os.path.join(
-        paths.OUTPUTS, f"carlini_wagner_attack_{norm}_targeted_output.json"
+        docker_paths.output_dir, f"carlini_wagner_attack_{norm}_targeted_output.json"
     )
     with open(filepath, "w") as f:
         output_dict = {

--- a/armory/eval_scripts/fgm_attack.py
+++ b/armory/eval_scripts/fgm_attack.py
@@ -11,7 +11,7 @@ from importlib import import_module
 import numpy as np
 
 from armory.data import datasets
-from armory import paths
+from armory.paths import DockerPaths
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
@@ -21,6 +21,8 @@ def evaluate_classifier(config_path: str) -> None:
     """
     Evaluate a config file for classiifcation robustness against attack.
     """
+    docker_paths = DockerPaths()
+
     with open(config_path, "r") as fp:
         config = json.load(fp)
 
@@ -74,7 +76,7 @@ def evaluate_classifier(config_path: str) -> None:
     )
 
     logger.info("Saving json output...")
-    filepath = os.path.join(paths.OUTPUTS, "evaluation-results.json")
+    filepath = os.path.join(docker_paths.output_dir, "evaluation-results.json")
     with open(filepath, "w") as f:
         output_dict = {
             "config": config,

--- a/armory/eval_scripts/fgm_attack_binary_search.py
+++ b/armory/eval_scripts/fgm_attack_binary_search.py
@@ -16,7 +16,7 @@ import numpy as np
 
 from armory.data import datasets
 from armory.eval import plot
-from armory import paths
+from armory.paths import DockerPaths
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.DEBUG)
@@ -45,6 +45,8 @@ def evaluate_classifier(config_path: str) -> None:
     """
     Evaluate a config file for classification robustness against attack.
     """
+    docker_paths = DockerPaths()
+
     with open(config_path) as fp:
         config = json.load(fp)
 
@@ -155,7 +157,7 @@ def evaluate_classifier(config_path: str) -> None:
 
     logger.info("Saving json output...")
     filepath = os.path.join(
-        paths.OUTPUTS, f"classifier_extended_{int(time.time())}.json"
+        docker_paths.output_dir, f"classifier_extended_{int(time.time())}.json"
     )
     with open(filepath, "w") as f:
         output_dict = {
@@ -163,11 +165,11 @@ def evaluate_classifier(config_path: str) -> None:
             "results": results,
         }
         json.dump(output_dict, f, sort_keys=True, indent=4)
-    shutil.copyfile(filepath, os.path.join(paths.OUTPUTS, "latest.json"))
+    shutil.copyfile(filepath, os.path.join(docker_paths.output_dir, "latest.json"))
 
     logger.info(f"Now plotting results...")
     plot.classification(filepath)
-    plot.classification(os.path.join(paths.OUTPUTS, "latest.json"))
+    plot.classification(os.path.join(docker_paths.output_dir, "latest.json"))
 
 
 def roc_epsilon(epsilons, min_epsilon=None, max_epsilon=None):

--- a/armory/eval_scripts/poisoning_attack_backdoor.py
+++ b/armory/eval_scripts/poisoning_attack_backdoor.py
@@ -14,7 +14,7 @@ import numpy as np
 
 from armory.eval.plot_poisoning import classification_poisoning
 from armory.data import datasets
-from armory import paths
+from armory.paths import DockerPaths
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
@@ -57,6 +57,8 @@ def evaluate_classifier(config_path: str) -> None:
     Evaluate a config file for classifcation robustness against attack.
     """
     # Generate adversarial test examples
+    docker_paths = DockerPaths()
+
     with open(config_path, "r") as fp:
         config = json.load(fp)
 
@@ -208,14 +210,14 @@ def evaluate_classifier(config_path: str) -> None:
     summarized_metrics = summarize_metrics(raw_metrics)
     logger.info("Saving json output...")
     filepath = os.path.join(
-        paths.OUTPUTS, f"backdoor_performance_{int(time.time())}.json"
+        docker_paths.output_dir, f"backdoor_performance_{int(time.time())}.json"
     )
     with open(filepath, "w") as f:
         output_dict = {"config": config, "results": summarized_metrics}
         json.dump(output_dict, f, sort_keys=True, indent=4)
-    shutil.copyfile(filepath, os.path.join(paths.OUTPUTS, "latest.json"))
+    shutil.copyfile(filepath, os.path.join(docker_paths.output_dir, "latest.json"))
     classification_poisoning(filepath)
-    classification_poisoning(os.path.join(paths.OUTPUTS, "latest.json"))
+    classification_poisoning(os.path.join(docker_paths.output_dir, "latest.json"))
 
 
 if __name__ == "__main__":

--- a/armory/eval_scripts/transfer_attack.py
+++ b/armory/eval_scripts/transfer_attack.py
@@ -10,7 +10,7 @@ from importlib import import_module
 
 import numpy as np
 
-from armory import paths
+from armory.paths import DockerPaths
 from armory.data import datasets
 
 logger = logging.getLogger(__name__)
@@ -21,6 +21,8 @@ def evaluate_classifier(config_path: str) -> None:
     """
     Evaluate a config file for classiifcation robustness against attack.
     """
+    docker_paths = DockerPaths()
+
     with open(config_path, "r") as fp:
         config = json.load(fp)
 
@@ -55,7 +57,7 @@ def evaluate_classifier(config_path: str) -> None:
     )
 
     logger.info("Saving json output...")
-    filepath = os.path.join(paths.OUTPUTS, "evaluation-results.json")
+    filepath = os.path.join(docker_paths.output_dir, "evaluation-results.json")
     with open(filepath, "w") as f:
         output_dict = {
             "config": config,

--- a/armory/paths.py
+++ b/armory/paths.py
@@ -29,8 +29,17 @@ def _parse_global_config(path, armory_dir):
         with open(path, "w") as f:
             json.dump(config, f)
 
-    os.makedirs(config["cached_dataset_dir"], exist_ok=True)
-    os.makedirs(config["output_dir"], exist_ok=True)
+    try:
+        os.makedirs(config["cached_dataset_dir"], exist_ok=True)
+        os.makedirs(config["output_dir"], exist_ok=True)
+
+    # TODO: Recommend to use armory config (#165)
+    except KeyError:
+        raise KeyError(
+            "Error parsing config.json. If you previously ran an older "
+            "version of armory you may need to remove the ~/.armory directory since"
+            "permission changes."
+        )
     return config
 
 

--- a/armory/paths.py
+++ b/armory/paths.py
@@ -41,9 +41,11 @@ class HostPaths:
         self.armory_dir = os.path.join(self.user_dir, ".armory")
         self.tmp_dir = os.path.join(self.armory_dir, "tmp")
         self.armory_config = os.path.join(self.armory_dir, "config.json")
-        self.config = _parse_global_config(self.armory_config, self.armory_dir)
-        self.dataset_dir = self.config.get("cached_dataset_dir")
-        self.output_dir = self.config.get("output_dir")
+
+        # Parse paths from config
+        config = _parse_global_config(self.armory_config, self.armory_dir)
+        self.dataset_dir = config.get("cached_dataset_dir")
+        self.output_dir = config.get("output_dir")
         self.external_repo_dir = os.path.join(self.dataset_dir, "external_repos")
 
 

--- a/armory/paths.py
+++ b/armory/paths.py
@@ -35,10 +35,9 @@ else:
 
 DATASETS = config.get("datasets") or os.path.join(USER_ARMORY, "datasets")
 EXTERNAL_REPOS = os.path.join(DATASETS, "external_repos")
-MODELS = config.get("models") or os.path.join(USER_ARMORY, "models")
 TMP = config.get("tmp") or os.path.join(USER_ARMORY, "tmp")
 OUTPUTS = config.get("outputs") or os.path.join(USER_ARMORY, "outputs")
 
-DOCKER = "/root"
+DOCKER = "/"
 DOCKER_ARMORY = os.path.join(DOCKER, ".armory")
 DOCKER_TMP = Path(os.path.join(DOCKER_ARMORY, "tmp")).as_posix()

--- a/armory/paths.py
+++ b/armory/paths.py
@@ -5,39 +5,51 @@ Handles pathnames for armory
 import json
 import logging
 import os
-from pathlib import Path
-
 
 logger = logging.getLogger(__name__)
 
 
-PROJECT_ROOT = Path(__file__).parents[1]
-CWD = os.getcwd()
-USER = os.path.expanduser("~")
-USER_ARMORY = os.path.join(USER, ".armory")
-USER_KERAS = os.path.join(USER, ".keras")
-ARMORY_CONFIG = os.path.join(USER_ARMORY, "config.json")
-if os.path.exists(ARMORY_CONFIG):
-    try:
-        with open(ARMORY_CONFIG) as f:
-            config = json.load(f)
-    except json.decoder.JSONDecodeError:
-        logger.exception(f"Armory config file {ARMORY_CONFIG} could not be decoded")
-        raise
-    except OSError:
-        logger.exception(f"Armory config file {ARMORY_CONFIG} could not be read")
-        raise
-else:
-    os.makedirs(USER_ARMORY, exist_ok=True)
-    config = {"cached_dataset_dir": os.path.join(USER_ARMORY, "datasets")}
-    with open(ARMORY_CONFIG, "w") as f:
-        json.dump(config, f)
+def _parse_global_config(path, armory_dir):
+    if os.path.exists(path):
+        try:
+            with open(path) as f:
+                config = json.load(f)
+        except json.decoder.JSONDecodeError:
+            logger.exception(f"Armory config file {path} could not be decoded")
+            raise
+        except OSError:
+            logger.exception(f"Armory config file {path} could not be read")
+            raise
+    else:
+        os.makedirs(armory_dir, exist_ok=True)
+        config = {
+            "cached_dataset_dir": os.path.join(armory_dir, "datasets"),
+            "output_dir": os.path.join(armory_dir, "outputs"),
+        }
+        with open(path, "w") as f:
+            json.dump(config, f)
 
-DATASETS = config.get("cached_dataset_dir") or os.path.join(USER_ARMORY, "datasets")
-EXTERNAL_REPOS = os.path.join(DATASETS, "external_repos")
-TMP = config.get("tmp") or os.path.join(USER_ARMORY, "tmp")
-OUTPUTS = config.get("outputs") or os.path.join(USER_ARMORY, "outputs")
+    os.makedirs(config["cached_dataset_dir"], exist_ok=True)
+    os.makedirs(config["output_dir"], exist_ok=True)
+    return config
 
-DOCKER = "/"
-DOCKER_ARMORY = os.path.join(DOCKER, ".armory")
-DOCKER_TMP = Path(os.path.join(DOCKER_ARMORY, "tmp")).as_posix()
+
+class HostPaths:
+    def __init__(self):
+        self.cwd = os.getcwd()
+        self.user_dir = os.path.expanduser("~")
+        self.armory_dir = os.path.join(self.user_dir, ".armory")
+        self.tmp_dir = os.path.join(self.armory_dir, "tmp")
+        self.armory_config = os.path.join(self.armory_dir, "config.json")
+        self.config = _parse_global_config(self.armory_config, self.armory_dir)
+        self.dataset_dir = self.config.get("cached_dataset_dir")
+        self.output_dir = self.config.get("output_dir")
+        self.external_repo_dir = os.path.join(self.dataset_dir, "external_repos")
+
+
+class DockerPaths:
+    def __init__(self):
+        self.armory_dir = "/armory"
+        self.tmp_dir = "/armory/tmp"
+        self.dataset_dir = "/datasets"
+        self.output_dir = "/outputs"

--- a/armory/utils/external_repo.py
+++ b/armory/utils/external_repo.py
@@ -8,7 +8,7 @@ import shutil
 
 import requests
 
-from armory import paths
+from armory.paths import HostPaths
 
 
 logger = logging.getLogger(__name__)
@@ -21,7 +21,9 @@ def download_and_extract_repo(external_repo_name: str) -> None:
     Private repositories require a `GITHUB_TOKEN` environment variable.
     :param external_repo_name: String name of "organization/repo-name"
     """
-    os.makedirs(paths.EXTERNAL_REPOS, exist_ok=True)
+    host_paths = HostPaths()
+
+    os.makedirs(host_paths.external_repo_dir, exist_ok=True)
     headers = {}
     repo_name = external_repo_name.split("/")[-1]
 
@@ -37,18 +39,21 @@ def download_and_extract_repo(external_repo_name: str) -> None:
     if response.status_code == 200:
         logging.info(f"Downloading external repo: {external_repo_name}")
 
-        tar_filename = os.path.join(paths.EXTERNAL_REPOS, repo_name + ".tar.gz")
+        tar_filename = os.path.join(host_paths.external_repo_dir, repo_name + ".tar.gz")
         with open(tar_filename, "wb") as f:
             f.write(response.raw.read())
         tar = tarfile.open(tar_filename, "r:gz")
         dl_directory_name = tar.getnames()[0]
-        tar.extractall(path=paths.EXTERNAL_REPOS)
+        tar.extractall(path=host_paths.external_repo_dir)
 
         # Always overwrite existing repositories to keep them at HEAD
-        final_dir_name = os.path.join(paths.EXTERNAL_REPOS, repo_name)
+        final_dir_name = os.path.join(host_paths.external_repo_dir, repo_name)
         if os.path.isdir(final_dir_name):
             shutil.rmtree(final_dir_name)
-        os.rename(os.path.join(paths.EXTERNAL_REPOS, dl_directory_name), final_dir_name)
+        os.rename(
+            os.path.join(host_paths.external_repo_dir, dl_directory_name),
+            final_dir_name,
+        )
         # os.remove(tar_filename)
 
     else:

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -102,7 +102,7 @@ class KerasTest(unittest.TestCase):
 
         clean_x, adv_x, labels = datasets.load(
             "imagenet_adversarial",
-            preprocessing_fn,
+            preprocessing_fn=preprocessing_fn,
             dataset_dir=HostPaths().dataset_dir,
         )
 

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -8,25 +8,32 @@ import numpy as np
 from importlib import import_module
 
 from armory.data import datasets
+from armory.paths import HostPaths
 
 
 class DatasetTest(unittest.TestCase):
     def test_mnist(self):
-        train_x, train_y, test_x, test_y = datasets.load("mnist")
+        train_x, train_y, test_x, test_y = datasets.load(
+            "mnist", dataset_dir=HostPaths().dataset_dir
+        )
         self.assertEqual(train_x.shape[0], 60000)
         self.assertEqual(train_y.shape[0], 60000)
         self.assertEqual(test_x.shape[0], 10000)
         self.assertEqual(test_y.shape[0], 10000)
 
     def test_cifar10(self):
-        train_x, train_y, test_x, test_y = datasets.load("cifar10")
+        train_x, train_y, test_x, test_y = datasets.load(
+            "cifar10", dataset_dir=HostPaths().dataset_dir
+        )
         self.assertEqual(train_x.shape[0], 50000)
         self.assertEqual(train_y.shape[0], 50000)
         self.assertEqual(test_x.shape[0], 10000)
         self.assertEqual(test_y.shape[0], 10000)
 
     def test_digit(self):
-        train_x, train_y, test_x, test_y = datasets.load("digit")
+        train_x, train_y, test_x, test_y = datasets.load(
+            "digit", dataset_dir=HostPaths().dataset_dir
+        )
         self.assertEqual(train_x.shape[0], 1350)
         self.assertEqual(train_y.shape[0], 1350)
         self.assertEqual(test_x.shape[0], 150)
@@ -36,7 +43,9 @@ class DatasetTest(unittest.TestCase):
                 self.assertTrue(1148 <= len(x) <= 18262)
 
     def test_imagenet_adv(self):
-        clean_x, adv_x, labels = datasets.load("imagenet_adversarial")
+        clean_x, adv_x, labels = datasets.load(
+            "imagenet_adversarial", dataset_dir=HostPaths().dataset_dir
+        )
         self.assertEqual(clean_x.shape[0], 1000)
         self.assertEqual(adv_x.shape[0], 1000)
         self.assertEqual(labels.shape[0], 1000)
@@ -53,7 +62,9 @@ class KerasTest(unittest.TestCase):
         preprocessing_fn = getattr(classifier_module, "preprocessing_fn")
 
         train_x, train_y, test_x, test_y = datasets.load(
-            "mnist", preprocessing_fn=preprocessing_fn
+            "mnist",
+            preprocessing_fn=preprocessing_fn,
+            dataset_dir=HostPaths().dataset_dir,
         )
 
         classifier.fit(train_x, train_y, batch_size=batch_size, nb_epochs=epochs)
@@ -72,7 +83,9 @@ class KerasTest(unittest.TestCase):
         preprocessing_fn = getattr(classifier_module, "preprocessing_fn")
 
         train_x, train_y, test_x, test_y = datasets.load(
-            "cifar10", preprocessing_fn=preprocessing_fn
+            "cifar10",
+            preprocessing_fn=preprocessing_fn,
+            dataset_dir=HostPaths().dataset_dir,
         )
 
         classifier.fit(train_x, train_y, batch_size=batch_size, nb_epochs=epochs)
@@ -87,7 +100,11 @@ class KerasTest(unittest.TestCase):
         classifier = classifier_fn(model_kwargs={}, wrapper_kwargs={})
         preprocessing_fn = getattr(classifier_module, "preprocessing_fn")
 
-        clean_x, adv_x, labels = datasets.load("imagenet_adversarial", preprocessing_fn)
+        clean_x, adv_x, labels = datasets.load(
+            "imagenet_adversarial",
+            preprocessing_fn,
+            dataset_dir=HostPaths().dataset_dir,
+        )
 
         predictions = classifier.predict(clean_x)
         accuracy = np.sum(np.argmax(predictions, axis=1) == labels) / len(labels)

--- a/tests/test_external_repo.py
+++ b/tests/test_external_repo.py
@@ -2,17 +2,20 @@ import os
 import unittest
 import shutil
 
-from armory import paths
+from armory.paths import HostPaths
 from armory.utils.external_repo import download_and_extract_repo
 
 
 class ExternalRepoTest(unittest.TestCase):
     def test_download(self):
+        host_paths = HostPaths()
         repo = "twosixlabs/armory-example"
         repo_name = repo.split("/")[-1]
 
         download_and_extract_repo(repo)
-        self.assertTrue(os.path.exists(f"{paths.EXTERNAL_REPOS}/{repo_name}"))
-        self.assertTrue(os.path.isfile(f"{paths.EXTERNAL_REPOS}/{repo_name}/README.md"))
+        self.assertTrue(os.path.exists(f"{host_paths.external_repo_dir}/{repo_name}"))
+        self.assertTrue(
+            os.path.isfile(f"{host_paths.external_repo_dir}/{repo_name}/README.md")
+        )
 
-        shutil.rmtree(f"{paths.EXTERNAL_REPOS}/{repo_name}")
+        shutil.rmtree(f"{host_paths.external_repo_dir}/{repo_name}")


### PR DESCRIPTION
We previously removed this strategy since we considered mounting the host's pip installed armory in the container (which could require root to use/modify). 

Since we've since installed the armory package within the container this is no longer needed. Saving files as root onto the user's host caused a number of issues and is a pretty poor practice.