### PR TITLE
Adversarial Imagenet Dataset --> TFDS

### DIFF
--- a/armory/data/README.md
+++ b/armory/data/README.md
@@ -9,7 +9,7 @@ datasets to the armory repository and standardizes them across all evaluations.
 |:---------- |:----------- |:------- |:-------- |:-------- |:------- |
 | `cifar10` | CIFAR 10 classes image dataset | (N, 32, 32, 3) | uint8 | (N,) | int64 |
 | `german_traffic_sign` | German traffic sign dataset | (N, variable_height, variable_width, 3) | uint8 | (N,) | int64 |
-| `imagenet_adversarial` | ILSVRC12 adversarial image dataset from ResNet50 | (N, 224, 224, 3) | float32 | (N,) | int32 |
+| `imagenet_adversarial` | ILSVRC12 adversarial image dataset from ResNet50 | (N, 224, 224, 3) | uint8 | (N,) | int64 |
 | `imagenette` | Smaller subset of 10 classes from Imagenet | (N, variable_height, variable_width, 3) | uint8  | (N,) | int64 |
 | `mnist` | MNIST hand written digit image dataset | (N, 28, 28, 1) | uint8 | (N,) | int64 |
 | `resisc45` | REmote Sensing Image Scene Classification | (N, 256, 256, 3) | uint8 | (N,) | int64 |

--- a/armory/data/adversarial/imagenet_adversarial.py
+++ b/armory/data/adversarial/imagenet_adversarial.py
@@ -21,7 +21,7 @@ _URL = "https://armory-public-data.s3.us-east-2.amazonaws.com/imagenet-adv/ILSVR
 class ImagenetAdversarial(tfds.core.GeneratorBasedBuilder):
     """ILSVRC12_ResNet50_PGD_adversarial_dataset_v1.0.tfrecords"""
 
