### PR TITLE
Updated docker release process

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,6 +24,26 @@ jobs:
         with:
           user: __token__
           password: ${{ secrets.pypi_token }}
+  release-armory-docker:
+    name: Build and release armory docker image
+    needs: [release-wheel]
+    runs-on: ubuntu-18.04
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.client_payload.branch }}
+      - uses: actions/setup-python@v1
+        with:
+          python-version: '3.6'
+      - name: Build and release docker images
+        run: |
+          python -m pip install -r requirements.txt
+          version=$(python -c "import armory; print(armory.__version__)")
+          previous_version=$(python -c "import armory; print(armory.__previous_docker_version__)")
+          docker login --username ${{ secrets.DOCKER_USERNAME }} --password ${{ secrets.DOCKER_PASSWORD }}
+          docker pull twosixarmory/armory:${previous_version}
+          bash docker/build.sh armory
+          docker push twosixarmory/armory:${version}
   release-tf1-docker:
     name: Build and release tf1 docker image
     needs: [release-wheel]
@@ -39,7 +59,10 @@ jobs:
         run: |
           python -m pip install -r requirements.txt
           version=$(python -c "import armory; print(armory.__version__)")
+          previous_version=$(python -c "import armory; print(armory.__previous_docker_version__)")
           docker login --username ${{ secrets.DOCKER_USERNAME }} --password ${{ secrets.DOCKER_PASSWORD }}
+          docker pull twosixarmory/armory:${version}
+          docker pull twosixarmory/tf1:${previous_version}
           bash docker/build.sh tf1
           docker push twosixarmory/tf1:${version}
   release-tf2-docker:
@@ -57,7 +80,10 @@ jobs:
         run: |
           python -m pip install -r requirements.txt
           version=$(python -c "import armory; print(armory.__version__)")
+          previous_version=$(python -c "import armory; print(armory.__previous_docker_version__)")
           docker login --username ${{ secrets.DOCKER_USERNAME }} --password ${{ secrets.DOCKER_PASSWORD }}
+          docker pull twosixarmory/armory:${version}
+          docker pull twosixarmory/tf2:${previous_version}
           bash docker/build.sh tf2
           docker push twosixarmory/tf2:${version}
   release-pytorch-docker:
@@ -75,6 +101,9 @@ jobs:
         run: |
           python -m pip install -r requirements.txt
           version=$(python -c "import armory; print(armory.__version__)")
+          previous_version=$(python -c "import armory; print(armory.__previous_docker_version__)")
           docker login --username ${{ secrets.DOCKER_USERNAME }} --password ${{ secrets.DOCKER_PASSWORD }}
+          docker pull twosixarmory/armory:${version}
+          docker pull twosixarmory/pytorch:${previous_version}
           bash docker/build.sh pytorch
           docker push twosixarmory/pytorch:${version}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,11 +39,12 @@ jobs:
         run: |
           python -m pip install -r requirements.txt
           version=$(python -c "import armory; print(armory.__version__)")
-          previous_version=$(python -c "import armory; print(armory.__previous_docker_version__)")
           docker login --username ${{ secrets.DOCKER_USERNAME }} --password ${{ secrets.DOCKER_PASSWORD }}
-          docker pull twosixarmory/armory:${previous_version}
+          docker pull twosixarmory/armory:latest
           bash docker/build.sh armory
           docker push twosixarmory/armory:${version}
+          docker tag twosixarmory/armory:${version} twosixarmory/armory:latest
+          docker push twosixarmory/armory:latest
   release-tf1-docker:
     name: Build and release tf1 docker image
     needs: [release-wheel]
@@ -59,12 +60,13 @@ jobs:
         run: |
           python -m pip install -r requirements.txt
           version=$(python -c "import armory; print(armory.__version__)")
-          previous_version=$(python -c "import armory; print(armory.__previous_docker_version__)")
           docker login --username ${{ secrets.DOCKER_USERNAME }} --password ${{ secrets.DOCKER_PASSWORD }}
           docker pull twosixarmory/armory:${version}
