### PR TITLE
Verify download if cache .tar.gz file exists

### DIFF
--- a/armory/data/utils.py
+++ b/armory/data/utils.py
@@ -92,6 +92,16 @@ def download_verify_dataset_cache(dataset_dir, checksum_file, name):
     cache_dir = os.path.join(dataset_dir, "cache")
     os.makedirs(cache_dir, exist_ok=True)
     tar_filepath = os.path.join(cache_dir, os.path.basename(s3_key))
+    if os.path.exists(tar_filepath):
+        # Check existing download to avoid falling back to processing data
+        logger.info(f"{tar_filepath} exists. Verifying...")
+        try:
+            verify_size(tar_filepath, int(file_length))
+            verify_sha256(tar_filepath, hash)
+        except ValueError as e:
+            logger.warning(f"Verification failed: {str(e)}")
+            os.remove(tar_filepath)
+
     if not os.path.exists(tar_filepath):
         logger.info(f"Downloading dataset: {name}...")
         try:

--- a/armory/data/utils.py
+++ b/armory/data/utils.py
@@ -92,12 +92,14 @@ def download_verify_dataset_cache(dataset_dir, checksum_file, name):
     cache_dir = os.path.join(dataset_dir, "cache")
     os.makedirs(cache_dir, exist_ok=True)
     tar_filepath = os.path.join(cache_dir, os.path.basename(s3_key))
+    already_verified = False
     if os.path.exists(tar_filepath):
         # Check existing download to avoid falling back to processing data
         logger.info(f"{tar_filepath} exists. Verifying...")
         try:
             verify_size(tar_filepath, int(file_length))
             verify_sha256(tar_filepath, hash)
+            already_verified = True
         except ValueError as e:
             logger.warning(f"Verification failed: {str(e)}")
             os.remove(tar_filepath)
@@ -115,17 +117,18 @@ def download_verify_dataset_cache(dataset_dir, checksum_file, name):
         logger.info("Dataset already downloaded.")
 
     # verification
-    try:
-        verify_size(tar_filepath, int(file_length))
-        logger.info("Verifying sha256 hash of download...")
-        verify_sha256(tar_filepath, hash)
-    except ValueError:
-        if os.path.exists(tar_filepath):
-            os.remove(tar_filepath)
-        logger.warning(
-            "Cached file download failed. Falling back to processing data..."
-        )
-        return
+    if not already_verified:
+        try:
+            verify_size(tar_filepath, int(file_length))
+            logger.info("Verifying sha256 hash of download...")
+            verify_sha256(tar_filepath, hash)
+        except ValueError:
+            if os.path.exists(tar_filepath):
+                os.remove(tar_filepath)
+            logger.warning(
+                "Cached file download failed. Falling back to processing data..."
+            )
+            return
 
     tmp_dir = os.path.join(
         cache_dir,


### PR DESCRIPTION
Currently, if the cache file exists but is incorrect, this will be caught after the "download" portion in verification, which will fail. This will then fall back to the full dataset processing, like so:
```
>>> d = datasets.librispeech_dev_clean("train", 1, 1)
2020-03-26 19:59:30 5315d24e3726 armory.data.utils[14] INFO Dataset already downloaded.
2020-03-26 19:59:30 5315d24e3726 armory.data.utils[14] WARNING Cached file download failed. Falling back to processing data...
...
```

With this change, it will verify any existing cache file, delete it if corrupted, re-download from cache, re-verify, and only go to processing if that also fails. Here is what a typical run would look like:
```
>>> d = datasets.librispeech_dev_clean("train", 1, 1)
2020-03-26 20:06:08 5315d24e3726 armory.data.utils[14] INFO /armory/datasets/cache/librispeech_dev_clean_split.tar.gz exists. Verifying...
2020-03-26 20:06:08 5315d24e3726 armory.data.utils[14] WARNING Verification failed: file size of /armory/datasets/cache/librispeech_dev_clean_split.tar.gz: 0 != 594065047
2020-03-26 20:06:08 5315d24e3726 armory.data.utils[14] INFO Downloading dataset: librispeech_dev_clean_split...
2020-03-26 20:06:08 5315d24e3726 armory.data.utils[14] INFO Downloading S3 data file...
2020-03-26 20:06:27 5315d24e3726 armory.data.utils[14] INFO Verifying sha256 hash of download...
2020-03-26 20:06:30 5315d24e3726 armory.data.utils[14] INFO Extracting .tfrecord files from download...
2020-03-26 20:07:44 5315d24e3726 absl[14] INFO No config specified, defaulting to first: librispeech_dev_clean_split/plain_text
2020-03-26 20:07:44 5315d24e3726 absl[14] INFO Overwrite dataset info from restored data version.
2020-03-26 20:07:45 5315d24e3726 absl[14] INFO Reusing dataset librispeech_dev_clean_split (/armory/datasets/librispeech_dev_clean_split/plain_text/1.1.0)
2020-03-26 20:07:45 5315d24e3726 absl[14] INFO Constructing tf.data.Dataset for split train, from /armory/datasets/librispeech_dev_clean_split/plain_text/1.1.0
```