### PR TITLE
Docker launch test

### DIFF
--- a/armory/__main__.py
+++ b/armory/__main__.py
@@ -81,7 +81,7 @@ def run(command_args, prog, description):
         action="store_const",
         const=True,
         default=False,
-        help="Whether to all interactive access to container",
+        help="Whether to allow interactive access to container",
     )
     parser.add_argument(
         "-j",
@@ -330,7 +330,7 @@ def launch(command_args, prog, description):
         action="store_const",
         const=True,
         default=False,
-        help="Whether to all interactive access to container",
+        help="Whether to allow interactive access to container",
     )
     parser.add_argument(
         "-j",
@@ -371,9 +371,9 @@ def launch(command_args, prog, description):
     rig.run(interactive=args.interactive, jupyter=args.jupyter, host_port=args.port)
 
 
-def bash(command_args, prog, description):
+def exec(command_args, prog, description):
     delimiter = "--"
-    usage = "armory bash <docker image> [-d] [--use-gpu] -- <bash command>"
+    usage = "armory exec <docker image> [-d] [--use-gpu] -- <exec command>"
     parser = argparse.ArgumentParser(prog=prog, description=description, usage=usage)
     parser.add_argument(
         "docker_image",
@@ -405,10 +405,10 @@ def bash(command_args, prog, description):
         print(f"ERROR: delimiter '{delimiter}' is required.")
         parser.print_help()
         sys.exit(1)
-    bash_args = command_args[index + 1 :]
+    exec_args = command_args[index + 1 :]
     armory_args = command_args[:index]
-    if not bash_args:
-        print("ERROR: bash command required")
+    if not exec_args:
+        print("ERROR: exec command required")
         parser.print_help()
         sys.exit(1)
     args = parser.parse_args(armory_args)
@@ -420,7 +420,7 @@ def bash(command_args, prog, description):
         "sysconfig": {"use_gpu": args.use_gpu, "docker_image": args.docker_image,}
     }
     rig = Evaluator(config)
-    rig.run(command=" ".join(bash_args))
+    rig.run(command=" ".join(exec_args))
 
 
 # command, (function, description)
@@ -434,7 +434,7 @@ COMMANDS = {
     "clean": (clean, "download new and remove all old armory docker images"),
     "configure": (configure, "set up armory and dataset paths"),
     "launch": (launch, "launch a given docker container in armory"),
-    "bash": (bash, "run a single bash command in the container"),
+    "exec": (exec, "run a single exec command in the container"),
 }
 
 

--- a/armory/eval/evaluator.py
+++ b/armory/eval/evaluator.py
@@ -8,6 +8,7 @@ import logging
 import shutil
 import time
 from pathlib import Path
+from typing import Union
 
 import docker
 import requests
@@ -24,7 +25,9 @@ logger = logging.getLogger(__name__)
 
 
 class Evaluator(object):
-    def __init__(self, config_path: str, container_config_name="eval-config.json"):
+    def __init__(
+        self, config_path: Union[str, dict], container_config_name="eval-config.json"
+    ):
         self.host_paths = paths.host()
         self.docker_paths = paths.docker()
 
@@ -34,7 +37,12 @@ class Evaluator(object):
             self.user_id, self.group_id = 0, 0
 
         self.extra_env_vars = dict()
-        self.config = load_config(config_path)
+        if isinstance(config_path, str):
+            self.config = load_config(config_path)
+        elif isinstance(config_path, dict):
+            self.config = config_path
+        else:
+            raise ValueError(f"config_path {config_path} must be a str or dict")
         self.tmp_config = os.path.join(self.host_paths.tmp_dir, container_config_name)
         self.docker_config_path = Path(
             os.path.join(self.docker_paths.tmp_dir, container_config_name)
@@ -131,17 +139,20 @@ class Evaluator(object):
                     f"Port {host_port} already in use. Try a different one with '--port <port>'"
                 )
             elif (
-                isinstance(e, docker.errors.APIError)
-                and str(e)
-                == r'400 Client Error: Bad Request ("Unknown runtime specified nvidia")'
-                and self.config.get("use_gpu")
+                str(e)
+                == '400 Client Error: Bad Request ("Unknown runtime specified nvidia")'
             ):
-                logger.error('nvidia runtime failed. Set config "use_gpu" to false')
+                logger.error(
+                    'NVIDIA runtime failed. Either install nvidia-docker or set config "use_gpu" to false'
+                )
             else:
                 logger.error("Is Docker Daemon running?")
         self._delete_tmp()
 
     def _run_config(self, runner) -> None:
+        if self.config.get("evaluation") is None:
+            logger.info(bold(red("No evaluation script to run")))
+            return
         logger.info(bold(red("Running evaluation script")))
         runner.exec_cmd(
             f"python -m {self.config['evaluation']['eval_file']} {self.docker_config_path}"
@@ -158,15 +169,20 @@ class Evaluator(object):
                     f"    docker exec -it -u {self.user_id}:{self.group_id} {runner.docker_container.short_id} bash"
                 )
             ),
-            bold("*** To run your script in the container:"),
-            bold(
-                red(
-                    f"    python -m {self.config['evaluation']['eval_file']} {self.docker_config_path}"
-                )
-            ),
-            bold("*** To gracefully shut down container, press: Ctrl-C"),
-            "",
         ]
+        if self.config.get("evaluation"):
+            lines.extend(
+                [
+                    bold("*** To run your script in the container:"),
+                    bold(
+                        red(
+                            f"    python -m {self.config['evaluation']['eval_file']} {self.docker_config_path}"
+                        )
+                    ),
+                    bold("*** To gracefully shut down container, press: Ctrl-C"),
+                    "",
+                ]
+            )
         logger.info("\n".join(lines))
         while True:
             time.sleep(1)

--- a/armory/eval/evaluator.py
+++ b/armory/eval/evaluator.py
@@ -110,7 +110,9 @@ class Evaluator(object):
             if not isinstance(e, FileNotFoundError):
                 logger.exception(f"Error removing tmp config {self.tmp_config}")
 
-    def run(self, interactive=False, jupyter=False, host_port=8888) -> None:
+    def run(
+        self, interactive=False, jupyter=False, host_port=8888, command=None
+    ) -> None:
         container_port = 8888
         self._write_tmp()
         ports = {container_port: host_port} if jupyter else None
@@ -123,6 +125,8 @@ class Evaluator(object):
                     self._run_jupyter(runner, host_port=host_port)
                 elif interactive:
                     self._run_interactive_bash(runner)
+                elif command:
+                    self._run_command(runner, command)
                 else:
                     self._run_config(runner)
             except KeyboardInterrupt:
@@ -157,6 +161,10 @@ class Evaluator(object):
         runner.exec_cmd(
             f"python -m {self.config['evaluation']['eval_file']} {self.docker_config_path}"
         )
+
+    def _run_command(self, runner, command) -> None:
+        logger.info(bold(red(f"Running bash command: {command}")))
+        runner.exec_cmd(command)
 
     def _run_interactive_bash(self, runner) -> None:
         lines = [


### PR DESCRIPTION
part of #264 - this creates two main commands:
`exec`, which allows you to run an arbitrary bash command inside a just launched container.
This is more general than a `test` command, and can be used with pytest. The remaining piece for #264 is to get the exit code from pytest to get passed to the main function, so that it can it turn send it to the CI runner.

`launch`, which is a convenience command similar to `run` that enables launching a docker image in armory without a specific evaluation config.
