### PR TITLE
Docker clean

### DIFF
--- a/armory/__main__.py
+++ b/armory/__main__.py
@@ -101,7 +101,9 @@ def _pull_docker_images(docker_client=None):
             docker_client.images.get(image)
         except ImageNotFound:
             if armory.is_dev():
-                raise NotImplementedError("For dev, please build locally")
+                raise ValueError(
+                    "For '-dev', please run 'docker/build.sh' locally before running armory"
+                )
             print(f"Image {image} was not found. Downloading...")
             docker_api.pull_verbose(docker_client, image)
 

--- a/armory/__main__.py
+++ b/armory/__main__.py
@@ -102,7 +102,7 @@ def _pull_docker_images(docker_client=None):
         except ImageNotFound:
             if armory.is_dev():
                 raise ValueError(
-                    "For '-dev', please run 'docker/build.sh' locally before running armory"
+                    "For '-dev', please run 'docker/build-dev.sh' locally before running armory"
                 )
             print(f"Image {image} was not found. Downloading...")
             docker_api.pull_verbose(docker_client, image)

--- a/armory/docker/images.py
+++ b/armory/docker/images.py
@@ -2,7 +2,6 @@
 Enables programmatic accessing of most recent docker images
 """
 
-from distutils import version
 import pkg_resources
 
 import armory
@@ -17,12 +16,22 @@ ALL = (
     TF2,
     PYTORCH,
 )
-REPOSITORIES = tuple(x.split(":")[0] for x in ALL)
+ARMORY_BASE = f"{USER}/armory:{TAG}"
+TF1_BASE = f"{USER}/tf1-base:{TAG}"
+TF2_BASE = f"{USER}/tf2-base:{TAG}"
+PYTORCH_BASE = f"{USER}/pytorch-base:{TAG}"
+BASES = (
+    ARMORY_BASE,
+    TF1_BASE,
+    TF2_BASE,
+    PYTORCH_BASE,
+)
+REPOSITORIES = tuple(x.split(":")[0] for x in (ALL + BASES))
 
 
 def parse_version(tag):
     """
-    Return version.LooseVersion class for given version tag
+    Return PEP 440 version for given version tag
     """
     if not isinstance(tag, str):
         raise ValueError(f"tag is a {type(tag)}, not a str")
@@ -32,8 +41,10 @@ def parse_version(tag):
         numeric_tag = tag
     if len(numeric_tag.split(".")) != 3:
         raise ValueError(f"tag {tag} must be of form 'major.minor.patch[-dev]'")
-    version.StrictVersion(numeric_tag)
-    return pkg_resources.parse_version(tag)
+    version = pkg_resources.parse_version(tag)
+    if not isinstance(version, pkg_resources.extern.packaging.version.Version):
+        raise ValueError(f"tag {tag} parses to type {type(version)}, not Version")
+    return version
 
 
 VERSION = parse_version(armory.__version__)

--- a/armory/docker/images.py
+++ b/armory/docker/images.py
@@ -3,6 +3,7 @@ Enables programmatic accessing of most recent docker images
 """
 
 from distutils import version
+import pkg_resources
 
 import armory
 
