### PR TITLE
Multiple container

### DIFF
--- a/armory/docker/management.py
+++ b/armory/docker/management.py
@@ -30,16 +30,11 @@ class ArmoryInstance(object):
 
         host_paths = paths.host()
         docker_paths = paths.docker()
+        host_tmp_dir = host_paths.tmp_dir
+        host_output_dir = host_paths.output_dir
         if container_subdir:
-            docker_tmp_dir = os.path.join(docker_paths.tmp_dir, container_subdir)
-            docker_output_dir = os.path.join(docker_paths.output_dir, container_subdir)
-            host_tmp_dir = os.path.join(host_paths.tmp_dir, container_subdir)
-            host_output_dir = os.path.join(host_paths.output_dir, container_subdir)
-        else:
-            docker_tmp_dir = docker_paths.tmp_dir
-            docker_output_dir = docker_paths.output_dir
-            host_tmp_dir = host_paths.tmp_dir
-            host_output_dir = host_paths.output_dir
+            host_tmp_dir = os.path.join(host_tmp_dir, container_subdir)
+            host_output_dir = os.path.join(host_output_dir, container_subdir)
 
         container_args = {
             "runtime": runtime,
@@ -55,8 +50,8 @@ class ArmoryInstance(object):
                     "bind": docker_paths.saved_model_dir,
                     "mode": "rw",
                 },
-                host_output_dir: {"bind": docker_output_dir, "mode": "rw"},
-                host_tmp_dir: {"bind": docker_tmp_dir, "mode": "rw"},
+                host_output_dir: {"bind": docker_paths.output_dir, "mode": "rw"},
+                host_tmp_dir: {"bind": docker_paths.tmp_dir, "mode": "rw"},
             },
         }
         if ports is not None:

--- a/armory/docker/volumes_util.py
+++ b/armory/docker/volumes_util.py
@@ -1,0 +1,42 @@
+"""
+Utility functions for dealing with docker directories and mounted volumes
+"""
+
+import datetime
+import logging
+import os
+
+from armory import paths
+
+logger = logging.getLogger(__name__)
+
+
+def tmp_output_subdir(retries=10):
+    """
+    Return (<subdir name>, <tmp subdir path>, <output subdir path>)
+
+    retries - number of times to retry folder creation before returning an error
+        if retries < 0, it will retry indefinitely.
+        retries are necessary to prevent timestamp collisions.
+    """
+    tries = int(retries) + 1
+    host_paths = paths.host()
+    while tries:
+        subdir = datetime.datetime.utcnow().isoformat()
+        # ":" characters violate docker-py volume specifications
+        subdir = subdir.replace(":", "-")
+        # Use tmp_subdir for locking
+        try:
+            tmp_subdir = os.path.join(host_paths.tmp_dir, subdir)
+            os.mkdir(tmp_subdir)
+        except FileExistsError:
+            tries -= 1
+            if tries:
+                logger.warning(f"Failed to create {tmp_subdir}. Retrying...")
+            continue
+
+        output_subdir = os.path.join(host_paths.output_dir, subdir)
+        os.mkdir(output_subdir)
+        return subdir, tmp_subdir, output_subdir
+
+    raise ValueError("Failed to create tmp and output subdirectories")

