### PR TITLE
Enable tf.data.Dataset return

### DIFF
--- a/armory/utils/config_loading.py
+++ b/armory/utils/config_loading.py
@@ -31,7 +31,8 @@ def load_dataset(dataset_config, *args, **kwargs):
     dataset_module = import_module(dataset_config["module"])
     dataset_fn = getattr(dataset_module, dataset_config["name"])
     batch_size = dataset_config["batch_size"]
-    dataset = dataset_fn(batch_size=batch_size, *args, **kwargs)
+    framework = dataset_config.get("framework", "numpy")
+    dataset = dataset_fn(batch_size=batch_size, framework=framework, *args, **kwargs)
     if not isinstance(dataset, ArmoryDataGenerator):
         raise ValueError(f"{dataset} is not an instance of {ArmoryDataGenerator}")
     return dataset

--- a/armory/utils/config_schema.json
+++ b/armory/utils/config_schema.json
@@ -43,7 +43,15 @@
                 },
                 "name": {
                     "type": "string"
-                }
+                },
+                "framework": {
+                    "enum": [
+                        "tf",
+                        "pytorch",
+                        "numpy"
+                    ],
+                    "type": "string"
+                    }
             },
             "required": [
                 "batch_size",

--- a/armory/utils/config_schema.json
+++ b/armory/utils/config_schema.json
@@ -38,12 +38,6 @@
                     "minimum": 1,
                     "type": "integer"
                 },
