### PR TITLE
Update release to trigger from API

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,10 +1,8 @@
 name: armory-release
 
 on:
-  release:
-    types: [published]
-    tags:
-      - v*
+  repository_dispatch:
+    types: build-and-release
 
 jobs:
   release-test:
@@ -14,7 +12,9 @@ jobs:
       matrix:
         python-version: ['3.6', '3.7']
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
+      with:
+        ref: ${{ github.event.client_payload.branch }}
       - uses: actions/setup-python@v1
         with:
           python-version: ${{ matrix.python-version }}
@@ -32,7 +32,9 @@ jobs:
       matrix:
         python-version: ['3.6']
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
+      with:
+        ref: ${{ github.event.client_payload.branch }}
       - uses: actions/setup-python@v1
         with:
           python-version: ${{ matrix.python-version }}
@@ -53,7 +55,9 @@ jobs:
       matrix:
         python-version: ['3.6']
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
+      with:
+        ref: ${{ github.event.client_payload.branch }}
       - uses: actions/setup-python@v1
         with:
           python-version: ${{ matrix.python-version }}


### PR DESCRIPTION
Closes #189 

Per discussion pre-release trigger doesn't really accomplish what we want to do here. API trigger for builds and then we can release will work.

Example test:
https://github.com/armory-twosix/testing-actions/blob/master/.github/workflows/blank.yml
https://github.com/armory-twosix/testing-actions/runs/469965239?check_suite_focus=true