### PR TITLE
update datasets for variable length input

### DIFF
--- a/tests/test_docker/test_dataset.py
+++ b/tests/test_docker/test_dataset.py
@@ -190,7 +190,7 @@ class DatasetTest(unittest.TestCase):
             self.skipTest("resisc45_split dataset not locally available.")
 
         for split, size in [("train", 22500), ("validation", 4500), ("test", 4500)]:
-            batch_size = 16
+            batch_size = 15
             epochs = 1
             test_dataset = datasets.resisc45(
                 split_type=split,

--- a/tests/test_docker/test_dataset.py
+++ b/tests/test_docker/test_dataset.py
@@ -175,7 +175,10 @@ class DatasetTest(unittest.TestCase):
             )
             self.assertEqual(train_dataset.size, size)
             self.assertEqual(train_dataset.batch_size, batch_size)
-            self.assertEqual(train_dataset.total_iterations, size)
+            self.assertEqual(
+                train_dataset.total_iterations,
+                size // batch_size + bool(size % batch_size),
+            )
 
             x, y = train_dataset.get_batch()
             self.assertEqual(x.shape[0], 1)
@@ -190,7 +193,7 @@ class DatasetTest(unittest.TestCase):
             self.skipTest("resisc45_split dataset not locally available.")
 
         for split, size in [("train", 22500), ("validation", 4500), ("test", 4500)]:
-            batch_size = 15
+            batch_size = 16
             epochs = 1
             test_dataset = datasets.resisc45(
                 split_type=split,
@@ -200,8 +203,35 @@ class DatasetTest(unittest.TestCase):
             )
             self.assertEqual(test_dataset.size, size)
             self.assertEqual(test_dataset.batch_size, batch_size)
-            self.assertEqual(test_dataset.total_iterations, size // batch_size)
+            self.assertEqual(
+                test_dataset.total_iterations,
+                size // batch_size + bool(size % batch_size),
+            )
 
             x, y = test_dataset.get_batch()
             self.assertEqual(x.shape, (batch_size, 256, 256, 3))
             self.assertEqual(y.shape, (batch_size,))
+
+    def test_variable_length(self):
+        """
+        Skip test if not locally available
+        """
+        size = 1350
+        batch_size = 4
+        test_dataset = datasets.digit(
+            split_type="train",
+            epochs=1,
+            batch_size=batch_size,
+            dataset_dir=DATASET_DIR,
+        )
+        self.assertEqual(
+            test_dataset.total_iterations, size // batch_size + bool(size % batch_size)
+        )
+
+        x, y = test_dataset.get_batch()
+        self.assertEqual(x.dtype, object)
+        self.assertEqual(x.shape, (batch_size,))
+        for x_i in x:
+            self.assertEqual(x_i.ndim, 1)
+            self.assertTrue(1148 <= len(x_i) <= 18262)
+        self.assertEqual(y.shape, (batch_size,))

--- a/tests/test_docker/test_dataset.py
+++ b/tests/test_docker/test_dataset.py
@@ -214,7 +214,7 @@ class DatasetTest(unittest.TestCase):
 
     def test_variable_length(self):
         """
-        Skip test if not locally available
+        Test batches with variable length items using digit dataset
         """
         size = 1350
         batch_size = 4


### PR DESCRIPTION
This enables datasets with variable size inputs (ucf101, librispeech, imagenette, german_traffic_sign, digits) to have batch_size > 1. This is handled differently for datasets backed by numpy arrays (in memory) and for those backed by TFDS.

The output batches are 1D np arrays of dtype object. In order to work with most systems, these will need to be modified by a preprocessing function prior to training on most models. Since this could involve a wide variety of functionality (clipping, zero-padding, masking), I think those should be handled more directly by users.