-                "module": {
-                    "$ref": "#/definitions/python_module"
-                },
-                "name": {
-                    "type": "string"
-                },
                 "framework": {
                     "enum": [
                         "tf",
@@ -51,7 +45,13 @@
                         "numpy"
                     ],
                     "type": "string"
-                    }
+                },
+                "module": {
+                    "$ref": "#/definitions/python_module"
+                },
+                "name": {
+                    "type": "string"
+                }
             },
             "required": [
                 "batch_size",

--- a/docs/configuration_files.md
+++ b/docs/configuration_files.md
@@ -22,7 +22,7 @@ All configuration files are verified against the jsonschema definition at run ti
     batch_size [Int]: Number of samples to include in each batch
     module: [String] Python module to load dataset from 
     name: [String] Name of the dataset function
-    framework: [String] Framework to return Tensors in. <`tf`|`pytorch`|`numpy`>. NumPy by default.
+    framework: [String] Framework to return Tensors in. <`tf`|`pytorch`|`numpy`>. `numpy` by default.
   }
 `defense`: [Object or null]
   {

--- a/docs/configuration_files.md
+++ b/docs/configuration_files.md
@@ -22,6 +22,7 @@ All configuration files are verified against the jsonschema definition at run ti
     batch_size [Int]: Number of samples to include in each batch
     module: [String] Python module to load dataset from 
     name: [String] Name of the dataset function
+    framework: [String] Framework to return Tensors in. <`tf`|`pytorch`|`numpy`>. NumPy by default.
   }
 `defense`: [Object or null]
   {
@@ -79,7 +80,8 @@ All configuration files are verified against the jsonschema definition at run ti
     "dataset": {
         "batch_size": 64,
         "module": "armory.data.datasets",
-        "name": "cifar10"
+        "name": "cifar10",
+        "framework": "numpy"
     },
     "defense": null,
     "metric": {

--- a/docs/datasets.md
+++ b/docs/datasets.md
@@ -1,16 +1,17 @@
 # Datasets
 
-The `armory.data.datasets` module implements functionality to return NumPy data 
-generators of various data modalities. Currently our datasets are loaded using 
-TensorFlow Datasets from cached tfrecord files served from the armory S3 buckets.
+The `armory.data.datasets` module implements functionality to return datasets of 
+various data modalities. By default, this is a NumPy `ArmoryDataGenerator` which 
+implements the methods needed  by the ART framework. Specifically `get_batch` will 
+return a tuple of `(data, labels)` for a specified batch size in numpy format.
 
-### ArmoryDataSet Generator
-All datasets return an `ArmoryDataGenerator` which implements the methods needed 
-by the ART framework. Specifically `get_batch` will return a tuple of `(data, labels)` 
-for a specified batch size.
+We have experimental support for returning `tf.data.Dataset` and 
+`torch.utils.data.Dataset`. These can be specified with the `framework` argument to 
+the dataset function. Options are `<numpy|tf|pytorch`.
 
-# TODO: Edit the above Section
-
+Currently, datasets are loaded using TensorFlow Datasets from cached tfrecord files. 
+These tfrecord files will be pulled from S3 if not available on your 
+`dataset_dir` directory.
 
 ### Image Datasets
 

--- a/docs/datasets.md
+++ b/docs/datasets.md
@@ -4,11 +4,12 @@ The `armory.data.datasets` module implements functionality to return NumPy data
 generators of various data modalities. Currently our datasets are loaded using 
 TensorFlow Datasets from cached tfrecord files served from the armory S3 buckets.
 
-
 ### ArmoryDataSet Generator
 All datasets return an `ArmoryDataGenerator` which implements the methods needed 
 by the ART framework. Specifically `get_batch` will return a tuple of `(data, labels)` 
 for a specified batch size.
+
+# TODO: Edit the above Section
 
 
 ### Image Datasets

--- a/scenario_configs/cifar10_baseline.json
+++ b/scenario_configs/cifar10_baseline.json
@@ -12,7 +12,8 @@
     "dataset": {
         "batch_size": 64,
         "module": "armory.data.datasets",
-        "name": "cifar10"
+        "name": "cifar10",
+        "framework": "numpy"
     },
     "defense": null,
     "metric": {

--- a/scenario_configs/cifar10_baseline.json
+++ b/scenario_configs/cifar10_baseline.json
@@ -11,9 +11,9 @@
     },
     "dataset": {
         "batch_size": 64,
+        "framework": "numpy",
         "module": "armory.data.datasets",
-        "name": "cifar10",
-        "framework": "numpy"
+        "name": "cifar10"
     },
     "defense": null,
     "metric": {

--- a/scenario_configs/cifar10_defended_example.json
+++ b/scenario_configs/cifar10_defended_example.json
@@ -11,9 +11,9 @@
     },
     "dataset": {
         "batch_size": 16,
+        "framework": "numpy",
         "module": "armory.data.datasets",
-        "name": "cifar10",
-        "framework": "numpy"
+        "name": "cifar10"
     },
     "defense": {
         "kwargs": {

--- a/scenario_configs/cifar10_defended_example.json
+++ b/scenario_configs/cifar10_defended_example.json
@@ -12,7 +12,8 @@
     "dataset": {
         "batch_size": 16,
         "module": "armory.data.datasets",
-        "name": "cifar10"
+        "name": "cifar10",
+        "framework": "numpy"
     },
     "defense": {
         "kwargs": {

--- a/scenario_configs/gtsrb_scenario_baseline.json
+++ b/scenario_configs/gtsrb_scenario_baseline.json
@@ -20,9 +20,9 @@
     },
     "dataset": {
         "batch_size": 512,
+        "framework": "numpy",
         "module": "armory.data.datasets",
-        "name": "german_traffic_sign",
-        "framework": "numpy"
+        "name": "german_traffic_sign"
     },
     "defense": {
         "kwargs": {},

--- a/scenario_configs/gtsrb_scenario_baseline.json
+++ b/scenario_configs/gtsrb_scenario_baseline.json
@@ -21,7 +21,8 @@
     "dataset": {
         "batch_size": 512,
         "module": "armory.data.datasets",
-        "name": "german_traffic_sign"
+        "name": "german_traffic_sign",
+        "framework": "numpy"
     },
     "defense": {
         "kwargs": {},

--- a/scenario_configs/librispeech_baseline_sincnet.json
+++ b/scenario_configs/librispeech_baseline_sincnet.json
@@ -17,7 +17,8 @@
     "dataset": {
         "batch_size": 128,
         "module": "armory.data.datasets",
-        "name": "librispeech_dev_clean"
+        "name": "librispeech_dev_clean",
+        "framework": "numpy"
     },
     "defense": null,
     "metric": {

--- a/scenario_configs/librispeech_baseline_sincnet.json
+++ b/scenario_configs/librispeech_baseline_sincnet.json
@@ -16,9 +16,9 @@
     },
     "dataset": {
         "batch_size": 128,
+        "framework": "numpy",
         "module": "armory.data.datasets",
-        "name": "librispeech_dev_clean",
-        "framework": "numpy"
+        "name": "librispeech_dev_clean"
     },
     "defense": null,
     "metric": {

--- a/scenario_configs/mnist_baseline.json
+++ b/scenario_configs/mnist_baseline.json
@@ -11,9 +11,9 @@
     },
     "dataset": {
         "batch_size": 64,
+        "framework": "numpy",
         "module": "armory.data.datasets",
-        "name": "mnist",
-        "framework": "numpy"
+        "name": "mnist"
     },
     "defense": null,
     "metric": {

--- a/scenario_configs/mnist_baseline.json
+++ b/scenario_configs/mnist_baseline.json
@@ -12,7 +12,8 @@
     "dataset": {
         "batch_size": 64,
         "module": "armory.data.datasets",
-        "name": "mnist"
+        "name": "mnist",
+        "framework": "numpy"
     },
     "defense": null,
     "metric": {

--- a/scenario_configs/resisc45_baseline_densenet121.json
+++ b/scenario_configs/resisc45_baseline_densenet121.json
@@ -12,7 +12,8 @@
     "dataset": {
         "batch_size": 16,
         "module": "armory.data.datasets",
-        "name": "resisc45"
+        "name": "resisc45",
+        "framework": "numpy"
     },
     "defense": null,
     "metric": {

--- a/scenario_configs/resisc45_baseline_densenet121.json
+++ b/scenario_configs/resisc45_baseline_densenet121.json
@@ -11,9 +11,9 @@
     },
     "dataset": {
         "batch_size": 16,
+        "framework": "numpy",
         "module": "armory.data.datasets",
-        "name": "resisc45",
-        "framework": "numpy"
+        "name": "resisc45"
     },
     "defense": null,
     "metric": {

--- a/scenario_configs/resisc45_baseline_densenet121_finetune.json
+++ b/scenario_configs/resisc45_baseline_densenet121_finetune.json
@@ -12,7 +12,8 @@
     "dataset": {
         "batch_size": 16,
         "module": "armory.data.datasets",
-        "name": "resisc45"
+        "name": "resisc45",
+        "framework": "numpy"
     },
     "defense": null,
     "metric": {

--- a/scenario_configs/resisc45_baseline_densenet121_finetune.json
+++ b/scenario_configs/resisc45_baseline_densenet121_finetune.json
@@ -11,9 +11,9 @@
     },
     "dataset": {
         "batch_size": 16,
+        "framework": "numpy",
         "module": "armory.data.datasets",
-        "name": "resisc45",
-        "framework": "numpy"
+        "name": "resisc45"
     },
     "defense": null,
     "metric": {

--- a/scenario_configs/ucf101_baseline_finetune.json
+++ b/scenario_configs/ucf101_baseline_finetune.json
@@ -12,9 +12,9 @@
     },
     "dataset": {
         "batch_size": 16,
+        "framework": "numpy",
         "module": "armory.data.datasets",
-        "name": "ucf101",
-        "framework": "numpy"
+        "name": "ucf101"
     },
     "defense": null,
     "metric": {

--- a/scenario_configs/ucf101_baseline_finetune.json
+++ b/scenario_configs/ucf101_baseline_finetune.json
@@ -13,7 +13,8 @@
     "dataset": {
         "batch_size": 16,
         "module": "armory.data.datasets",
-        "name": "ucf101"
+        "name": "ucf101",
+        "framework": "numpy"
     },
     "defense": null,
     "metric": {

--- a/scenario_configs/ucf101_baseline_pretrained.json
+++ b/scenario_configs/ucf101_baseline_pretrained.json
@@ -12,9 +12,9 @@
     },
     "dataset": {
         "batch_size": 16,
+        "framework": "numpy",
         "module": "armory.data.datasets",
-        "name": "ucf101",
-        "framework": "numpy"
+        "name": "ucf101"
     },
     "defense": null,
     "metric": {

--- a/scenario_configs/ucf101_baseline_pretrained.json
+++ b/scenario_configs/ucf101_baseline_pretrained.json
@@ -13,7 +13,8 @@
     "dataset": {
         "batch_size": 16,
         "module": "armory.data.datasets",
-        "name": "ucf101"
+        "name": "ucf101",
+        "framework": "numpy"
     },
     "defense": null,
     "metric": {

--- a/tests/scenarios/broken/invalid_dataset_framework.json
+++ b/tests/scenarios/broken/invalid_dataset_framework.json
@@ -1,49 +1,49 @@
 {
-  "_description": "",
-  "adhoc": null,
-  "attack": {
-    "knowledge": "white",
-    "kwargs": {
-      "eps": 0.2
+    "_description": "",
+    "adhoc": null,
+    "attack": {
+        "knowledge": "white",
+        "kwargs": {
+            "eps": 0.2
+        },
+        "module": "art.attacks",
+        "name": "FastGradientMethod"
     },
-    "module": "art.attacks",
-    "name": "FastGradientMethod"
-  },
-  "dataset": {
-    "batch_size": 64,
-    "module": "armory.data.datasets",
-    "name": "mnist",
-    "framework": "chainer"
-  },
-  "defense": null,
-  "metric": {
-    "means": true,
-    "perturbation": "linf",
-    "record_metric_per_sample": false,
-    "task": [
-      "categorical_accuracy"
-    ]
-  },
-  "model": {
-    "fit": true,
-    "fit_kwargs": {
-      "nb_epochs": 3
+    "dataset": {
+        "batch_size": 64,
+        "framework": "chainer",
+        "module": "armory.data.datasets",
+        "name": "mnist"
     },
-    "model_kwargs": {},
-    "module": "armory.baseline_models.keras.mnist",
-    "name": "get_art_model",
-    "weights_file": null,
-    "wrapper_kwargs": {}
-  },
-  "scenario": {
-    "kwargs": {},
-    "module": "armory.scenarios.image_classification",
-    "name": "ImageClassificationTask"
-  },
-  "sysconfig": {
-    "docker_image": "twosixarmory/tf1:0.7.0-dev",
-    "external_github_repo": null,
-    "gpus": "all",
-    "use_gpu": false
-  }
+    "defense": null,
+    "metric": {
+        "means": true,
+        "perturbation": "linf",
+        "record_metric_per_sample": false,
+        "task": [
+            "categorical_accuracy"
+        ]
+    },
+    "model": {
+        "fit": true,
+        "fit_kwargs": {
+            "nb_epochs": 3
+        },
+        "model_kwargs": {},
+        "module": "armory.baseline_models.keras.mnist",
+        "name": "get_art_model",
+        "weights_file": null,
+        "wrapper_kwargs": {}
+    },
+    "scenario": {
+        "kwargs": {},
+        "module": "armory.scenarios.image_classification",
+        "name": "ImageClassificationTask"
+    },
+    "sysconfig": {
+        "docker_image": "twosixarmory/tf1:0.7.0-dev",
+        "external_github_repo": null,
+        "gpus": "all",
+        "use_gpu": false
+    }
 }

--- a/tests/scenarios/broken/invalid_dataset_framework.json
+++ b/tests/scenarios/broken/invalid_dataset_framework.json
@@ -1,0 +1,49 @@
+{
+  "_description": "",
+  "adhoc": null,
+  "attack": {
+    "knowledge": "white",
+    "kwargs": {
+      "eps": 0.2
+    },
+    "module": "art.attacks",
+    "name": "FastGradientMethod"
+  },
+  "dataset": {
+    "batch_size": 64,
+    "module": "armory.data.datasets",
+    "name": "mnist",
+    "framework": "chainer"
+  },
+  "defense": null,
+  "metric": {
+    "means": true,
+    "perturbation": "linf",
+    "record_metric_per_sample": false,
+    "task": [
+      "categorical_accuracy"
+    ]
+  },
+  "model": {
+    "fit": true,
+    "fit_kwargs": {
+      "nb_epochs": 3
+    },
+    "model_kwargs": {},
+    "module": "armory.baseline_models.keras.mnist",
+    "name": "get_art_model",
+    "weights_file": null,
+    "wrapper_kwargs": {}
+  },
+  "scenario": {
+    "kwargs": {},
+    "module": "armory.scenarios.image_classification",
+    "name": "ImageClassificationTask"
+  },
+  "sysconfig": {
+    "docker_image": "twosixarmory/tf1:0.7.0-dev",
+    "external_github_repo": null,
+    "gpus": "all",
+    "use_gpu": false
+  }
+}

--- a/tests/scenarios/pytorch/image_classification.json
+++ b/tests/scenarios/pytorch/image_classification.json
@@ -11,9 +11,9 @@
     },
     "dataset": {
         "batch_size": 64,
+        "framework": "numpy",
         "module": "armory.data.datasets",
-        "name": "mnist",
-        "framework": "numpy"
+        "name": "mnist"
     },
     "defense": null,
     "metric": {

--- a/tests/scenarios/pytorch/image_classification.json
+++ b/tests/scenarios/pytorch/image_classification.json
@@ -12,7 +12,8 @@
     "dataset": {
         "batch_size": 64,
         "module": "armory.data.datasets",
-        "name": "mnist"
+        "name": "mnist",
+        "framework": "numpy"
     },
     "defense": null,
     "metric": {

--- a/tests/scenarios/pytorch/image_classification_pretrained.json
+++ b/tests/scenarios/pytorch/image_classification_pretrained.json
@@ -11,9 +11,9 @@
     },
     "dataset": {
         "batch_size": 64,
+        "framework": "numpy",
         "module": "armory.data.datasets",
-        "name": "mnist",
-        "framework": "numpy"
+        "name": "mnist"
     },
     "defense": null,
     "metric": {

--- a/tests/scenarios/pytorch/image_classification_pretrained.json
+++ b/tests/scenarios/pytorch/image_classification_pretrained.json
@@ -12,7 +12,8 @@
     "dataset": {
         "batch_size": 64,
         "module": "armory.data.datasets",
-        "name": "mnist"
+        "name": "mnist",
+        "framework": "numpy"
     },
     "defense": null,
     "metric": {

--- a/tests/scenarios/tf1/image_classification.json
+++ b/tests/scenarios/tf1/image_classification.json
@@ -11,9 +11,9 @@
     },
     "dataset": {
         "batch_size": 64,
+        "framework": "numpy",
         "module": "armory.data.datasets",
-        "name": "mnist",
-        "framework": "numpy"
+        "name": "mnist"
     },
     "defense": null,
     "metric": {

--- a/tests/scenarios/tf1/image_classification.json
+++ b/tests/scenarios/tf1/image_classification.json
@@ -12,7 +12,8 @@
     "dataset": {
         "batch_size": 64,
         "module": "armory.data.datasets",
-        "name": "mnist"
+        "name": "mnist",
+        "framework": "numpy"
     },
     "defense": null,
     "metric": {

--- a/tests/scenarios/tf1/image_classification_pretrained.json
+++ b/tests/scenarios/tf1/image_classification_pretrained.json
@@ -11,9 +11,9 @@
     },
     "dataset": {
         "batch_size": 64,
+        "framework": "numpy",
         "module": "armory.data.datasets",
-        "name": "mnist",
-        "framework": "numpy"
+        "name": "mnist"
     },
     "defense": null,
     "metric": {

--- a/tests/scenarios/tf1/image_classification_pretrained.json
+++ b/tests/scenarios/tf1/image_classification_pretrained.json
@@ -12,7 +12,8 @@
     "dataset": {
         "batch_size": 64,
         "module": "armory.data.datasets",
-        "name": "mnist"
+        "name": "mnist",
+        "framework": "numpy"
     },
     "defense": null,
     "metric": {

--- a/tests/test_docker/test_dataset.py
+++ b/tests/test_docker/test_dataset.py
@@ -5,6 +5,7 @@ Test cases for ARMORY datasets.
 import os
 
 import pytest
+import numpy as np
 
 from armory.data import datasets
 from armory import paths
@@ -233,3 +234,15 @@ def test_generator():
             assert x.shape == (batch_size, 28, 28, 1)
             assert y.shape == (batch_size,)
             break
+
+
+def test_numpy_generator():
+    dataset = datasets.mnist(
+        split_type="train",
+        epochs=1,
+        batch_size=16,
+        dataset_dir=DATASET_DIR,
+        framework="numpy",
+    )
+    x, y = dataset.get_batch()
+    assert isinstance(x, np.ndarray)

--- a/tests/test_host/test_config_verification.py
+++ b/tests/test_host/test_config_verification.py
@@ -20,6 +20,15 @@ def test_no_scenario():
         load_config(str(pathlib.Path("tests/scenarios/broken/missing_scenario.json")))
 
 
+def test_invalid_dataset_framework():
+    with pytest.raises(
+        jsonschema.ValidationError, match=r"is not one of \['tf', 'pytorch', 'numpy'\]",
+    ):
+        load_config(
+            str(pathlib.Path("tests/scenarios/broken/invalid_dataset_framework.json"))
+        )
+
+
 def test_invalid_module():
     with pytest.raises(
         jsonschema.ValidationError,

--- a/tests/test_pytorch/test_framework_dataset.py
+++ b/tests/test_pytorch/test_framework_dataset.py
@@ -1,0 +1,21 @@
+"""
+Test cases for framework specific ARMORY datasets.
+"""
+
+import pytest
+
+from armory.data import datasets
+from armory import paths
+
+DATASET_DIR = paths.docker().dataset_dir
+
+
+def test_pytorch_generator():
+    with pytest.raises(NotImplementedError):
+        _ = datasets.mnist(
+            split_type="train",
+            epochs=1,
+            batch_size=16,
+            dataset_dir=DATASET_DIR,
+            framework="pytorch",
+        )

--- a/tests/test_tf1/test_framework_dataset.py
+++ b/tests/test_tf1/test_framework_dataset.py
@@ -1,0 +1,21 @@
+"""
+Test cases for framework specific ARMORY datasets.
+"""
+
+import tensorflow as tf
+
+from armory.data import datasets
+from armory import paths
+
+DATASET_DIR = paths.docker().dataset_dir
+
+
+def test_tf_generator():
+    dataset = datasets.mnist(
+        split_type="train",
+        epochs=1,
+        batch_size=16,
+        dataset_dir=DATASET_DIR,
+        framework="tf",
+    )
+    assert isinstance(dataset, tf.data.Dataset)


### PR DESCRIPTION
Closes #452 

Wanted to discuss the implementation a little bit before finalizing. It's a bit tricker than expected since in TF the Dataset we're working with prior to `as_numpy` is a tf.data.Dataset which is not iterable since it's used in graph execution (This applies to TF1 and TF2). That means we can't pass it to ArmoryDataGenerator and it will not have a `get_batch` method for ART to use. It may still be useful for users to have this type of dataset be returned for their own training etc. but it doesn't fit as nicely in the framework as we had hoped. 

We can coerce the dataset into an iterable by executing the session, but not sure if that's preferable. Similar to how it's done for ART:
https://github.com/IBM/adversarial-robustness-toolbox/blob/c3434e6e9406df4a25d91dd7c746beb019be2bd2/tests/test_data_generators.py#L280

It would be nice to return ArmoryDataGenerators instead of a Union of ArmoryDataGenerators and tf.data.Datasets so after writing this I'm leaning toward working on that. 

Two other questions:
1. Do we want to cast the `framework` field to lowercase so there's not issue with say `NumPy` and `numpy` or would we rather be explicit.
2. Do we want to make the framework a required field in the config? Currently it will default to numpy but there's pros and cons to that.