-          docker pull twosixarmory/tf1:${previous_version}
+          docker pull twosixarmory/tf1:latest
           bash docker/build.sh tf1
           docker push twosixarmory/tf1:${version}
+          docker tag twosixarmory/tf1:${version} twosixarmory/tf1:latest
+          docker push twosixarmory/tf1:latest
   release-tf2-docker:
     name: Build and release tf2 docker image
     needs: [release-wheel]
@@ -80,12 +82,13 @@ jobs:
         run: |
           python -m pip install -r requirements.txt
           version=$(python -c "import armory; print(armory.__version__)")
-          previous_version=$(python -c "import armory; print(armory.__previous_docker_version__)")
           docker login --username ${{ secrets.DOCKER_USERNAME }} --password ${{ secrets.DOCKER_PASSWORD }}
           docker pull twosixarmory/armory:${version}
-          docker pull twosixarmory/tf2:${previous_version}
+          docker pull twosixarmory/tf2:latest
           bash docker/build.sh tf2
           docker push twosixarmory/tf2:${version}
+          docker tag twosixarmory/tf2:${version} twosixarmory/tf2:latest
+          docker push twosixarmory/tf2:latest
   release-pytorch-docker:
     name: Build and release pytorch docker image
     needs: [release-wheel]
@@ -101,9 +104,10 @@ jobs:
         run: |
           python -m pip install -r requirements.txt
           version=$(python -c "import armory; print(armory.__version__)")
-          previous_version=$(python -c "import armory; print(armory.__previous_docker_version__)")
           docker login --username ${{ secrets.DOCKER_USERNAME }} --password ${{ secrets.DOCKER_PASSWORD }}
           docker pull twosixarmory/armory:${version}
-          docker pull twosixarmory/pytorch:${previous_version}
+          docker pull twosixarmory/pytorch:latest
           bash docker/build.sh pytorch
           docker push twosixarmory/pytorch:${version}
+          docker tag twosixarmory/pytorch:${version} twosixarmory/pytorch:latest
+          docker push twosixarmory/pytorch:latest

--- a/armory/__init__.py
+++ b/armory/__init__.py
@@ -33,3 +33,7 @@ DEV = "-dev"
 
 def is_dev():
     return __version__.endswith(DEV)
+
+
+# For Docker layer reuse
+__previous_docker_version__ = "0.6.0"

--- a/armory/__init__.py
+++ b/armory/__init__.py
@@ -27,7 +27,7 @@ except ImportError as e:
 
 
 # Semantic Version
-__version__ = "0.7.0-dev"
+__version__ = "0.7.1-dev"
 DEV = "-dev"
 
 

--- a/armory/__init__.py
+++ b/armory/__init__.py
@@ -27,7 +27,7 @@ except ImportError as e:
 
 
 # Semantic Version
-__version__ = "0.7.1-dev"
+__version__ = "0.7.0-dev"
 DEV = "-dev"
 
 

--- a/armory/__init__.py
+++ b/armory/__init__.py
@@ -33,7 +33,3 @@ DEV = "-dev"
 
 def is_dev():
     return __version__.endswith(DEV)
-
-
-# For Docker layer reuse
-__previous_docker_version__ = "0.6.0"

--- a/docker/build-dev.sh
+++ b/docker/build-dev.sh
@@ -1,29 +1,29 @@
 #!/usr/bin/env bash
-# Build a dev image for specific framework. Optionally `all` frameworks can be built.
+# Build a dev docker image for specific framework. Optionally `all` frameworks can be built.
 # Ex: `bash docker/build-dev.sh pytorch`
 
 if [ "$#" -ne 1 ]; then
