### PR TITLE
Utilize ART 1.2

### DIFF
--- a/armory/data/datasets.py
+++ b/armory/data/datasets.py
@@ -205,10 +205,7 @@ def _generator_from_np(
 
     # variable_length not needed for ArmoryDataGenerator because np handles it
     return ArmoryDataGenerator(
-        ds,
-        size=len(X) * epochs,
-        batch_size=batch_size,
-        preprocessing_fn=preprocessing_fn,
+        ds, size=len(X), batch_size=batch_size, preprocessing_fn=preprocessing_fn,
     )
 
 
@@ -418,10 +415,7 @@ def imagenet_adversarial(
     ds = tfds.as_numpy(ds, graph=default_graph)
 
     generator = ArmoryDataGenerator(
-        ds,
-        size=num_images * epochs,
-        batch_size=batch_size,
-        preprocessing_fn=preprocessing_fn,
+        ds, size=num_images, batch_size=batch_size, preprocessing_fn=preprocessing_fn,
     )
 
     return generator

--- a/armory/data/datasets.py
+++ b/armory/data/datasets.py
@@ -43,19 +43,13 @@ class ArmoryDataGenerator(DataGenerator):
     """
 
     def __init__(
-        self,
-        generator,
-        size,
-        batch_size,
-        epochs,
-        preprocessing_fn=None,
-        variable_length=False,
+        self, generator, size, batch_size, preprocessing_fn=None, variable_length=False,
     ):
         super().__init__(size, batch_size)
         self.preprocessing_fn = preprocessing_fn
         self.generator = generator
         # drop_remainder is False
-        self.total_iterations = epochs * (size // batch_size + bool(size % batch_size))
+        self.batches_per_epoch = size // batch_size + bool(size % batch_size)
         self.variable_length = variable_length
         if self.variable_length:
             self.current = 0
@@ -147,7 +141,6 @@ def _generator_from_tfds(
         ds,
         size=ds_info.splits[split_type].num_examples,
         batch_size=batch_size,
-        epochs=epochs,
         preprocessing_fn=preprocessing_fn,
         variable_length=bool(variable_length and batch_size > 1),
     )
@@ -213,8 +206,7 @@ def _generator_from_np(
     # variable_length not needed for ArmoryDataGenerator because np handles it
     return ArmoryDataGenerator(
         ds,
-        size=len(X),
-        epochs=epochs,
+        size=len(X) * epochs,
         batch_size=batch_size,
         preprocessing_fn=preprocessing_fn,
     )
@@ -427,8 +419,7 @@ def imagenet_adversarial(
 
     generator = ArmoryDataGenerator(
         ds,
-        size=num_images,
-        epochs=epochs,
+        size=num_images * epochs,
         batch_size=batch_size,
         preprocessing_fn=preprocessing_fn,
     )

--- a/armory/data/datasets.py
+++ b/armory/data/datasets.py
@@ -43,13 +43,19 @@ class ArmoryDataGenerator(DataGenerator):
     """
 
     def __init__(
-        self, generator, size, batch_size, preprocessing_fn=None, variable_length=False
+        self,
+        generator,
+        size,
+        batch_size,
+        epochs,
+        preprocessing_fn=None,
+        variable_length=False,
     ):
         super().__init__(size, batch_size)
         self.preprocessing_fn = preprocessing_fn
         self.generator = generator
         # drop_remainder is False
-        self.total_iterations = size // batch_size + bool(size % batch_size)
+        self.total_iterations = epochs * (size // batch_size + bool(size % batch_size))
         self.variable_length = variable_length
         if self.variable_length:
             self.current = 0
@@ -139,8 +145,9 @@ def _generator_from_tfds(
 
     generator = ArmoryDataGenerator(
         ds,
-        size=epochs * ds_info.splits[split_type].num_examples,
+        size=ds_info.splits[split_type].num_examples,
         batch_size=batch_size,
+        epochs=epochs,
         preprocessing_fn=preprocessing_fn,
         variable_length=bool(variable_length and batch_size > 1),
     )
@@ -206,7 +213,8 @@ def _generator_from_np(
     # variable_length not needed for ArmoryDataGenerator because np handles it
     return ArmoryDataGenerator(
         ds,
-        size=epochs * len(X),
+        size=len(X),
+        epochs=epochs,
         batch_size=batch_size,
         preprocessing_fn=preprocessing_fn,
     )
@@ -419,7 +427,8 @@ def imagenet_adversarial(
 
     generator = ArmoryDataGenerator(
         ds,
-        size=epochs * num_images,
+        size=num_images,
+        epochs=epochs,
         batch_size=batch_size,
         preprocessing_fn=preprocessing_fn,
     )

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -21,7 +21,7 @@ RUN /opt/conda/bin/pip install \
     tensorflow-datasets==2.0.0 \
     jupyterlab==1.2.6 \
     boto3==1.11.13 \
-    adversarial-robustness-toolbox==1.1.1 \
+    adversarial-robustness-toolbox==1.2.0 \
     Pillow==7.0.0 \
     pydub==0.23.1 \
     apache-beam==2.18.0 \

--- a/tests/evals/fgm_attack.py
+++ b/tests/evals/fgm_attack.py
@@ -49,7 +49,7 @@ def evaluate_classifier(config_path: str) -> None:
     )
 
     classifier.fit_generator(
-        train_data_generator, nb_epochs=train_data_generator.total_iterations,
+        train_data_generator, nb_epochs=train_epochs,
     )
 
     # Evaluate the ART classifier on benign test examples

--- a/tests/evals/fgm_attack.py
+++ b/tests/evals/fgm_attack.py
@@ -37,12 +37,6 @@ def evaluate_classifier(config_path: str) -> None:
         split_type="train",
         preprocessing_fn=preprocessing_fn,
     )
-    test_data_generator = load_dataset(
-        config["dataset"],
-        epochs=2,
-        split_type="test",
-        preprocessing_fn=preprocessing_fn,
-    )
 
     logger.info(
         f"Fitting clean unpoisoned model of {model_config['module']}.{model_config['name']}..."
@@ -54,9 +48,15 @@ def evaluate_classifier(config_path: str) -> None:
 
     # Evaluate the ART classifier on benign test examples
     logger.info("Running inference on benign examples...")
+    test_data_generator = load_dataset(
+        config["dataset"],
+        epochs=1,
+        split_type="test",
+        preprocessing_fn=preprocessing_fn,
+    )
     benign_accuracy = 0
     cnt = 0
-    for _ in range(test_data_generator.total_iterations // 2):
+    for _ in range(test_data_generator.batches_per_epoch):
         x, y = test_data_generator.get_batch()
         predictions = classifier.predict(x)
         benign_accuracy += np.sum(np.argmax(predictions, axis=1) == y) / len(y)
@@ -72,11 +72,16 @@ def evaluate_classifier(config_path: str) -> None:
 
     # Evaluate the ART classifier on adversarial test examples
     logger.info("Generating / testing adversarial examples...")
-
+    test_data_generator = load_dataset(
+        config["dataset"],
+        epochs=1,
+        split_type="test",
+        preprocessing_fn=preprocessing_fn,
+    )
     attack = attack_fn(classifier=classifier, **attack_config["kwargs"])
     adversarial_accuracy = 0
     cnt = 0
-    for _ in range(test_data_generator.total_iterations // 2):
+    for _ in range(test_data_generator.batches_per_epoch):
         x, y = test_data_generator.get_batch()
         test_x_adv = attack.generate(x=x)
         predictions = classifier.predict(test_x_adv)

--- a/tests/evals/resisc45_scenario.py
+++ b/tests/evals/resisc45_scenario.py
@@ -17,9 +17,6 @@ logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
 
 
-DEMO = True
-
-
 def evaluate_classifier(config_path: str) -> None:
     """
     Evaluate a config file for classiifcation robustness against attack.
@@ -38,41 +35,25 @@ def evaluate_classifier(config_path: str) -> None:
         split_type="train",
         preprocessing_fn=preprocessing_fn,
     )
-    # val_data_generator = load_dataset(
-    #     config["dataset"],
-    #     epochs=2,
-    #     split_type="validation",
-    #     preprocessing_fn=preprocessing_fn,
-    # )
-    test_data_generator = load_dataset(
-        config["dataset"],
-        epochs=2,
-        split_type="test",
-        preprocessing_fn=preprocessing_fn,
-    )
 
     logger.info(
         f"Fitting clean unpoisoned model of {model_config['module']}.{model_config['name']}..."
     )
 
-    if DEMO:
-        nb_epochs = 10
-    else:
-        nb_epochs = train_data_generator.total_iterations
-
-    classifier.fit_generator(train_data_generator, nb_epochs=nb_epochs)
+    classifier.fit_generator(train_data_generator, nb_epochs=1)
 
     # Evaluate the ART classifier on benign test examples
     logger.info("Running inference on benign examples...")
+    test_data_generator = load_dataset(
+        config["dataset"],
+        epochs=1,
+        split_type="test",
+        preprocessing_fn=preprocessing_fn,
+    )
+
     benign_accuracy = 0
     cnt = 0
-
-    if DEMO:
-        iterations = 3
-    else:
-        iterations = test_data_generator.total_iterations // 2
-
-    for _ in range(iterations):
+    for _ in range(test_data_generator.batches_per_epoch):
         x, y = test_data_generator.get_batch()
         predictions = classifier.predict(x)
         benign_accuracy += np.sum(np.argmax(predictions, axis=1) == y) / len(y)
@@ -88,11 +69,17 @@ def evaluate_classifier(config_path: str) -> None:
 
     # Evaluate the ART classifier on adversarial test examples
     logger.info("Generating / testing adversarial examples...")
+    test_data_generator = load_dataset(
+        config["dataset"],
+        epochs=1,
+        split_type="test",
+        preprocessing_fn=preprocessing_fn,
+    )
 
     attack = attack_fn(classifier=classifier, **attack_config["kwargs"])
     adversarial_accuracy = 0
     cnt = 0
-    for _ in range(iterations):
+    for _ in range(test_data_generator.batches_per_epoch):
         x, y = test_data_generator.get_batch()
         test_x_adv = attack.generate(x=x)
         predictions = classifier.predict(test_x_adv)

--- a/tests/test_docker/test_dataset.py
+++ b/tests/test_docker/test_dataset.py
@@ -24,7 +24,7 @@ class DatasetTest(unittest.TestCase):
             self.assertEqual(dataset.size, size)
             self.assertEqual(dataset.batch_size, batch_size)
             self.assertEqual(
-                dataset.total_iterations, size // batch_size + bool(size % batch_size),
+                dataset.batches_per_epoch, size // batch_size + bool(size % batch_size),
             )
 
             x, y = dataset.get_batch()
@@ -43,7 +43,7 @@ class DatasetTest(unittest.TestCase):
             self.assertEqual(dataset.size, size)
             self.assertEqual(dataset.batch_size, batch_size)
             self.assertEqual(
-                dataset.total_iterations, size // batch_size + bool(size % batch_size),
+                dataset.batches_per_epoch, size // batch_size + bool(size % batch_size),
             )
 
             x, y = dataset.get_batch()
@@ -87,7 +87,7 @@ class DatasetTest(unittest.TestCase):
         self.assertEqual(test_dataset.size, total_size)
         self.assertEqual(test_dataset.batch_size, batch_size)
         self.assertEqual(
-            test_dataset.total_iterations,
+            test_dataset.batches_per_epoch,
             total_size // batch_size + bool(total_size % batch_size),
         )
 
@@ -174,7 +174,7 @@ class DatasetTest(unittest.TestCase):
             self.assertEqual(dataset.size, size)
             self.assertEqual(dataset.batch_size, batch_size)
             self.assertEqual(
-                dataset.total_iterations, size // batch_size + bool(size % batch_size),
+                dataset.batches_per_epoch, size // batch_size + bool(size % batch_size),
             )
 
             x, y = dataset.get_batch()
@@ -201,7 +201,7 @@ class DatasetTest(unittest.TestCase):
             self.assertEqual(dataset.size, size)
             self.assertEqual(dataset.batch_size, batch_size)
             self.assertEqual(
-                dataset.total_iterations, size // batch_size + bool(size % batch_size),
+                dataset.batches_per_epoch, size // batch_size + bool(size % batch_size),
             )
 
             x, y = dataset.get_batch()
@@ -221,7 +221,7 @@ class DatasetTest(unittest.TestCase):
             dataset_dir=DATASET_DIR,
         )
         self.assertEqual(
-            dataset.total_iterations, size // batch_size + bool(size % batch_size)
+            dataset.batches_per_epoch, size // batch_size + bool(size % batch_size)
         )
 
         x, y = dataset.get_batch()

--- a/tests/test_pytorch/test_pytorch_models.py
+++ b/tests/test_pytorch/test_pytorch_models.py
@@ -32,15 +32,15 @@ class PyTorchModelsTest(unittest.TestCase):
         )
 
         classifier.fit_generator(
-            train_dataset, nb_epochs=train_dataset.total_iterations,
+            train_dataset, nb_epochs=1,
         )
 
         accuracy = 0
-        for _ in range(test_dataset.total_iterations):
+        for _ in range(test_dataset.batches_per_epoch):
             x, y = test_dataset.get_batch()
             predictions = classifier.predict(x)
             accuracy += np.sum(np.argmax(predictions, axis=1) == y) / len(y)
-        self.assertGreater(accuracy / test_dataset.total_iterations, 0.9)
+        self.assertGreater(accuracy / test_dataset.batches_per_epoch, 0.9)
 
     def test_keras_cifar(self):
         classifier_module = import_module("armory.baseline_models.pytorch.cifar")
@@ -64,7 +64,7 @@ class PyTorchModelsTest(unittest.TestCase):
         )
 
         classifier.fit_generator(
-            train_dataset, nb_epochs=train_dataset.total_iterations,
+            train_dataset, nb_epochs=1,
         )
 
         accuracy = 0
@@ -72,4 +72,4 @@ class PyTorchModelsTest(unittest.TestCase):
             x, y = test_dataset.get_batch()
             predictions = classifier.predict(x)
             accuracy += np.sum(np.argmax(predictions, axis=1) == y) / len(y)
-        self.assertGreater(accuracy / test_dataset.total_iterations, 0.3)
+        self.assertGreater(accuracy / test_dataset.batches_per_epoch, 0.3)

--- a/tests/test_pytorch/test_pytorch_models.py
+++ b/tests/test_pytorch/test_pytorch_models.py
@@ -68,7 +68,7 @@ class PyTorchModelsTest(unittest.TestCase):
         )
 
         accuracy = 0
-        for _ in range(test_dataset.total_iterations):
+        for _ in range(test_dataset.batches_per_epoch):
             x, y = test_dataset.get_batch()
             predictions = classifier.predict(x)
             accuracy += np.sum(np.argmax(predictions, axis=1) == y) / len(y)

--- a/tests/test_tf1/test_keras_models.py
+++ b/tests/test_tf1/test_keras_models.py
@@ -32,15 +32,15 @@ class KerasTest(unittest.TestCase):
         )
 
         classifier.fit_generator(
-            train_dataset, nb_epochs=train_dataset.total_iterations,
+            train_dataset, nb_epochs=1,
         )
 
         accuracy = 0
-        for _ in range(test_dataset.total_iterations):
+        for _ in range(test_dataset.batches_per_epoch):
             x, y = test_dataset.get_batch()
             predictions = classifier.predict(x)
             accuracy += np.sum(np.argmax(predictions, axis=1) == y) / len(y)
-        self.assertGreater(accuracy / test_dataset.total_iterations, 0.9)
+        self.assertGreater(accuracy / test_dataset.batches_per_epoch, 0.9)
 
     def test_keras_cifar(self):
         classifier_module = import_module("armory.baseline_models.keras.cifar")
@@ -64,15 +64,15 @@ class KerasTest(unittest.TestCase):
         )
 
         classifier.fit_generator(
-            train_dataset, nb_epochs=train_dataset.total_iterations,
+            train_dataset, nb_epochs=1,
         )
 
         accuracy = 0
-        for _ in range(test_dataset.total_iterations):
+        for _ in range(test_dataset.batches_per_epoch):
             x, y = test_dataset.get_batch()
             predictions = classifier.predict(x)
             accuracy += np.sum(np.argmax(predictions, axis=1) == y) / len(y)
-        self.assertGreater(accuracy / test_dataset.total_iterations, 0.3)
+        self.assertGreater(accuracy / test_dataset.batches_per_epoch, 0.3)
 
     def test_keras_imagenet(self):
         classifier_module = import_module("armory.baseline_models.keras.resnet50")
@@ -97,18 +97,18 @@ class KerasTest(unittest.TestCase):
         )
 
         accuracy = 0
-        for _ in range(clean_dataset.total_iterations):
+        for _ in range(clean_dataset.batches_per_epoch):
             x, y = clean_dataset.get_batch()
             predictions = classifier.predict(x)
             accuracy += np.sum(np.argmax(predictions, axis=1) == y) / len(y)
-        self.assertGreater(accuracy / clean_dataset.total_iterations, 0.65)
+        self.assertGreater(accuracy / clean_dataset.batches_per_epoch, 0.65)
 
         accuracy = 0
-        for _ in range(adv_dataset.total_iterations):
+        for _ in range(adv_dataset.batches_per_epoch):
             x, y = adv_dataset.get_batch()
             predictions = classifier.predict(x)
             accuracy += np.sum(np.argmax(predictions, axis=1) == y) / len(y)
-        self.assertLess(accuracy / adv_dataset.total_iterations, 0.02)
+        self.assertLess(accuracy / adv_dataset.batches_per_epoch, 0.02)
 
     def test_keras_imagenet_transfer(self):
         classifier_module = import_module(
@@ -139,11 +139,11 @@ class KerasTest(unittest.TestCase):
             x, y = clean_dataset.get_batch()
             predictions = classifier.predict(x)
             accuracy += np.sum(np.argmax(predictions, axis=1) == y) / len(y)
-        self.assertGreater(accuracy / clean_dataset.total_iterations, 0.75)
+        self.assertGreater(accuracy / clean_dataset.batches_per_epoch, 0.75)
 
         accuracy = 0
         for _ in range(adv_dataset.batches_per_epoch):
             x, y = adv_dataset.get_batch()
             predictions = classifier.predict(x)
             accuracy += np.sum(np.argmax(predictions, axis=1) == y) / len(y)
-        self.assertLess(accuracy / adv_dataset.total_iterations, 0.73)
+        self.assertLess(accuracy / adv_dataset.batches_per_epoch, 0.73)

--- a/tests/test_tf1/test_keras_models.py
+++ b/tests/test_tf1/test_keras_models.py
@@ -135,14 +135,14 @@ class KerasTest(unittest.TestCase):
         )
 
         accuracy = 0
-        for _ in range(clean_dataset.total_iterations):
+        for _ in range(clean_dataset.batches_per_epoch):
             x, y = clean_dataset.get_batch()
             predictions = classifier.predict(x)
             accuracy += np.sum(np.argmax(predictions, axis=1) == y) / len(y)
         self.assertGreater(accuracy / clean_dataset.total_iterations, 0.75)
 
         accuracy = 0
-        for _ in range(adv_dataset.total_iterations):
+        for _ in range(adv_dataset.batches_per_epoch):
             x, y = adv_dataset.get_batch()
             predictions = classifier.predict(x)
             accuracy += np.sum(np.argmax(predictions, axis=1) == y) / len(y)


### PR DESCRIPTION
* No longer uses epochs*examples as `size` since 1.2 now properly uses epochs in `fit_generator`:
https://github.com/IBM/adversarial-robustness-toolbox/pull/325/files#diff-d8fef06604d63d41409534325ce29c6f

This causes an issue with using testset data generators with multiple epochs loaded. The last batch of the first epoch will take from the next epoch if they are not divisible. I think it's cleaner to just load the testsets individually with epoch=1.