-    VERSION = tfds.core.Version("1.0")
+    VERSION = tfds.core.Version("1.0.0")
 
     def _info(self):
         return tfds.core.DatasetInfo(

--- a/armory/data/adversarial/imagenet_adversarial.py
+++ b/armory/data/adversarial/imagenet_adversarial.py
@@ -1,0 +1,78 @@
+"""
+TensorFlow Dataset for resisc45 with train/validate/test splits
+"""
+
+import tensorflow.compat.v2 as tf
+import tensorflow_datasets.public_api as tfds
+
+_DESCRIPTION = """\
+ILSVRC12 adversarial image dataset for ResNet50
+
+ProjectedGradientDescent
+    Iterations = 10
+    Max perturbation epsilon = 8
+    Attack step size = 2
+    Targeted = True
+"""
+
+_URL = "https://armory-public-data.s3.us-east-2.amazonaws.com/imagenet-adv/ILSVRC12_ResNet50_PGD_adversarial_dataset_v1.0.tfrecords"
+
+
+class ImagenetAdversarial(tfds.core.GeneratorBasedBuilder):
+    """ILSVRC12_ResNet50_PGD_adversarial_dataset_v1.0.tfrecords"""
+
+    VERSION = tfds.core.Version("1.0")
+
+    def _info(self):
+        return tfds.core.DatasetInfo(
+            builder=self,
+            description=_DESCRIPTION,
+            features=tfds.features.FeaturesDict(
+                {
+                    "image": tfds.features.Tensor(
+                        shape=[None, None, 3], dtype=tf.float32
+                    ),
+                    "label": tfds.features.Tensor(shape=[1], dtype=tf.int32),
+                }
+            ),
+            supervised_keys=("image", "label"),
+        )
+
+    def _split_generators(self, dl_manager):
+        """Returns SplitGenerators."""
+        path = dl_manager.download_and_extract(_URL)
+        splits = [
+            tfds.core.SplitGenerator(name=x, gen_kwargs={"path": path, "split": x})
+            for x in ("adversarial", "clean")
+        ]
+        return splits
+
+    def _generate_examples(self, path, split):
+        """Yields examples."""
+        if split == "adversarial":
+            key = "adv-image"
+        elif split == "clean":
+            key = "clean-image"
+        else:
+            raise ValueError(f"split {split} not in ('adversarial', 'clean')")
+
+        ds = tf.data.TFRecordDataset(filenames=[path])
+
+        def _parse(serialized_example, key):
+            ds_features = {
+                "height": tf.io.FixedLenFeature([], tf.int64),
+                "width": tf.io.FixedLenFeature([], tf.int64),
+                "label": tf.io.FixedLenFeature([], tf.int64),
+                "adv-image": tf.io.FixedLenFeature([], tf.string),
+                "clean-image": tf.io.FixedLenFeature([], tf.string),
+            }
+            example = tf.io.parse_single_example(serialized_example, ds_features)
+
+            img = tf.io.decode_raw(example[key], tf.float32)
+            img = tf.reshape(img, (example["height"], example["width"], -1))
+            label = tf.cast(example["label"], tf.int32)
+            return img, label
+
+        ds = ds.map(lambda x: _parse(x, key))
+        for i, (img, label) in ds.enumerate:
+            yield str(i), {"image": img, "label": label}

--- a/armory/data/datasets.py
+++ b/armory/data/datasets.py
@@ -93,7 +93,7 @@ def _generator_from_tfds(
     supervised_xy_keys=None,
     download_and_prepare_kwargs=None,
     variable_length=False,
-    shuffle=True,
+    shuffle_files=True,
 ):
     """
     If as_supervised=False, must designate keys as a tuple in supervised_xy_keys:
@@ -113,7 +113,7 @@ def _generator_from_tfds(
         data_dir=dataset_dir,
         with_info=True,
         download_and_prepare_kwargs=download_and_prepare_kwargs,
-        shuffle_files=True,
+        shuffle_files=shuffle_files,
     )
     if not as_supervised:
         try:
@@ -131,7 +131,8 @@ def _generator_from_tfds(
         ds = ds.map(lambda x: (x[x_key], x[y_key]))
 
     ds = ds.repeat(epochs)
-    ds = ds.shuffle(batch_size * 10, reshuffle_each_iteration=True)
+    if shuffle_files:
+        ds = ds.shuffle(batch_size * 10, reshuffle_each_iteration=True)
     if variable_length and batch_size > 1:
         ds = ds.batch(1, drop_remainder=False)
     else:
@@ -369,7 +370,7 @@ def imagenet_adversarial(
         epochs=epochs,
         dataset_dir=dataset_dir,
         preprocessing_fn=preprocessing_fn,
-        shuffle=False,
+        shuffle_files=False,
     )
 
 

--- a/armory/data/datasets.py
+++ b/armory/data/datasets.py
@@ -20,10 +20,11 @@ import tensorflow_datasets as tfds
 import apache_beam as beam
 
 from art.data_generators import DataGenerator
-from armory.data.utils import curl, download_file_from_s3, download_verify_dataset_cache
+from armory.data.utils import curl, download_verify_dataset_cache
 from armory import paths
 from armory.data.librispeech import librispeech_dev_clean_split  # noqa: F401
 from armory.data.resisc45 import resisc45_split  # noqa: F401
+from armory.data.adversarial import imagenet_adversaril  # noqa: F401
 
 
 os.environ["KMP_WARNINGS"] = "0"
@@ -92,6 +93,7 @@ def _generator_from_tfds(
     supervised_xy_keys=None,
     download_and_prepare_kwargs=None,
     variable_length=False,
+    shuffle=True,
 ):
     """
     If as_supervised=False, must designate keys as a tuple in supervised_xy_keys:
@@ -344,12 +346,12 @@ def digit(
 
 
 def imagenet_adversarial(
-    batch_size: int,
-    epochs: int,
     split_type: str,
+    epochs: int,
+    batch_size: int,
     dataset_dir: str = None,
     preprocessing_fn: Callable = None,
-) -> (np.ndarray, np.ndarray, np.ndarray):
+) -> ArmoryDataGenerator:
     """
     ILSVRC12 adversarial image dataset for ResNet50
 
@@ -358,67 +360,17 @@ def imagenet_adversarial(
         Max perturbation epsilon = 8
         Attack step size = 2
         Targeted = True
-
-    :param dataset_dir: Directory where cached datasets are stored
-    :param preprocessing_fn: Callable function to preprocess inputs
-    :return: (Adversarial_images, Labels)
     """
 
-    def _parse(serialized_example, split_type):
-        ds_features = {
-            "height": tf.io.FixedLenFeature([], tf.int64),
-            "width": tf.io.FixedLenFeature([], tf.int64),
-            "label": tf.io.FixedLenFeature([], tf.int64),
-            "adv-image": tf.io.FixedLenFeature([], tf.string),
-            "clean-image": tf.io.FixedLenFeature([], tf.string),
-        }
-
-        example = tf.io.parse_single_example(serialized_example, ds_features)
-
-        if split_type == "clean":
-            img = tf.io.decode_raw(example["clean-image"], tf.float32)
-            img = tf.reshape(img, (example["height"], example["width"], -1))
-        elif split_type == "adversarial":
-            img = tf.io.decode_raw(example["adv-image"], tf.float32)
-            img = tf.reshape(img, (example["height"], example["width"], -1))
-
-        label = tf.cast(example["label"], tf.int32)
-        return img, label
-
-    default_graph = tf.compat.v1.keras.backend.get_session().graph
-
-    acceptable_splits = ["clean", "adversarial"]
-    if split_type not in acceptable_splits:
-        raise ValueError(f"split_type must be one of {acceptable_splits}")
-
-    if not dataset_dir:
-        dataset_dir = paths.docker().dataset_dir
-
-    num_images = 1000
-    filename = "ILSVRC12_ResNet50_PGD_adversarial_dataset_v1.0.tfrecords"
-    dirpath = os.path.join(dataset_dir, "imagenet_adversarial", "imagenet_adv")
-    output_filepath = os.path.join(dirpath, filename)
-
-    os.makedirs(dirpath, exist_ok=True)
-    download_file_from_s3(
-        bucket_name="armory-public-data",
-        key=f"imagenet-adv/{filename}",
-        local_path=output_filepath,
+    return _generator_from_tfds(
+        "imagenet_adversarial:1.0",
+        split_type=split_type,
+        batch_size=batch_size,
+        epochs=epochs,
+        dataset_dir=dataset_dir,
+        preprocessing_fn=preprocessing_fn,
+        shuffle=False,
     )
-
-    ds = tf.data.TFRecordDataset(filenames=[output_filepath])
-    ds = ds.map(lambda example_proto: _parse(example_proto, split_type))
-    ds = ds.repeat(epochs)
-    ds = ds.shuffle(batch_size * 10)
-    ds = ds.batch(batch_size, drop_remainder=False)
-    ds = ds.prefetch(tf.data.experimental.AUTOTUNE)
-    ds = tfds.as_numpy(ds, graph=default_graph)
-
-    generator = ArmoryDataGenerator(
-        ds, size=num_images, batch_size=batch_size, preprocessing_fn=preprocessing_fn,
-    )
-
-    return generator
 
 
 def imagenette(

--- a/armory/data/datasets.py
+++ b/armory/data/datasets.py
@@ -24,7 +24,7 @@ from armory.data.utils import curl, download_verify_dataset_cache
 from armory import paths
 from armory.data.librispeech import librispeech_dev_clean_split  # noqa: F401
 from armory.data.resisc45 import resisc45_split  # noqa: F401
-from armory.data.adversarial import imagenet_adversaril  # noqa: F401
+from armory.data.adversarial import imagenet_adversarial as IA  # noqa: F401
 
 
 os.environ["KMP_WARNINGS"] = "0"

--- a/armory/data/datasets.py
+++ b/armory/data/datasets.py
@@ -363,7 +363,7 @@ def imagenet_adversarial(
     """
 
     return _generator_from_tfds(
-        "imagenet_adversarial:1.0",
+        "imagenet_adversarial:1.0.0",
         split_type=split_type,
         batch_size=batch_size,
         epochs=epochs,

--- a/armory/data/url_checksums/imagenet_adversarial.txt
+++ b/armory/data/url_checksums/imagenet_adversarial.txt
@@ -1,0 +1,1 @@
+https://armory-public-data.s3.us-east-2.amazonaws.com/imagenet-adv/ILSVRC12_ResNet50_PGD_adversarial_dataset_v1.0.tfrecords 1204414872 cb0a18f2cad6851dafe7427c472f376e111dbe469301a9d2bdf8d30bd8ba7ba2


### PR DESCRIPTION
There is one remaining issue. I could not figure out how to get TFDS to *not* shuffle the items when writing them to file (which results in the "clean" and "adversarial" splits returning in a different order):
```
Downloading and preparing dataset imagenet_adversarial (?? GiB) to /armory/datasets/imagenet_adversarial/1.0.0...
Dl Completed...: 0 url [00:00, ? url/s]
Extraction completed...: 0 file [00:00, ? file/s]
Extraction completed...: 0 file [00:00, ? file/s]
Dl Size...: 0 MiB [00:00, ? MiB/s]

Dl Completed...: 0 url [00:00, ? url/s]
Shuffling and writing examples to /armory/datasets/imagenet_adversarial/1.0.0.incompleteDC9UV6/imagenet_adversarial-adversarial.tfrecord
Shuffling and writing examples to /armory/datasets/imagenet_adversarial/1.0.0.incompleteDC9UV6/imagenet_adversarial-clean.tfrecord                    
Computing statistics...: 100%|██████████████████████████████████████████████████████████████████████████████████████| 2/2 [00:04<00:00,  2.47s/ split]
Dataset imagenet_adversarial downloaded and prepared to /armory/datasets/imagenet_adversarial/1.0.0. Subsequent calls will reuse this data.
```

I suggest that we merge this and make an issue for that single issue.