-    echo "Please pass a single argument to specify which framework to build. Must be either \`tf1\`, \`tf2\` or \`pytorch\` or \`all\`"
+    echo "Usage: bash docker/build-dev.sh <framework>"
+    echo "    <framework> be \`armory\`, \`tf1\`, \`tf2\`, \`pytorch\`, or \`all\`"
     exit 1
 fi
 
-if [[ "$1" != "pytorch" && "$1" != "tf1" && "$1" != "tf2" && "$1" != "all" ]]; then
-    echo "Framework argument must be either \`tf1\`, \`tf2\` or \`pytorch\` or \`all\`"
+# Parse framework argument
+if [[ "$1" != "armory" && "$1" != "pytorch" && "$1" != "tf1" && "$1" != "tf2" && "$1" != "all" ]]; then
+    echo "ERROR: <framework> argument must be \`armory\`, \`tf1\`, \`tf2\`, \`pytorch\`, or \`all\`, not \`$1\`"
     exit 1
 fi
 
 # Parse Version
 version=$(python -m armory --version)
 
-if [[ "$1" == "all" ]]; then
-  echo "Building docker images for all frameworks..."
-  for framework in "tf1" "tf2" "pytorch"; do
-    docker build --force-rm --file docker/Dockerfile --target armory -t twosixarmory/armory:${version} .
-    docker build --force-rm --file docker/${framework}/Dockerfile --build-arg armory_version=${version} --target armory-${framework}-base -t twosixarmory/${framework}-base:${version} .
-    docker build --force-rm --file docker/${framework}-dev/Dockerfile --build-arg armory_version=${version} --target armory-${framework}-dev -t twosixarmory/${framework}:${version} .
-  done
-else
-  docker build --force-rm --file docker/Dockerfile --target armory -t twosixarmory/armory:${version} .
-  docker build --force-rm --file docker/${1}/Dockerfile --build-arg armory_version=${version} --target armory-${1}-base -t twosixarmory/${1}-base:${version} .
-  docker build --force-rm --file docker/${1}-dev/Dockerfile --build-arg armory_version=${version} --target armory-${1}-dev -t twosixarmory/${1}:${version} .
-fi
+# Build images
+echo "Building base docker image: armory"
+docker build --force-rm --file docker/Dockerfile --target armory -t twosixarmory/armory:${version} .
+for framework in "tf1" "tf2" "pytorch"; do
+    if [[ "$1" == "$framework" || "$1" == "all" ]]; then
+        echo "Building docker images for framework: $framework"
+        docker build --force-rm --file docker/${framework}/Dockerfile --build-arg armory_version=${version} --target armory-${framework}-base -t twosixarmory/${framework}-base:${version} .
+        docker build --force-rm --file docker/${framework}-dev/Dockerfile --build-arg armory_version=${version} --target armory-${framework}-dev -t twosixarmory/${framework}:${version} .
+    fi
+done

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -23,11 +23,11 @@ fi
 
 # Build images
 echo "Building base docker image: armory"
-docker build --force-rm --file docker/Dockerfile --target armory -t twosixarmory/armory:${version} .
+docker build --cache-from twosixarmory/armory:latest --force-rm --file docker/Dockerfile --target armory -t twosixarmory/armory:${version} .
 for framework in "tf1" "tf2" "pytorch"; do
     if [[ "$1" == "$framework" || "$1" == "all" ]]; then
         echo "Building docker images for framework: $framework"
-        docker build --force-rm --file docker/${framework}/Dockerfile --build-arg armory_version=${version} --target armory-${framework}-base -t twosixarmory/${framework}-base:${version} .
-        docker build --force-rm --file docker/${framework}/Dockerfile --build-arg armory_version=${version} --target armory-${framework} -t twosixarmory/${framework}:${version} .
+        docker build --cache-from twosixarmory/armory:${version} --cache-from twosixarmory/${framework}:latest --force-rm --file docker/${framework}/Dockerfile --build-arg armory_version=${version} --target armory-${framework}-base -t twosixarmory/${framework}-base:${version} .
+        docker build --cache-from twosixarmory/armory:${version} --cache-from twosixarmory/${framework}:latest --force-rm --file docker/${framework}/Dockerfile --build-arg armory_version=${version} --target armory-${framework} -t twosixarmory/${framework}:${version} .
     fi
 done

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -2,13 +2,14 @@
 # Build a docker image for specific framework. Optionally `all` frameworks can be built.
 # Ex: `bash docker/build.sh pytorch`
 if [ "$#" -ne 1 ]; then
