### PR TITLE
fix accuracy calculation for example resisc scenario 

### DIFF
--- a/tests/evals/resisc45_scenario.py
+++ b/tests/evals/resisc45_scenario.py
@@ -78,9 +78,7 @@ def evaluate_classifier(config_path: str) -> None:
         benign_accuracy += np.sum(np.argmax(predictions, axis=1) == y) / len(y)
         cnt += 1
     benign_accuracy = benign_accuracy / cnt
-    logger.info(
-        "Accuracy on benign test examples: {}%".format(benign_accuracy * 100)
-    )
+    logger.info("Accuracy on benign test examples: {}%".format(benign_accuracy * 100))
 
     # Generate adversarial test examples
     attack_config = config["attack"]
@@ -101,9 +99,7 @@ def evaluate_classifier(config_path: str) -> None:
         cnt += 1
     adversarial_accuracy = adversarial_accuracy / cnt
     logger.info(
-        "Accuracy on adversarial test examples: {}%".format(
-            adversarial_accuracy * 100 
-        )
+        "Accuracy on adversarial test examples: {}%".format(adversarial_accuracy * 100)
     )
 
     logger.info("Saving json output...")

--- a/tests/evals/resisc45_scenario.py
+++ b/tests/evals/resisc45_scenario.py
@@ -77,8 +77,9 @@ def evaluate_classifier(config_path: str) -> None:
         predictions = classifier.predict(x)
         benign_accuracy += np.sum(np.argmax(predictions, axis=1) == y) / len(y)
         cnt += 1
+    benign_accuracy = benign_accuracy / cnt
     logger.info(
-        "Accuracy on benign test examples: {}%".format(benign_accuracy * 100 / cnt)
+        "Accuracy on benign test examples: {}%".format(benign_accuracy * 100)
     )
 
     # Generate adversarial test examples
@@ -98,9 +99,10 @@ def evaluate_classifier(config_path: str) -> None:
         predictions = classifier.predict(test_x_adv)
         adversarial_accuracy += np.sum(np.argmax(predictions, axis=1) == y) / len(y)
         cnt += 1
+    adversarial_accuracy = adversarial_accuracy / cnt
     logger.info(
         "Accuracy on adversarial test examples: {}%".format(
-            adversarial_accuracy * 100 / cnt
+            adversarial_accuracy * 100 
         )
     )
 


### PR DESCRIPTION
Without this fix, the benign/adversarial accuracies for Evaluation Results written to <output_dir>/evaluation-results.json are >100%