### PR TITLE
ArmoryDataGenerator implements iterator interface

### DIFF
--- a/armory/data/datasets.py
+++ b/armory/data/datasets.py
@@ -81,6 +81,12 @@ class ArmoryDataGenerator(DataGenerator):
 
         return x, y
 
+    def __iter__(self):
+        return self
+
+    def __next__(self):
+        return self.get_batch()
+
 
 def _generator_from_tfds(
     dataset_name: str,

--- a/tests/test_docker/test_dataset.py
+++ b/tests/test_docker/test_dataset.py
@@ -231,3 +231,18 @@ class DatasetTest(unittest.TestCase):
             self.assertEqual(x_i.ndim, 1)
             self.assertTrue(1148 <= len(x_i) <= 18262)
         self.assertEqual(y.shape, (batch_size,))
+
+    def test_generator(self):
+        batch_size = 600
+        for split, size in [("train", 60000)]:
+            dataset = datasets.mnist(
+                split_type=split,
+                epochs=1,
+                batch_size=batch_size,
+                dataset_dir=DATASET_DIR,
+            )
+
+            for x, y in dataset:
+                self.assertEqual(x.shape, (batch_size, 28, 28, 1))
+                self.assertEqual(y.shape, (batch_size,))
+                break


### PR DESCRIPTION
Enable iteration (and enumeration) of ArmoryDataGenerator.

It's definitely counterintuitive to have a generator that you can't directly iterate on. This small change enables that. It also enables syntactic sugar which might be nice for scenarios. Thus:
```python
    cnt = 0                                                                              
    for _ in range(test_data_generator.batches_per_epoch):                               
        x, y = test_data_generator.get_batch()                                           
        test_x_adv = attack.generate(x=x)                                                
        predictions = classifier.predict(test_x_adv)                                     
        adversarial_accuracy += np.sum(np.argmax(predictions, axis=1) == y) / len(y)     
        cnt += 1
    adversarial_accuracy = adversarial_accuracy / cnt                                    
```
would become 
```python
    for cnt, (x, y) in test_data_generator:                                              
        test_x_adv = attack.generate(x=x)                                                
        predictions = classifier.predict(test_x_adv)                                     
        adversarial_accuracy += np.sum(np.argmax(predictions, axis=1) == y) / len(y)
    adversarial_accuracy = adversarial_accuracy / cnt                                    
```