### PR TITLE
Fix import structure for top level imports

### DIFF
--- a/armory/__init__.py
+++ b/armory/__init__.py
@@ -7,9 +7,13 @@ logger = logging.getLogger(__name__)
 logger.addHandler(logging.NullHandler())
 
 # Submodule imports
+from armory import art_experimental
+from armory import data
 from armory import baseline_models
 from armory import docker
 from armory import eval
+from armory import eval_scripts
+from armory import utils
 from armory import webapi
 from armory import paths
 

--- a/armory/art_experimental/__init__.py
+++ b/armory/art_experimental/__init__.py
@@ -2,3 +2,7 @@
 This subpackage will contain experimental ART features that are not merged into
 the PyPi package.
 """
+
+from armory.art_experimental import attacks
+from armory.art_experimental import defences
+from armory.art_experimental import poison_detection

--- a/armory/art_experimental/attacks/poisoning_attack_backdoor.py
+++ b/armory/art_experimental/attacks/poisoning_attack_backdoor.py
@@ -3,7 +3,7 @@ Simple data poisoning backdoor attack
 """
 
 import numpy as np
-from art.attacks.attack import PoisoningAttack
+from art.attacks import PoisoningAttack
 
 
 class PoisoningAttackBackdoor(PoisoningAttack):

--- a/armory/data/__init__.py
+++ b/armory/data/__init__.py
@@ -1,0 +1,6 @@
+"""
+Data methods in ARMORY
+"""
+
+from armory.data import common
+from armory.data import utils

--- a/armory/docker/__init__.py
+++ b/armory/docker/__init__.py
@@ -1,0 +1,5 @@
+"""
+Docker management in ARMORY
+"""
+
+from armory.docker import management

--- a/armory/eval/__init__.py
+++ b/armory/eval/__init__.py
@@ -1,1 +1,6 @@
+"""
+Evaluation within ARMORY
+"""
+
 from armory.eval.evaluator import Evaluator
+from armory.eval.export import Exporter

--- a/armory/utils/__init__.py
+++ b/armory/utils/__init__.py
@@ -1,0 +1,7 @@
+"""
+ARMORY Utilities
+"""
+
+from armory.utils import configuration
+from armory.utils import external_repo
+from armory.utils import printing


### PR DESCRIPTION
Enables for example:
```
import armory
armory.art_experimental.attacks.FGMBinarySearch
```