### PR TITLE
Update transfer attack to resize and add test

### DIFF
--- a/armory/baseline_models/keras/keras_inception_resnet_v2.py
+++ b/armory/baseline_models/keras/keras_inception_resnet_v2.py
@@ -1,10 +1,21 @@
 from art.classifiers import KerasClassifier
+import numpy as np
+from tensorflow.keras.preprocessing import image
 from tensorflow.keras.applications.inception_resnet_v2 import (
     InceptionResNetV2,
-    preprocess_input,
+    preprocess_input as preprocess_input_inception_resnet_v2,
 )
 
-preprocessing_fn = preprocess_input
+
+def preprocessing_fn(x: np.ndarray) -> np.ndarray:
+    shape = (299, 299)  # Expected input shape of model
+    output = []
+    for i in range(x.shape[0]):
+        im_raw = image.array_to_img(x[i])
+        im = image.img_to_array(im_raw.resize(shape))
+        output.append(im)
+    output = preprocess_input_inception_resnet_v2(np.array(output))
+    return output
 
 
 def get_art_model(model_kwargs, wrapper_kwargs):

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -121,3 +121,24 @@ class KerasTest(unittest.TestCase):
         accuracy = np.sum(np.argmax(predictions, axis=1) == labels) / len(labels)
         print(accuracy)
         self.assertLess(accuracy, 0.02)
+
+    def test_keras_imagenet_transfer(self):
+        classifier_module = import_module(
+            "armory.baseline_models.keras.keras_inception_resnet_v2"
+        )
+        classifier_fn = getattr(classifier_module, "get_art_model")
+        classifier = classifier_fn(model_kwargs={}, wrapper_kwargs={})
+        preprocessing_fn = getattr(classifier_module, "preprocessing_fn")
+
+        clean_x, adv_x, labels = datasets.imagenet_adversarial(
+            preprocessing_fn=preprocessing_fn, dataset_dir=HostPaths().dataset_dir,
+        )
+
+        predictions = classifier.predict(clean_x)
+        accuracy = np.sum(np.argmax(predictions, axis=1) == labels) / len(labels)
+        self.assertGreater(accuracy, 0.75)
+
+        predictions = classifier.predict(adv_x)
+        accuracy = np.sum(np.argmax(predictions, axis=1) == labels) / len(labels)
+        print(accuracy)
+        self.assertLess(accuracy, 0.72)


### PR DESCRIPTION
Update transfer attack to resize input dimensions and added test (Issue #200). The transfer attack leads to a drop in accuracy from 75.5% to 71.8%, which suggests that the impact on the adversarial data is within tolerance.