### PR TITLE
Use curl with download_verify_dataset_cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,5 +74,3 @@ armory run examples/fgm_attack.json
 # Scenarios
 Armory will provide several scenarios for various data modalities and threat models. 
 More information will be added 
-
-""

--- a/README.md
+++ b/README.md
@@ -74,3 +74,5 @@ armory run examples/fgm_attack.json
 # Scenarios
 Armory will provide several scenarios for various data modalities and threat models. 
 More information will be added 
+
+""

--- a/armory/data/utils.py
+++ b/armory/data/utils.py
@@ -6,6 +6,7 @@ import logging
 import hashlib
 import tarfile
 import os
+import subprocess
 import shutil
 import random
 import string
@@ -31,6 +32,21 @@ def download_file_from_s3(bucket_name: str, key: str, local_path: str):
         client.download_file(bucket_name, key, local_path)
     else:
         logger.info("Reusing cached file...")
+
+
+def curl(url: str, dirpath: str, filename: str) -> None:
+    """
+    Downloads a file with a specified output filename and directory
+    :param url: URL to file
+    :param dirpath: Output directory
+    :param filename: Output filename
+    """
+    try:
+        subprocess.check_call(["curl", "-L", url, "--output", filename], cwd=dirpath)
+    except FileNotFoundError as e:
+        raise FileNotFoundError(f"curl command not found. Is curl installed? {e}")
+    except subprocess.CalledProcessError:
+        raise subprocess.CalledProcessError
 
 
 def sha256(filepath: str, block_size=4096):
@@ -107,7 +123,9 @@ def download_verify_dataset_cache(dataset_dir, checksum_file, name):
     if not os.path.exists(tar_filepath):
         logger.info(f"Downloading dataset: {name}...")
         try:
-            download_file_from_s3(s3_bucket_name, s3_key, tar_filepath)
+            s3_url_region = "us-east-2"
+            url = f"https://{s3_bucket_name}.{s3_url_region}.amazonaws.com/{s3_key}"
+            curl(url, dataset_dir, tar_filepath)
         except KeyboardInterrupt:
             logger.exception("Keyboard interrupt caught")
             if os.path.exists(tar_filepath):

--- a/armory/data/utils.py
+++ b/armory/data/utils.py
@@ -124,7 +124,7 @@ def download_verify_dataset_cache(dataset_dir, checksum_file, name):
         logger.info(f"Downloading dataset: {name}...")
         try:
             s3_url_region = "us-east-2"
-            url = f"https://{s3_bucket_name}.{s3_url_region}.amazonaws.com/{s3_key}"
+            url = f"https://{s3_bucket_name}.s3.{s3_url_region}.amazonaws.com/{s3_key}"
             curl(url, dataset_dir, tar_filepath)
         except KeyboardInterrupt:
             logger.exception("Keyboard interrupt caught")


### PR DESCRIPTION
Exact details of the bug are unclear (could not replicate locally), but the boto3 call seems to be intermittently creating segmentation faults during CI testing. Below are two example failing CI tests:

https://github.com/twosixlabs/armory/runs/540390645?check_suite_focus=true
https://github.com/twosixlabs/armory/runs/540179652?check_suite_focus=true