### PR TITLE
UCF101_adversarial_dataset_deliverables

### DIFF
--- a/armory/data/adversarial/ucf101_mars_perturbation_and_patch_adversarial_112x112.py
+++ b/armory/data/adversarial/ucf101_mars_perturbation_and_patch_adversarial_112x112.py
@@ -1,6 +1,6 @@
 """
-UFC101 actiona recognition adversarial dataset generated using non-universal,
-non-patch perturbation attack
+UFC101 action recognition adversarial dataset generated using
+perturbation and patch attacks
 """
 
 from __future__ import absolute_import
@@ -31,7 +31,7 @@ _CITATION = """
 }
 """
 _DESCRIPTION = """
-Dataset contains five randomly chosen videos from each class,
+Dataset contains five randomly chosen videos from each class, taken from test split,
 totaling 505 videos. Each video is broken into its component frames.  Therefore,
 the dataset comprises sum_i(N_i) images, where N_i is the number of frames in video
 i.  All frames are of the size (112, 112, 3). For each video, a clean version,

--- a/armory/data/adversarial/ucf101_mars_perturbation_and_patch_adversarial_112x112.py
+++ b/armory/data/adversarial/ucf101_mars_perturbation_and_patch_adversarial_112x112.py
@@ -1,0 +1,248 @@
+"""
+UFC101 actiona recognition adversarial dataset generated using non-universal,
+non-patch perturbation attack
+"""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import os
+
+import tensorflow.compat.v2 as tf
+import tensorflow_datasets.public_api as tfds
+
+_CITATION = """
+@article{DBLP:journals/corr/abs-1212-0402,
+  author    = {Khurram Soomro and
+               Amir Roshan Zamir and
+               Mubarak Shah},
+  title     = {{UCF101:} {A} Dataset of 101 Human Actions Classes From Videos in
+               The Wild},
+  journal   = {CoRR},
+  volume    = {abs/1212.0402},
+  year      = {2012},
+  url       = {http://arxiv.org/abs/1212.0402},
+  archivePrefix = {arXiv},
+  eprint    = {1212.0402},
+  timestamp = {Mon, 13 Aug 2018 16:47:45 +0200},
+  biburl    = {https://dblp.org/rec/bib/journals/corr/abs-1212-0402},
+  bibsource = {dblp computer science bibliography, https://dblp.org}
+}
+"""
+_DESCRIPTION = """
+Dataset contains five randomly chosen videos from each class,
+totaling 505 videos. Each video is broken into its component frames.  Therefore,
+the dataset comprises sum_i(N_i) images, where N_i is the number of frames in video
+i.  All frames are of the size (112, 112, 3). For each video, a clean version,
+an adversarially perturbed version (using whole video perturbation attacks), and
+an adversarially patched version (using regional patch attacks) are included.
+"""
+
+_LABELS = [
+    "ApplyEyeMakeup",
+    "ApplyLipstick",
+    "Archery",
+    "BabyCrawling",
+    "BalanceBeam",
+    "BandMarching",
+    "BaseballPitch",
+    "Basketball",
+    "BasketballDunk",
+    "BenchPress",
+    "Biking",
+    "Billiards",
+    "BlowDryHair",
+    "BlowingCandles",
+    "BodyWeightSquats",
+    "Bowling",
+    "BoxingPunchingBag",
+    "BoxingSpeedBag",
+    "BreastStroke",
+    "BrushingTeeth",
+    "CleanAndJerk",
+    "CliffDiving",
+    "CricketBowling",
+    "CricketShot",
+    "CuttingInKitchen",
+    "Diving",
+    "Drumming",
+    "Fencing",
+    "FieldHockeyPenalty",
+    "FloorGymnastics",
+    "FrisbeeCatch",
+    "FrontCrawl",
+    "GolfSwing",
+    "Haircut",
+    "Hammering",
+    "HammerThrow",
+    "HandstandPushups",
+    "HandstandWalking",
+    "HeadMassage",
+    "HighJump",
+    "HorseRace",
+    "HorseRiding",
+    "HulaHoop",
+    "IceDancing",
+    "JavelinThrow",
+    "JugglingBalls",
+    "JumpingJack",
+    "JumpRope",
+    "Kayaking",
+    "Knitting",
+    "LongJump",
+    "Lunges",
+    "MilitaryParade",
+    "Mixing",
+    "MoppingFloor",
+    "Nunchucks",
+    "ParallelBars",
+    "PizzaTossing",
+    "PlayingCello",
+    "PlayingDaf",
+    "PlayingDhol",
+    "PlayingFlute",
+    "PlayingGuitar",
+    "PlayingPiano",
+    "PlayingSitar",
+    "PlayingTabla",
+    "PlayingViolin",
+    "PoleVault",
+    "PommelHorse",
+    "PullUps",
+    "Punch",
+    "PushUps",
+    "Rafting",
+    "RockClimbingIndoor",
+    "RopeClimbing",
+    "Rowing",
+    "SalsaSpin",
+    "ShavingBeard",
+    "Shotput",
+    "SkateBoarding",
+    "Skiing",
+    "Skijet",
+    "SkyDiving",
+    "SoccerJuggling",
+    "SoccerPenalty",
+    "StillRings",
+    "SumoWrestling",
+    "Surfing",
+    "Swing",
+    "TableTennisShot",
+    "TaiChi",
+    "TennisSwing",
+    "ThrowDiscus",
+    "TrampolineJumping",
+    "Typing",
+    "UnevenBars",
+    "VolleyballSpiking",
+    "WalkingWithDog",
+    "WallPushups",
+    "WritingOnBoard",
+    "YoYo",
+]
+
+_URL = "https://www.crcv.ucf.edu/data/UCF101.php"
+_DL_URL = "/armory/datasets/ucf101_mars_perturbation_and_patch_adversarial_112x112.tar.gz"  # TODO: Update to S3 bucket
+
+
+class Ucf101MarsPerturbationAndPatchAdversarial112x112(tfds.core.GeneratorBasedBuilder):
+    """ Ucf101 action recognition adversarial dataset"""
+
+    VERSION = tfds.core.Version("1.0.0")
+
+    def _info(self):
+        return tfds.core.DatasetInfo(
+            builder=self,
+            description=_DESCRIPTION,
+            features=tfds.features.FeaturesDict(
+                {
+                    "videos": {
+                        "clean": tfds.features.Video(shape=(None, 112, 112, 3)),
+                        "adversarial_perturbation": tfds.features.Video(
+                            shape=(None, 112, 112, 3)
+                        ),
+                        "adversarial_patch": tfds.features.Video(
+                            shape=(None, 112, 112, 3)
+                        ),
+                    },
+                    "label": tfds.features.ClassLabel(names=_LABELS),
+                    "videoname": tfds.features.Text(),
+                }
+            ),
+            supervised_keys=("videos", "label"),
+            homepage=_URL,
+            citation=_CITATION,
+        )
+
+    def _split_generators(self, dl_manager):
+        """Returns SplitGenerators."""
+        """Adversarial dataset only has TEST split"""
+        dl_path = dl_manager.download_and_extract(_DL_URL)
+        return [
+            tfds.core.SplitGenerator(
+                name="adversarial", gen_kwargs={"data_dir_path": dl_path,},
+            ),
+        ]
+
+    def _generate_examples(self, data_dir_path):
+        """Yields examples."""
+        root_dir = "data"
+        split_dirs = ["clean", "adversarial_perturbation", "adversarial_patch"]
+        labels = tf.io.gfile.listdir(
+            os.path.join(data_dir_path, root_dir, split_dirs[0])
+        )
+        labels.sort()
+        for label in labels:
+            videonames = tf.io.gfile.listdir(
+                os.path.join(data_dir_path, root_dir, split_dirs[0], label)
+            )
+            videonames.sort()
+            for videoname in videonames:
+                # prepare clean data
+                video_clean = tf.io.gfile.glob(
+                    os.path.join(
+                        data_dir_path,
+                        root_dir,
+                        split_dirs[0],
+                        label,
+                        videoname,
+                        "*.jpg",
+                    )
+                )
+                video_clean.sort()
+                # prepare adversarial perturbation data
+                adv_pert = tf.io.gfile.glob(
+                    os.path.join(
+                        data_dir_path,
+                        root_dir,
+                        split_dirs[1],
+                        label,
+                        videoname,
+                        "*.png",
+                    )
+                )
+                adv_pert.sort()
+                # prepare adversarial patch data
+                adv_patch = tf.io.gfile.glob(
+                    os.path.join(
+                        data_dir_path,
+                        root_dir,
+                        split_dirs[2],
+                        label,
+                        videoname,
+                        "*.png",
+                    )
+                )
+                adv_patch.sort()
+                example = {
+                    "videos": {
+                        "clean": video_clean,
+                        "adversarial_perturbation": adv_pert,
+                        "adversarial_patch": adv_patch,
+                    },
+                    "label": label,
+                    "videoname": videoname,
+                }
+                yield videoname, example

--- a/armory/data/datasets.py
+++ b/armory/data/datasets.py
@@ -27,6 +27,9 @@ from armory.data.librispeech import librispeech_dev_clean_split  # noqa: F401
 from armory.data.resisc45 import resisc45_split  # noqa: F401
 from armory.data.german_traffic_sign import german_traffic_sign as gtsrb  # noqa: F401
 from armory.data.adversarial import imagenet_adversarial as IA  # noqa: F401
+from armory.data.adversarial import (  # noqa: F401
+    ucf101_mars_perturbation_and_patch_adversarial_112x112,  # noqa: F401
+)  # noqa: F401
 from armory.data.digit import digit as digit_tfds  # noqa: F401
 
 
@@ -93,7 +96,13 @@ class ArmoryDataGenerator(DataGenerator):
             x, y = next(self.generator)
 
         if self.preprocessing_fn:
-            x = self.preprocessing_fn(x)
+            if isinstance(x, dict):
+                x_new = {}
+                for k in x.keys():
+                    x_new[k] = self.preprocessing_fn(x[k])
+                x = x_new
+            else:
+                x = self.preprocessing_fn(x)
 
         return x, y
 
@@ -456,6 +465,36 @@ def ucf101(
         as_supervised=False,
         supervised_xy_keys=("video", "label"),
         variable_length=bool(batch_size > 1),
+        cache_dataset=cache_dataset,
+        framework=framework,
+    )
+
+
+def ucf101_adversarial_112x112(
+    split_type: str = "adversarial",
+    epochs: int = 1,
+    batch_size: int = 1,
+    dataset_dir: str = None,
+    preprocessing_fn: Callable = None,
+    cache_dataset: bool = False,
+    framework: str = "numpy",
+) -> ArmoryDataGenerator:
+    """
+    UCF 101 Adversarial Dataset of size (112, 112, 3),
+    including clean, adversarial perturbed, and
+    adversarial patched
+    """
+
+    return _generator_from_tfds(
+        "ucf101_mars_perturbation_and_patch_adversarial112x112:1.0.0",
+        split_type=split_type,
+        batch_size=batch_size,
+        epochs=epochs,
+        dataset_dir=dataset_dir,
+        preprocessing_fn=preprocessing_fn,
+        as_supervised=False,
+        supervised_xy_keys=("videos", "label"),
+        variable_length=False,
         cache_dataset=cache_dataset,
         framework=framework,
     )

--- a/armory/data/url_checksums/ucf101_mars_perturbation_and_patch_adversarial_112x112.txt
+++ b/armory/data/url_checksums/ucf101_mars_perturbation_and_patch_adversarial_112x112.txt
@@ -1,0 +1,1 @@
+/armory/datasets/ucf101_mars_perturbation_and_patch_adversarial_112x112.tar.gz 4059732832 f8518692b0cd9c9f1d9e4bb2895a38fc956d3d19ebbc0cfc4ed3f167a16b91f2

--- a/armory/scenarios/video_ucf101_scenario_adversarial_preloaded.py
+++ b/armory/scenarios/video_ucf101_scenario_adversarial_preloaded.py
@@ -145,4 +145,3 @@ class Ucf101(Scenario):
 
         metrics_logger.log_task(adversarial=True)
         return metrics_logger.results()
-

--- a/armory/scenarios/video_ucf101_scenario_adversarial_preloaded.py
+++ b/armory/scenarios/video_ucf101_scenario_adversarial_preloaded.py
@@ -1,0 +1,162 @@
+"""
+Classifier evaluation within ARMORY
+
+Scenario Contributor: MITRE Corporation
+"""
+
+import logging
+
+import numpy as np
+from tqdm import tqdm
+
+from armory.utils.config_loading import (
+    load_dataset,
+    load_model,
+    load_attack,
+    load_defense_wrapper,
+    load_defense_internal,
+)
+from armory.utils import metrics
+from armory.scenarios.base import Scenario
+
+logger = logging.getLogger(__name__)
+
+
+class Ucf101(Scenario):
+    def _evaluate(self, config: dict) -> dict:
+        """
+        Evaluate the config and return a results dict
+        """
+
+        model_config = config["model"]
+        classifier, preprocessing_fn = load_model(model_config)
+
+        defense_config = config.get("defense") or {}
+        defense_type = defense_config.get("type")
+
+        if defense_type in ["Preprocessor", "Postprocessor"]:
+            logger.info(f"Applying internal {defense_type} defense to classifier")
+            classifier = load_defense_internal(config["defense"], classifier)
+
+        if model_config["fit"]:
+            classifier.set_learning_phase(True)
+            logger.info(
+                f"Fitting model {model_config['module']}.{model_config['name']}..."
+            )
+            train_epochs = config["model"]["fit_kwargs"]["nb_epochs"]
+            batch_size = config["dataset"]["batch_size"]
+
+            logger.info(f"Loading train dataset {config['dataset']['name']}...")
+            train_data = load_dataset(
+                config["dataset"],
+                epochs=train_epochs,
+                split_type="train",
+                preprocessing_fn=preprocessing_fn,
+            )
+
+            if defense_type == "Trainer":
+                logger.info(f"Training with {defense_type} defense...")
+                defense = load_defense_wrapper(config["defense"], classifier)
+            else:
+                logger.info(f"Fitting classifier on clean train dataset...")
+
+            for epoch in range(train_epochs):
+                classifier.set_learning_phase(True)
+
+                for _ in tqdm(
+                    range(train_data.batches_per_epoch),
+                    desc=f"Epoch: {epoch}/{train_epochs}",
+                ):
+                    x, y = train_data.get_batch()
+                    # x_trains consists of one or more videos, each represented as an
+                    # ndarray of shape (n_stacks, 3, 16, 112, 112).
+                    # To train, randomly sample a batch of stacks
+                    x = np.stack([x_i[np.random.randint(x_i.shape[0])] for x_i in x])
+                    if defense_type == "Trainer":
+                        defense.fit(x, y, batch_size=batch_size, nb_epochs=1)
+                    else:
+                        classifier.fit(x, y, batch_size=batch_size, nb_epochs=1)
+
+        if defense_type == "Transform":
+            # NOTE: Transform currently not supported
+            logger.info(f"Transforming classifier with {defense_type} defense...")
+            defense = load_defense_wrapper(config["defense"], classifier)
+            classifier = defense()
+
+        classifier.set_learning_phase(False)
+
+        # Evaluate the ART classifier on benign test examples
+        logger.info(f"Loading test dataset {config['dataset']['name']}...")
+        test_data_generator = load_dataset(
+            config["dataset"],
+            epochs=1,
+            split_type="test",
+            preprocessing_fn=preprocessing_fn,
+        )
+
+        logger.info("Running inference on benign examples...")
+        metrics_logger = metrics.MetricsLogger.from_config(config["metric"])
+
+        for x_batch, y_batch in tqdm(test_data_generator, desc="Benign"):
+            for x, y in zip(x_batch, y_batch):
+                # combine predictions across all stacks
+                y_pred = np.mean(classifier.predict(x), axis=0)
+                metrics_logger.update_task(y, y_pred)
+        metrics_logger.log_task()
+
+        # Evaluate the ART classifier on adversarial test examples
+        logger.info("Loading / testing adversarial examples...")
+
+        if config["attack"]["preloaded"]:  # load existing adversarial dataset
+            test_data_generator = load_dataset(
+                config["attack"]["preloaded"],
+                epochs=1,
+                split_type="adversarial",
+                preprocessing_fn=preprocessing_fn,
+            )
+        else:  # generate attack using ART
+            attack = load_attack(config["attack"], classifier)
+            test_data_generator = load_dataset(
+                config["dataset"],
+                epochs=1,
+                split_type="test",
+                preprocessing_fn=preprocessing_fn,
+            )
+        for x_batch, y_batch in tqdm(test_data_generator, desc="Attack"):
+            if config["attack"]["preloaded"]:
+                attack_type = config["attack"]["preloaded"]["attack_type"]
+                x_batch = x_batch[attack_type]
+            for x, y in zip(x_batch, y_batch):
+                if config["attack"]["preloaded"]:
+                    x_adv = x
+                else:
+                    # each x is of shape (n_stack, 3, 16, 112, 112)
+                    #    n_stack varies
+                    attack.set_params(batch_size=x.shape[0])
+                    x_adv = attack.generate(x=x)
+
+                # combine predictions across all stacks
+                y_pred = np.mean(classifier.predict(x_adv), axis=0)
+                metrics_logger.update_task(y, y_pred, adversarial=True)
+                metrics_logger.update_perturbation([x], [x_adv])
+
+        metrics_logger.log_task(adversarial=True)
+        return metrics_logger.results()
+
+        # Template for calculating various distance measures
+        # TODO: add distance functions (e.g., L-p norm, SNR, Wasserstein)
+        """
+        if config["attack"]["preloaded"]:  # load existing adversarial dataset
+            test_data_generator = load_dataset(
+                config["attack"]["preloaded"],
+                epochs=1,
+                split_type="adversarial",
+                preprocessing_fn=preprocessing_fn,
+
+            for x_batch, y_batch in tqdm(test_data_generator, desc="Attack"):
+                attack_type = config["attack"]["preloaded"]["attack_type"]
+                x_adv_batch = x_batch[attack_type]
+                x_clean_batch = x_batch["clean"]
+                for x_adv, x_clean in zip(x_adv_batch, x_clean_batch):
+                    distance = distance_fn(x_adv, x_clean)
+        """

--- a/scenario_configs/ucf101_baseline_adversarial.json
+++ b/scenario_configs/ucf101_baseline_adversarial.json
@@ -10,6 +10,7 @@
         "module": "none",
         "name": "none",
         "preloaded": {
+            "description": "'attack_type' can be {'adversarial_perturbation', 'adversarial_patch'}",
             "attack_type": "adversarial_perturbation",
             "batch_size": 1,
             "module": "armory.data.datasets",

--- a/scenario_configs/ucf101_baseline_adversarial.json
+++ b/scenario_configs/ucf101_baseline_adversarial.json
@@ -10,9 +10,9 @@
         "module": "none",
         "name": "none",
         "preloaded": {
-            "description": "'attack_type' can be {'adversarial_perturbation', 'adversarial_patch'}",
             "attack_type": "adversarial_perturbation",
             "batch_size": 1,
+            "description": "'attack_type' can be {'adversarial_perturbation', 'adversarial_patch'}",
             "module": "armory.data.datasets",
             "name": "ucf101_adversarial_112x112"
         }

--- a/scenario_configs/ucf101_baseline_adversarial.json
+++ b/scenario_configs/ucf101_baseline_adversarial.json
@@ -1,0 +1,59 @@
+{
+    "_description": "UCF101 video classification from pretrained, contributed by MITRE Corporation",
+    "adhoc": null,
+    "attack": {
+        "budget": null,
+        "knowledge": "white",
+        "kwargs": {
+            "eps": 0.0
+        },
+        "module": "none",
+        "name": "none",
+        "preloaded": {
+            "attack_type": "adversarial_perturbation",
+            "batch_size": 1,
+            "module": "armory.data.datasets",
+            "name": "ucf101_adversarial_112x112"
+        }
+    },
+    "dataset": {
+        "batch_size": 16,
+        "framework": "numpy",
+        "module": "armory.data.datasets",
+        "name": "ucf101"
+    },
+    "defense": null,
+    "metric": {
+        "means": true,
+        "perturbation": "linf",
+        "record_metric_per_sample": false,
+        "task": [
+            "categorical_accuracy",
+            "top_5_categorical_accuracy"
+        ]
+    },
+    "model": {
+        "fit": false,
+        "fit_kwargs": {
+            "nb_epochs": 10
+        },
+        "model_kwargs": {
+            "model_status": "ucf101_trained"
+        },
+        "module": "armory.baseline_models.pytorch.ucf101_mars",
+        "name": "get_art_model",
+        "weights_file": "mars_ucf101_v1.pth",
+        "wrapper_kwargs": {}
+    },
+    "scenario": {
+        "kwargs": {},
+        "module": "armory.scenarios.video_ucf101_scenario_adversarial_preloaded",
+        "name": "Ucf101"
+    },
+    "sysconfig": {
+        "docker_image": "twosixarmory/pytorch:0.7.0-dev",
+        "external_github_repo": "yusong-tan/MARS",
+        "gpus": "all",
+        "use_gpu": true
+    }
+}


### PR DESCRIPTION
Replaces a previous PR.

- Added an adversarial databuilder for UCF101 (data/adversarial/ucf101_mars_perturbation_and_patch_adversarial_112x112.py), where the a dict of features are used to pair clean examples with adversarial examples

- Minimally modified datasets.py to accommodate the adversarial dataset.

- Added a config (scenario_configs/ucf101_baseline_adversarial.json) showing one way of integrating the adversarial dataset under the "attack" module. Currently, the batch size for adversarial dataset must be 1. May require more modification to datasets.py for batch size > 1, but the effort may not be worth it if batch size = 1 could be enforced.

- Added a scenario file (scenarios/video_ucf101_scenario_adversarial_preloaded.py) showing an example of how to call preloaded adversarial dataset, run inference on it, and calculate distance measures between clean and adversarial examples.