--- a/armory/eval/evaluator.py
+++ b/armory/eval/evaluator.py
@@ -2,6 +2,7 @@
 Evaluators control launching of ARMORY evaluations.
 """
 
+import datetime
 import os
 import json
 import logging
@@ -24,6 +25,40 @@ from armory import paths
 logger = logging.getLogger(__name__)
 
 
+def tmp_output_subdir(retries=10):
+    """
+    Return (<subdir name>, <tmp subdir path>, <output subdir path>)
+
+    retries - number of times to retry folder creation before returning an error
+        if retries < 0, it will retry indefinitely.
+    """
+    tries = int(retries) + 1
+    host_paths = paths.host()
+    while tries:
+        subdir = datetime.datetime.utcnow().isoformat()
+        # Use tmp_subdir for locking
+        try:
+            tmp_subdir = os.path.join(host_paths.tmp_dir, subdir)
+            os.mkdir(tmp_subdir)
+        except FileExistsError:
+            tries -= 1
+            if tries:
+                logger.warning(f"Failed to create {tmp_subdir}. Retrying...")
+            continue
+
+        try:
+            output_subdir = os.path.join(host_paths.output_dir, subdir)
+            os.mkdir(output_subdir)
+        except OSError:
+            logger.exception(
+                f"Sync failure: created {tmp_subdir} but failed on {output_subdir}. Exiting."
+            )
+            raise
+        return subdir, tmp_subdir, output_subdir
+
+    raise ValueError("Failed to create tmp and output subdirectories")
+
+
 class Evaluator(object):
     def __init__(
         self, config_path: Union[str, dict], container_config_name="eval-config.json"
@@ -43,9 +78,13 @@ class Evaluator(object):
             self.config = config_path
         else:
             raise ValueError(f"config_path {config_path} must be a str or dict")
-        self.tmp_config = os.path.join(self.host_paths.tmp_dir, container_config_name)
+        self.container_subdir, self.tmp_dir, self.output_dir = tmp_output_subdir()
+        self.tmp_config = os.path.join(self.tmp_dir, container_config_name)
+        self.external_repo_dir = paths.get_external(self.tmp_dir)
         self.docker_config_path = Path(
-            os.path.join(self.docker_paths.tmp_dir, container_config_name)
+            os.path.join(
+                self.docker_paths.tmp_dir, self.container_subdir, container_config_name
+            )
         ).as_posix()
 
         kwargs = dict(runtime="runc")
@@ -76,11 +115,14 @@ class Evaluator(object):
 
     def _download_external(self):
         external_repo.download_and_extract_repo(
-            self.config["sysconfig"]["external_github_repo"]
+            self.config["sysconfig"]["external_github_repo"],
+            external_repo_dir=self.external_repo_dir,
         )
 
     def _download_private(self):
-        external_repo.download_and_extract_repo("twosixlabs/armory-private")
+        external_repo.download_and_extract_repo(
+            "twosixlabs/armory-private", external_repo_dir=self.external_repo_dir
+        )
         self.extra_env_vars.update(
             {
                 "ARMORY_PRIVATE_S3_ID": os.getenv("ARMORY_PRIVATE_S3_ID"),
@@ -89,36 +131,39 @@ class Evaluator(object):
         )
 
     def _write_tmp(self):
-        os.makedirs(self.host_paths.tmp_dir, exist_ok=True)
+        os.makedirs(self.tmp_dir, exist_ok=True)
         if os.path.exists(self.tmp_config):
             logger.warning(f"Overwriting previous temp config: {self.tmp_config}...")
         with open(self.tmp_config, "w") as f:
             json.dump(self.config, f)
 
     def _delete_tmp(self):
-        if os.path.exists(self.host_paths.external_repo_dir):
+        if os.path.exists(self.external_repo_dir):
             try:
-                shutil.rmtree(self.host_paths.external_repo_dir)
+                shutil.rmtree(self.external_repo_dir)
             except OSError as e:
                 if not isinstance(e, FileNotFoundError):
                     logger.exception(
-                        f"Error removing external repo {self.host_paths.external_repo_dir}"
+                        f"Error removing external repo {self.external_repo_dir}"
                     )
+
         try:
-            os.remove(self.tmp_config)
+            logger.info(f"Deleting tmp_dir {self.tmp_dir}")
+            shutil.rmtree(self.tmp_dir)
         except OSError as e:
             if not isinstance(e, FileNotFoundError):
-                logger.exception(f"Error removing tmp config {self.tmp_config}")
+                logger.exception(f"Error removing tmp_dir {self.tmp_dir}")
 
     def run(
         self, interactive=False, jupyter=False, host_port=8888, command=None
     ) -> None:
+        container_subdir, tmp_subdir_path, output_subdir_path = tmp_output_subdir()
         container_port = 8888
         self._write_tmp()
         ports = {container_port: host_port} if jupyter else None
         try:
             runner = self.manager.start_armory_instance(
-                envs=self.extra_env_vars, ports=ports
+                envs=self.extra_env_vars, ports=ports, container_subdir=container_subdir
             )
             try:
                 if jupyter:

--- a/armory/paths.py
+++ b/armory/paths.py
@@ -105,6 +105,10 @@ class HostPaths:
         os.makedirs(self.output_dir, exist_ok=True)
 
 
+def get_external(tmp_dir):
+    return os.path.join(tmp_dir, "external")
+
+
 class HostDefault:
     def __init__(self):
         self.cwd = os.getcwd()
@@ -116,7 +120,7 @@ class HostDefault:
         self.saved_model_dir = os.path.join(self.armory_dir, "saved_models")
         self.tmp_dir = os.path.join(self.armory_dir, "tmp")
         self.output_dir = os.path.join(self.armory_dir, "outputs")
-        self.external_repo_dir = os.path.join(self.tmp_dir, "external")
+        self.external_repo_dir = get_external(self.tmp_dir)
 
 
 class DockerPaths:

--- a/armory/utils/external_repo.py
+++ b/armory/utils/external_repo.py
@@ -14,16 +14,19 @@ from armory import paths
 logger = logging.getLogger(__name__)
 
 
-def download_and_extract_repo(external_repo_name: str) -> None:
+def download_and_extract_repo(
+    external_repo_name: str, external_repo_dir: str = None
+) -> None:
     """
     Downloads and extracts an external repository for use within ARMORY.
 
     Private repositories require a `GITHUB_TOKEN` environment variable.
     :param external_repo_name: String name of "organization/repo-name"
     """
-    host_paths = paths.host()
+    if external_repo_dir is None:
+        external_repo_dir = paths.host().external_repo_dir
 
-    os.makedirs(host_paths.external_repo_dir, exist_ok=True)
+    os.makedirs(external_repo_dir, exist_ok=True)
     headers = {}
     repo_name = external_repo_name.split("/")[-1]
 
@@ -39,20 +42,19 @@ def download_and_extract_repo(external_repo_name: str) -> None:
     if response.status_code == 200:
         logging.info(f"Downloading external repo: {external_repo_name}")
 
-        tar_filename = os.path.join(host_paths.external_repo_dir, repo_name + ".tar.gz")
+        tar_filename = os.path.join(external_repo_dir, repo_name + ".tar.gz")
         with open(tar_filename, "wb") as f:
             f.write(response.raw.read())
         tar = tarfile.open(tar_filename, "r:gz")
         dl_directory_name = tar.getnames()[0]
-        tar.extractall(path=host_paths.external_repo_dir)
+        tar.extractall(path=external_repo_dir)
 
         # Always overwrite existing repositories to keep them at HEAD
-        final_dir_name = os.path.join(host_paths.external_repo_dir, repo_name)
+        final_dir_name = os.path.join(external_repo_dir, repo_name)
         if os.path.isdir(final_dir_name):
             shutil.rmtree(final_dir_name)
         os.rename(
-            os.path.join(host_paths.external_repo_dir, dl_directory_name),
-            final_dir_name,
+            os.path.join(external_repo_dir, dl_directory_name), final_dir_name,
         )
         # os.remove(tar_filename)
 

--- a/tests/test_host/test_external_repo.py
+++ b/tests/test_host/test_external_repo.py
@@ -19,3 +19,10 @@ class ExternalRepoTest(unittest.TestCase):
         self.assertTrue(os.path.exists(basedir))
         self.assertTrue(os.path.isfile(basedir / "README.md"))
         shutil.rmtree(basedir)
+        os.remove(external_repo_dir / (repo_name + ".tar.gz"))
+        try:
+            os.rmdir(external_repo_dir)
+        except OSError:
+            # Only delete if empty
+            pass
+        self.assertFalse(os.path.exists(external_repo_dir))

--- a/tests/test_host/test_external_repo.py
+++ b/tests/test_host/test_external_repo.py
@@ -9,7 +9,8 @@ from armory.utils.external_repo import download_and_extract_repo
 
 class ExternalRepoTest(unittest.TestCase):
     def test_download(self):
-        external_repo_dir = pathlib.Path(paths.host().external_repo_dir)
+        tmp_subdir = pathlib.Path(paths.host().tmp_dir, "test-external-repo-subdir")
+        external_repo_dir = pathlib.Path(paths.get_external(tmp_subdir))
         repo = "twosixlabs/armory-example"
         repo_name = repo.split("/")[-1]
 
@@ -20,9 +21,5 @@ class ExternalRepoTest(unittest.TestCase):
         self.assertTrue(os.path.isfile(basedir / "README.md"))
         shutil.rmtree(basedir)
         os.remove(external_repo_dir / (repo_name + ".tar.gz"))
-        try:
-            os.rmdir(external_repo_dir)
-        except OSError:
-            # Only delete if empty
-            pass
-        self.assertFalse(os.path.exists(external_repo_dir))
+        os.rmdir(external_repo_dir)
+        os.rmdir(tmp_subdir)

--- a/tests/test_host/test_external_repo.py
+++ b/tests/test_host/test_external_repo.py
@@ -9,20 +9,13 @@ from armory.utils.external_repo import download_and_extract_repo
 
 class ExternalRepoTest(unittest.TestCase):
     def test_download(self):
-        host_paths = paths.host()
+        external_repo_dir = pathlib.Path(paths.host().external_repo_dir)
         repo = "twosixlabs/armory-example"
         repo_name = repo.split("/")[-1]
 
-        download_and_extract_repo(repo)
-        self.assertTrue(os.path.exists(f"{host_paths.external_repo_dir}/{repo_name}"))
-        self.assertTrue(
-            os.path.isfile(
-                str(
-                    pathlib.Path(
-                        f"{host_paths.external_repo_dir}/{repo_name}/README.md"
-                    )
-                )
-            )
-        )
+        download_and_extract_repo(repo, external_repo_dir=external_repo_dir)
+        basedir = external_repo_dir / repo_name
 
-        shutil.rmtree(str(pathlib.Path(f"{host_paths.external_repo_dir}/{repo_name}")))
+        self.assertTrue(os.path.exists(basedir))
+        self.assertTrue(os.path.isfile(basedir / "README.md"))
+        shutil.rmtree(basedir)


### PR DESCRIPTION
Should enable multiple docker containers to run simultaneously without impacting each others`tmp` and `output` directories. Collisions can still happen on `datasets` and `models`, but those are expected/desired.

fixes #178 