-    echo "Please pass a single argument to specify which framework to build. Must be either \`tf1\`, \`tf2\` or \`pytorch\` or \`all\`"
+    echo "Usage: bash docker/build.sh <framework>"
+    echo "    <framework> be \`armory\`, \`tf1\`, \`tf2\`, \`pytorch\`, or \`all\`"
     exit 1
 fi
 
 # Parse framework argument
-if [[ "$1" != "pytorch" && "$1" != "tf1" && "$1" != "tf2" && "$1" != "all" ]]; then
-    echo "Framework argument must be either \`tf1\`, \`tf2\` or \`pytorch\` or \`all\`"
+if [[ "$1" != "armory" && "$1" != "pytorch" && "$1" != "tf1" && "$1" != "tf2" && "$1" != "all" ]]; then
+    echo "ERROR: <framework> argument must be \`armory\`, \`tf1\`, \`tf2\`, \`pytorch\`, or \`all\`, not \`$1\`"
     exit 1
 fi
 
@@ -21,16 +22,12 @@ if [[ $version == *"-dev" ]]; then
 fi
 
 # Build images
-if [[ "$1" == "all" ]]; then
-  echo "Building docker images for all frameworks..."
-  for framework in "tf1" "tf2" "pytorch"; do
-    docker build --force-rm --file docker/Dockerfile --target armory -t twosixarmory/armory:${version} .
-    docker build --force-rm --file docker/${framework}/Dockerfile --build-arg armory_version=${version} --target armory-${framework}-base -t twosixarmory/${framework}-base:${version} .
-    docker build --force-rm --file docker/${framework}-dev/Dockerfile --build-arg armory_version=${version} --target armory-${framework}-dev -t twosixarmory/${framework}:${version} .
-  done
-else
-    docker build --force-rm --file docker/Dockerfile --target armory -t twosixarmory/armory:${version} .
-    docker build --force-rm --file docker/${1}/Dockerfile --build-arg armory_version=${version} --target armory-${1}-base -t twosixarmory/${1}-base:${version} .
-    docker build --force-rm --file docker/${1}-dev/Dockerfile --build-arg armory_version=${version} --target armory-${1}-dev -t twosixarmory/${1}:${version} .
-fi
-
+echo "Building base docker image: armory"
+docker build --force-rm --file docker/Dockerfile --target armory -t twosixarmory/armory:${version} .
+for framework in "tf1" "tf2" "pytorch"; do
+    if [[ "$1" == "$framework" || "$1" == "all" ]]; then
+        echo "Building docker images for framework: $framework"
+        docker build --force-rm --file docker/${framework}/Dockerfile --build-arg armory_version=${version} --target armory-${framework}-base -t twosixarmory/${framework}-base:${version} .
+        docker build --force-rm --file docker/${framework}/Dockerfile --build-arg armory_version=${version} --target armory-${framework} -t twosixarmory/${framework}:${version} .
+    fi
+done


### PR DESCRIPTION
Fixes #476 

There are three things to resolve before removing WIP status:
1) How do we test this?
2) Is the `__previous_docker_version__` (or alternatively, `__previous_version__`) what we want to use to pull older docker containers? We could use the "latest" tag, but that may make it harder to test things. (And I don't know if we want performers trying to pull "latest".)
3) (minor) For our first build, we'll need a previous version of the `armory` container so that it doesn't error when it tries to pull one.

However, I think review before resolving these would be helpful.