### PR TITLE
Utilize GPU for pytorch models if available

### DIFF
--- a/.github/workflows/ci_test.yml
+++ b/.github/workflows/ci_test.yml
@@ -11,6 +11,10 @@ on:
     branches:
       - master
       - r*
+
+env:
+  DOCKER_BUILDKIT: 1
+
 jobs:
   pytest-host:
     name: PyTest Host
@@ -40,8 +44,6 @@ jobs:
         with:
           python-version: '3.6'
       - name: Run armory TF1 docker tests
-        env:
-          DOCKER_BUILDKIT: 1
         run: |
           pip install -r requirements.txt
           version=$(python -m armory --version)
@@ -56,12 +58,9 @@ jobs:
       - uses: actions/setup-python@v1
         with:
           python-version: '3.6'
-      - name: Run armory TF1 docker tests
-        env:
-          DOCKER_BUILDKIT: 1
+      - name: Run armory TF1 configs
         run: |
           pip install -r requirements.txt
-          version=$(python -m armory --version)
           bash docker/build-dev.sh tf1
           python -m armory run tests/configs/tf1/fgm_attack_test.json
   pytest-tf2:
@@ -73,8 +72,6 @@ jobs:
         with:
           python-version: '3.6'
       - name: Run armory TF2 docker tests
-        env:
-          DOCKER_BUILDKIT: 1
         run: |
           pip install -r requirements.txt
           version=$(python -m armory --version)
@@ -90,14 +87,25 @@ jobs:
         with:
           python-version: '3.6'
       - name: Run armory PyTorch docker tests
-        env:
-          DOCKER_BUILDKIT: 1
         run: |
           pip install -r requirements.txt
           version=$(python -m armory --version)
           bash docker/build-dev.sh pytorch
           docker run -w /armory_dev twosixarmory/pytorch:${version} pytest -s ./tests/test_docker
           docker run -w /armory_dev twosixarmory/pytorch:${version} pytest -s ./tests/test_pytorch
+  armory-pytorch:
+    name: Armory run tests PyTorch
+    runs-on: ubuntu-18.04
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v1
+        with:
+          python-version: '3.6'
+      - name: Run armory Pytorch configs
+        run: |
+          pip install -r requirements.txt
+          bash docker/build-dev.sh pytorch
+          python -m armory run tests/configs/pytorch/fgm_attack_test.json
   flake8-test:
     name: Flake8
     runs-on: ubuntu-18.04

--- a/armory/baseline_models/pytorch/cifar.py
+++ b/armory/baseline_models/pytorch/cifar.py
@@ -46,6 +46,10 @@ def make_cifar_model(**kwargs):
 
 def get_art_model(model_kwargs, wrapper_kwargs, weights_file=None):
     model = make_cifar_model(**model_kwargs)
+
+    if torch.cuda.is_available():
+        model.cuda()
+
     if weights_file:
         saved_model_dir = paths.docker().saved_model_dir
         filepath = os.path.join(saved_model_dir, weights_file)

--- a/armory/baseline_models/pytorch/mnist.py
+++ b/armory/baseline_models/pytorch/mnist.py
@@ -46,6 +46,10 @@ def make_mnist_model(**kwargs):
 
 def get_art_model(model_kwargs, wrapper_kwargs, weights_file=None):
     model = make_mnist_model(**model_kwargs)
+
+    if torch.cuda.is_available():
+        model.cuda()
+
     if weights_file:
         saved_model_dir = paths.docker().saved_model_dir
         filepath = os.path.join(saved_model_dir, weights_file)

--- a/armory/baseline_models/pytorch/resnet50.py
+++ b/armory/baseline_models/pytorch/resnet50.py
@@ -37,6 +37,9 @@ def preprocessing_fn(img):
 def get_art_model(model_kwargs, wrapper_kwargs, weights_file=None):
     model = models.resnet50(**model_kwargs)
 
+    if torch.cuda.is_available():
+        model.cuda()
+
     if weights_file:
         saved_model_dir = paths.docker().saved_model_dir
         filepath = os.path.join(saved_model_dir, weights_file)

--- a/tests/configs/pytorch/fgm_attack_test.json
+++ b/tests/configs/pytorch/fgm_attack_test.json
@@ -1,0 +1,36 @@
+{
+    "adhoc": {
+        "train_epochs": 3
+    },
+    "attack": {
+        "budget": null,
+        "knowledge": "white",
+        "kwargs": {
+            "eps": 0.2
+        },
+        "module": "art.attacks",
+        "name": "FastGradientMethod"
+    },
+    "dataset": {
+        "batch_size": 64,
+        "module": "armory.data.datasets",
+        "name": "mnist"
+    },
+    "defense": null,
+    "evaluation": {
+        "eval_file": "tests.evals.fgm_attack"
+    },
+    "metric": null,
+    "model": {
+        "model_kwargs": {},
+        "module": "armory.baseline_models.pytorch.mnist",
+        "name": "get_art_model",
+        "weights_file": null,
+        "wrapper_kwargs": {}
+    },
+    "sysconfig": {
+        "docker_image": "twosixarmory/pytorch:0.6.0-dev",
+        "external_github_repo": "twosixlabs/armory-example",
+        "use_gpu": false
+    }
+}


### PR DESCRIPTION
Closes #342 

Better than having to parse a GPU config, if it's available then it'll be used. Same strategy our TF models use.