### PR TITLE
Remove unnecessary tmp dir creation

### DIFF
--- a/armory/eval/evaluator.py
+++ b/armory/eval/evaluator.py
@@ -138,10 +138,7 @@ class Evaluator(object):
             }
         )
 
-    def _write_tmp(self):
-        os.makedirs(self.tmp_dir, exist_ok=True)
-        if os.path.exists(self.tmp_config):
-            logger.warning(f"Overwriting previous temp config: {self.tmp_config}...")
+    def _copy_config_file(self):
         with open(self.tmp_config, "w") as f:
             f.write(json.dumps(self.config, sort_keys=True, indent=4) + "\n")
 
@@ -171,7 +168,7 @@ class Evaluator(object):
     def run(
         self, interactive=False, jupyter=False, host_port=8888, command=None
     ) -> None:
-        self._write_tmp()
+        self._copy_config_file()
         if self.no_docker:
             if jupyter or interactive or command:
                 raise ValueError(


### PR DESCRIPTION
The temp directories are created through armory.paths()