@@ -19,23 +20,23 @@ ALL = (
 REPOSITORIES = tuple(x.split(":")[0] for x in ALL)
 
 
-def dev_version(tag):
+def parse_version(tag):
     """
     Return version.LooseVersion class for given version tag
     """
-    if not tag.endswith(armory.DEV):
-        raise ValueError(f"invalid dev tag: {tag} does not end with {armory.DEV}")
+    if not isinstance(tag, str):
+        raise ValueError(f"tag is a {type(tag)}, not a str")
+    if tag.endswith(armory.DEV):
+        numeric_tag = tag[: -len(armory.DEV)]
+    else:
+        numeric_tag = tag
+    if len(numeric_tag.split(".")) != 3:
+        raise ValueError(f"tag {tag} must be of form 'major.minor.patch[-dev]'")
+    version.StrictVersion(numeric_tag)
+    return pkg_resources.parse_version(tag)
 
-    # check that the remaining version number is strict
-    strict = tag[: -len(armory.DEV)]
-    version.StrictVersion(strict)
-    return version.LooseVersion(tag)
 
-
-if TAG.endswith(armory.DEV):
-    VERSION = dev_version(TAG)
-else:
-    VERSION = version.StrictVersion(TAG)
+VERSION = parse_version(armory.__version__)
 
 
 def is_old(tag: str):
@@ -44,9 +45,6 @@ def is_old(tag: str):
 
     If current version is dev, only returns True for old "-dev" containers.
     """
-    if armory.is_dev():
-        raise NotImplementedError("dev tag")
-
     if not isinstance(tag, str):
         raise ValueError(f"tag must be of type str, not type {type(tag)}")
     if tag in ALL:
@@ -57,14 +55,10 @@ def is_old(tag: str):
     repo, tag = tokens
     if repo in REPOSITORIES:
         try:
-            if armory.is_dev():
-                if not tag.endswith(armory.DEV):
-                    return False
-                tag = dev_version(tag)
-                if tag < VERSION:
-                    return True
-            elif version.StrictVersion(tag) < VERSION:
-                return True
+            other = parse_version(tag)
+            if other < VERSION:
+                # return True if both prerelease or both not prerelease
+                return not (other.is_prerelease ^ VERSION.is_prerelease)
         except (AttributeError, ValueError):
             # Catch empty tag and tag parsing errors
             pass

--- a/docker/build-dev-minimal.sh
+++ b/docker/build-dev-minimal.sh
@@ -13,6 +13,6 @@ if [[ "$1" != "pytorch" && "$1" != "tf1" && "$1" != "tf2" ]]; then
 fi
 
 version=$(python -m armory --version)
-docker build --file docker/Dockerfile --target armory -t twosixarmory/armory:${version} .
-docker build --file docker/${1}/Dockerfile --build-arg armory_version=${version} --target armory-${1}-base -t twosixarmory/${1}-base:${version} .
-docker build --file docker/${1}-dev/Dockerfile --build-arg armory_version=${version} --target armory-${1}-dev -t twosixarmory/${1}:${version} .
+docker build --force-rm --file docker/Dockerfile --target armory -t twosixarmory/armory:${version} .
+docker build --force-rm --file docker/${1}/Dockerfile --build-arg armory_version=${version} --target armory-${1}-base -t twosixarmory/${1}-base:${version} .
+docker build --force-rm --file docker/${1}-dev/Dockerfile --build-arg armory_version=${version} --target armory-${1}-dev -t twosixarmory/${1}:${version} .

--- a/docker/build-dev.sh
+++ b/docker/build-dev.sh
@@ -1,13 +1,13 @@
 #!/usr/bin/env bash
 version=$(python -m armory --version)
 
-docker build --file docker/Dockerfile --target armory -t twosixarmory/armory:${version} .
+docker build --force-rm --file docker/Dockerfile --target armory -t twosixarmory/armory:${version} .
 
-docker build --file docker/tf1/Dockerfile --build-arg armory_version=${version} --target armory-tf1-base -t twosixarmory/tf1-base:${version} .
-docker build --file docker/tf1-dev/Dockerfile --build-arg armory_version=${version} --target armory-tf1-dev -t twosixarmory/tf1:${version} .
+docker build --force-rm --file docker/tf1/Dockerfile --build-arg armory_version=${version} --target armory-tf1-base -t twosixarmory/tf1-base:${version} .
+docker build --force-rm --file docker/tf1-dev/Dockerfile --build-arg armory_version=${version} --target armory-tf1-dev -t twosixarmory/tf1:${version} .
 
-docker build --file docker/tf2/Dockerfile --build-arg armory_version=${version} --target armory-tf2-base -t twosixarmory/tf2-base:${version} .
-docker build --file docker/tf2-dev/Dockerfile --build-arg armory_version=${version} --target armory-tf2-dev -t twosixarmory/tf2:${version} .
+docker build --force-rm --file docker/tf2/Dockerfile --build-arg armory_version=${version} --target armory-tf2-base -t twosixarmory/tf2-base:${version} .
+docker build --force-rm --file docker/tf2-dev/Dockerfile --build-arg armory_version=${version} --target armory-tf2-dev -t twosixarmory/tf2:${version} .
 
-docker build --file docker/pytorch/Dockerfile --build-arg armory_version=${version} --target armory-pytorch-base -t twosixarmory/pytorch-base:${version} .
-docker build --file docker/pytorch-dev/Dockerfile --build-arg armory_version=${version} --target armory-pytorch-dev -t twosixarmory/pytorch:${version} .
+docker build --force-rm --file docker/pytorch/Dockerfile --build-arg armory_version=${version} --target armory-pytorch-base -t twosixarmory/pytorch-base:${version} .
+docker build --force-rm --file docker/pytorch-dev/Dockerfile --build-arg armory_version=${version} --target armory-pytorch-dev -t twosixarmory/pytorch:${version} .

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -6,7 +6,7 @@ if [[ $version == *"-dev" ]]; then
     exit
 fi
 
-docker build --file docker/Dockerfile --target armory -t twosixarmory/armory:${version} .
-docker build --file docker/tf1/Dockerfile --build-arg armory_version=${version} --target armory-tf1 -t twosixarmory/tf1:${version} .
-docker build --file docker/tf2/Dockerfile --build-arg armory_version=${version} --target armory-tf2 -t twosixarmory/tf2:${version} .
-docker build --file docker/pytorch/Dockerfile --build-arg armory_version=${version} --target armory-pytorch -t twosixarmory/pytorch:${version} .
+docker build --force-rm --file docker/Dockerfile --target armory -t twosixarmory/armory:${version} .
+docker build --force-rm --file docker/tf1/Dockerfile --build-arg armory_version=${version} --target armory-tf1 -t twosixarmory/tf1:${version} .
+docker build --force-rm --file docker/tf2/Dockerfile --build-arg armory_version=${version} --target armory-tf2 -t twosixarmory/tf2:${version} .
+docker build --force-rm --file docker/pytorch/Dockerfile --build-arg armory_version=${version} --target armory-pytorch -t twosixarmory/pytorch:${version} .


### PR DESCRIPTION
fixes #258 

1) It still uses distutils to check for strict versioning, but uses pkg_resources for comparisons.

This merge also does two other things:
2) uses --force-rm when creating docker images to remove intermediate containers on failed builds
3) updates armory clean to handle "-dev" versions. (When using clean on "-dev", it only removes old "-dev" images.)