### PR TITLE
Refactor path referencing

### DIFF
--- a/armory/baseline_models/keras/resnet50.py
+++ b/armory/baseline_models/keras/resnet50.py
@@ -1,15 +1,13 @@
 """
 ResNet50 CNN model for 244x244x3 image classification
 """
-import os
 
 import numpy as np
 from art.classifiers import KerasClassifier
 from tensorflow.keras.applications.resnet50 import ResNet50
 from tensorflow.keras.preprocessing import image
 
-from armory import paths
-from armory.data.utils import download_file_from_s3
+from armory.data.utils import maybe_download_weights_from_s3
 
 
 IMAGENET_MEANS = [103.939, 116.779, 123.68]
@@ -40,16 +38,7 @@ def get_art_model(model_kwargs, wrapper_kwargs, weights_file=None):
     model = ResNet50(weights=None, **model_kwargs)
 
     if weights_file:
-        saved_model_dir = paths.docker().saved_model_dir
-        filepath = os.path.join(saved_model_dir, weights_file)
-
-        if not os.path.isfile(filepath):
-            download_file_from_s3(
-                "armory-public-data",
-                f"model-weights/{weights_file}",
-                f"{saved_model_dir}/{weights_file}",
-            )
-
+        filepath = maybe_download_weights_from_s3(weights_file)
         model.load_weights(filepath)
 
     wrapped_model = KerasClassifier(

--- a/armory/configuration.py
+++ b/armory/configuration.py
@@ -1,0 +1,60 @@
+"""
+Utilities for handling the global armory configuration file
+"""
+import logging
+import json
+import os
+
+logger = logging.getLogger(__name__)
+
+
+# TODO: Validate with JSON schema
+def validate_config(config: dict) -> None:
+    if not isinstance(config, dict):
+        raise TypeError(f"config is a {type(config)}, not a dict")
+    keys = ("dataset_dir", "saved_model_dir", "output_dir", "tmp_dir", "verify_ssl")
+    for key in keys:
+        if key not in config:
+            raise KeyError(
+                f"config is missing key {key}. config may be out of date. Please run 'armory configure'"
+            )
+    for key, value in config.items():
+        if key not in keys:
+            raise KeyError(f"config has additional key {key}")
+
+        if key in ("verify_ssl") and not isinstance(value, bool):
+            raise ValueError(f"{key} value {value} is not a bool")
+
+        if key not in ("verify_ssl") and not isinstance(value, str):
+            raise ValueError(f"{key} value {value} is not a string")
+
+
+def load_global_config(config_path: str) -> dict:
+    try:
+        with open(config_path) as f:
+            config = json.load(f)
+    except json.decoder.JSONDecodeError:
+        logger.exception(f"Armory config file {config_path} could not be decoded")
+        raise
+    except OSError:
+        logger.exception(f"Armory config file {config_path} could not be read")
+        raise
+
+    try:
+        validate_config(config)
+    except (TypeError, KeyError, ValueError):
+        logger.error(
+            "Error parsing config.json. Please run `armory configure`.\n"
+            "    If you previously ran an older version of armory, you may\n"
+            f"    need to remove the {os.path.dirname(config_path)} directory due to changes"
+        )
+        raise
+
+    return config
+
+
+def save_config(config: dict, output_dir: str) -> None:
+    validate_config(config)
+    os.makedirs(output_dir, exist_ok=True)
+    with open(os.path.join(output_dir, "config.json"), "w") as f:
+        f.write(json.dumps(config, sort_keys=True, indent=4) + "\n")

--- a/armory/data/datasets.py
+++ b/armory/data/datasets.py
@@ -140,7 +140,7 @@ def _generator_from_tfds(
         )
 
     if not dataset_dir:
-        dataset_dir = paths.docker().dataset_dir
+        dataset_dir = paths.runtime_paths().dataset_dir
 
     if cache_dataset:
         _cache_dataset(

--- a/armory/data/model_weights.py
+++ b/armory/data/model_weights.py
@@ -28,7 +28,7 @@ def _download_weights(weights_file, force_download=False):
     if not weights_file:
         return
 
-    saved_model_dir = paths.docker().saved_model_dir
+    saved_model_dir = paths.runtime_paths().saved_model_dir
     filepath = os.path.join(saved_model_dir, weights_file)
 
     if not os.path.isfile(filepath) and not force_download:

--- a/armory/data/resisc45/resisc45_dataset_partition.py
+++ b/armory/data/resisc45/resisc45_dataset_partition.py
@@ -64,7 +64,7 @@ LABELS = [
 def split_data(rootdir=None, full="NWPU-RESISC45"):
     if rootdir is None:
         rootdir = os.path.join(
-            paths.host().dataset_dir, "downloads", "manual", "resisc45"
+            paths.HostPaths().dataset_dir, "downloads", "manual", "resisc45"
         )
     train = "train"
     validation = "validation"

--- a/armory/data/utils.py
+++ b/armory/data/utils.py
@@ -34,7 +34,7 @@ def maybe_download_weights_from_s3(weights_file: str) -> str:
     :param weights_file:
     :return:
     """
-    saved_model_dir = paths.docker().saved_model_dir
+    saved_model_dir = paths.runtime_paths().saved_model_dir
     filepath = os.path.join(saved_model_dir, weights_file)
 
     if os.path.isfile(filepath):

--- a/armory/docker/management.py
+++ b/armory/docker/management.py
@@ -28,8 +28,8 @@ class ArmoryInstance(object):
     ):
         self.docker_client = docker.from_env(version="auto")
 
-        host_paths = paths.host()
-        docker_paths = paths.docker()
+        host_paths = paths.HostPaths()
+        docker_paths = paths.DockerPaths()
         host_tmp_dir = host_paths.tmp_dir
         host_output_dir = host_paths.output_dir
 

--- a/armory/eval/evaluator.py
+++ b/armory/eval/evaluator.py
@@ -44,7 +44,12 @@ class Evaluator(object):
             raise ValueError(f"config_path {config_path} must be a str or dict")
 
         self.host_paths = paths.HostPaths()
-        self.armory_global_config = load_global_config(self.host_paths.armory_config)
+        if os.path.exists(self.host_paths.armory_config):
+            self.armory_global_config = load_global_config(
+                self.host_paths.armory_config
+            )
+        else:
+            self.armory_global_config = {"verify_ssl": True}
 
         eval_id = str(uuid.uuid4())
         self.config["eval_id"] = eval_id

--- a/armory/eval/evaluator.py
+++ b/armory/eval/evaluator.py
@@ -14,6 +14,7 @@ import docker
 import requests
 from docker.errors import ImageNotFound
 
+from armory.configuration import load_global_config
 from armory.docker.management import ManagementInstance
 from armory.docker.host_management import HostManagementInstance
 from armory.utils.configuration import load_config
@@ -42,12 +43,13 @@ class Evaluator(object):
         else:
             raise ValueError(f"config_path {config_path} must be a str or dict")
 
-        self.host_paths = paths.host()
+        self.host_paths = paths.HostPaths()
+        self.armory_global_config = load_global_config(self.host_paths.armory_config)
 
         eval_id = str(uuid.uuid4())
         self.config["eval_id"] = eval_id
-        self.output_dir = os.path.join(paths.host().output_dir, eval_id)
-        self.tmp_dir = os.path.join(paths.host().tmp_dir, eval_id)
+        self.output_dir = os.path.join(self.host_paths.output_dir, eval_id)
+        self.tmp_dir = os.path.join(self.host_paths.tmp_dir, eval_id)
 
         # Retrieve environment variables that should be used in evaluation
         self.extra_env_vars = dict()
@@ -59,11 +61,8 @@ class Evaluator(object):
         self.no_docker = not image_name or no_docker
 
         if self.no_docker:
-            self.docker_paths = paths.host()
             self.manager = HostManagementInstance()
             return
-
-        self.docker_paths = paths.docker()
 
         # Download docker image on host
         docker_client = docker.from_env()
@@ -92,7 +91,7 @@ class Evaluator(object):
             "ARMORY_PRIVATE_S3_KEY", default=""
         )
 
-        if not self.host_paths.verify_ssl:
+        if not self.armory_global_config["verify_ssl"]:
             self.extra_env_vars["VERIFY_SSL"] = "false"
 
         if self.config["sysconfig"].get("use_gpu", None):
@@ -205,11 +204,11 @@ class Evaluator(object):
             ),
         ]
         if self.config.get("scenario"):
-            tmp_dir = os.path.join(paths.host().tmp_dir, self.config["eval_id"])
+            tmp_dir = os.path.join(self.host_paths.tmp_dir, self.config["eval_id"])
             os.makedirs(tmp_dir)
             self.tmp_config = os.path.join(tmp_dir, "interactive-config.json")
             docker_config_path = os.path.join(
-                paths.docker().tmp_dir,
+                paths.runtime_paths().tmp_dir,
                 self.config["eval_id"],
                 "interactive-config.json",
             )

--- a/armory/paths.py
+++ b/armory/paths.py
@@ -1,134 +1,25 @@
 """
-Handles pathnames for armory
+Reference objects for armory paths
 """
 
-import functools
-import json
 import logging
 import os
 
+from armory import configuration
+
 logger = logging.getLogger(__name__)
 
-no_docker = False
-
-# Only initialize the host and docker paths once
-@functools.lru_cache(maxsize=1)
-def default():
-    return HostDefault()
+NO_DOCKER = False
 
 
-@functools.lru_cache(maxsize=1)
-def host():
-    return HostPaths()
-
-
-def docker():
-    if no_docker:
+def runtime_paths():
+    """
+    Delegates armory evaluation paths to be either Host or Docker paths.
+    """
+    if NO_DOCKER:
         return HostPaths()
     else:
         return DockerPaths()
-
-
-def validate_config(config):
-    if not isinstance(config, dict):
-        raise TypeError(f"config is a {type(config)}, not a dict")
-    keys = ("dataset_dir", "saved_model_dir", "output_dir", "tmp_dir", "verify_ssl")
-    for key in keys:
-        if key not in config:
-            raise KeyError(
-                f"config is missing key {key}. config may be out of date. Please run 'armory configure'"
-            )
-    for key, value in config.items():
-        if key not in keys:
-            raise KeyError(f"config has additional key {key}")
-
-        if key in ("verify_ssl") and not isinstance(value, bool):
-            raise ValueError(f"{key} value {value} is not a bool")
-
-        if key not in ("verify_ssl") and not isinstance(value, str):
-            raise ValueError(f"{key} value {value} is not a string")
-
-
-def save_config(config):
-    validate_config(config)
-    os.makedirs(default().armory_dir, exist_ok=True)
-    with open(default().armory_config, "w") as f:
-        f.write(json.dumps(config, sort_keys=True, indent=4) + "\n")
-
-
-def load_config():
-    path = default().armory_config
-    try:
-        with open(path) as f:
-            config = json.load(f)
-    except json.decoder.JSONDecodeError:
-        logger.exception(f"Armory config file {path} could not be decoded")
-        raise
-    except OSError:
-        logger.exception(f"Armory config file {path} could not be read")
-        raise
-
-    try:
-        validate_config(config)
-    except (TypeError, KeyError, ValueError):
-        logger.error(
-            "Error parsing config.json. Please run `armory configure`.\n"
-            "    If you previously ran an older version of armory, you may\n"
-            f"    need to remove the {default().armory_dir} directory due to changes"
-        )
-        raise
-
-    return config
-
-
-class HostPaths:
-    def __init__(self):
-        self.cwd = default().cwd
-        self.user_dir = default().user_dir
-        self.armory_dir = default().armory_dir
-        self.armory_config = default().armory_config
-        if os.path.isfile(self.armory_config):
-            # Parse paths from config
-            config = load_config()
-            for k in (
-                "dataset_dir",
-                "saved_model_dir",
-                "output_dir",
-                "tmp_dir",
-                "verify_ssl",
-            ):
-                setattr(self, k, config[k])
-            self.external_repo_dir = os.path.join(self.tmp_dir, "external")
-        else:
-            logger.warning(f"No {self.armory_config} file. Using default paths.")
-            logger.warning("Please run `armory configure`")
-            self.dataset_dir = default().dataset_dir
-            self.saved_model_dir = default().saved_model_dir
-            self.tmp_dir = default().tmp_dir
-            self.output_dir = default().output_dir
-            self.external_repo_dir = default().external_repo_dir
-            self.verify_ssl = default().verify_ssl
-
-        logger.info("Creating armory directories if they do not exist")
-        os.makedirs(self.dataset_dir, exist_ok=True)
-        os.makedirs(self.saved_model_dir, exist_ok=True)
-        os.makedirs(self.tmp_dir, exist_ok=True)
-        os.makedirs(self.output_dir, exist_ok=True)
-
-
-class HostDefault:
-    def __init__(self):
-        self.cwd = os.getcwd()
-        self.user_dir = os.path.expanduser("~")
-        self.armory_dir = os.path.join(self.user_dir, ".armory")
-        self.armory_config = os.path.join(self.armory_dir, "config.json")
-
-        self.dataset_dir = os.path.join(self.armory_dir, "datasets")
-        self.saved_model_dir = os.path.join(self.armory_dir, "saved_models")
-        self.tmp_dir = os.path.join(self.armory_dir, "tmp")
-        self.output_dir = os.path.join(self.armory_dir, "outputs")
-        self.external_repo_dir = os.path.join(self.tmp_dir, "external")
-        self.verify_ssl = True
 
 
 class DockerPaths:
@@ -140,3 +31,39 @@ class DockerPaths:
         self.tmp_dir = armory_dir + "/tmp"
         self.output_dir = armory_dir + "/outputs"
         self.external_repo_dir = self.tmp_dir + "/external"
+
+
+class HostDefaultPaths:
+    def __init__(self):
+        self.cwd = os.getcwd()
+        self.user_dir = os.path.expanduser("~")
+        self.armory_dir = os.path.join(self.user_dir, ".armory")
+        self.armory_config = os.path.join(self.armory_dir, "config.json")
+        self.dataset_dir = os.path.join(self.armory_dir, "datasets")
+        self.saved_model_dir = os.path.join(self.armory_dir, "saved_models")
+        self.tmp_dir = os.path.join(self.armory_dir, "tmp")
+        self.output_dir = os.path.join(self.armory_dir, "outputs")
+        self.external_repo_dir = os.path.join(self.tmp_dir, "external")
+
+
+class HostPaths(HostDefaultPaths):
+    def __init__(self):
+        super().__init__()
+        if os.path.isfile(self.armory_config):
+            # Parse paths from config
+            config = configuration.load_global_config(self.armory_config)
+            for k in (
+                "dataset_dir",
+                "saved_model_dir",
+                "output_dir",
+                "tmp_dir",
+            ):
+                setattr(self, k, config[k])
+        else:
+            logger.warning(f"No {self.armory_config} file. Using default paths.")
+            logger.warning("Please run `armory configure`")
+
+        os.makedirs(self.dataset_dir, exist_ok=True)
+        os.makedirs(self.saved_model_dir, exist_ok=True)
+        os.makedirs(self.tmp_dir, exist_ok=True)
+        os.makedirs(self.output_dir, exist_ok=True)

--- a/armory/scenarios/base.py
+++ b/armory/scenarios/base.py
@@ -49,13 +49,13 @@ class Scenario(abc.ABC):
         Performs scenario setup on the evaluating system.
         """
 
+        runtime_paths = paths.runtime_paths()
+
         self.scenario_output_dir = os.path.join(
-            paths.runtime_paths().output_dir, config["eval_id"]
+            runtime_paths.output_dir, config["eval_id"]
         )
 
-        self.scenario_tmp_dir = os.path.join(
-            paths.runtime_paths().tmp_dir, config["eval_id"]
-        )
+        self.scenario_tmp_dir = os.path.join(runtime_paths.tmp_dir, config["eval_id"])
         os.makedirs(self.scenario_output_dir, exist_ok=True)
         os.makedirs(self.scenario_tmp_dir, exist_ok=True)
         logger.warning(f"Outputs will be written to {self.scenario_output_dir}")

--- a/armory/scenarios/base.py
+++ b/armory/scenarios/base.py
@@ -50,10 +50,12 @@ class Scenario(abc.ABC):
         """
 
         self.scenario_output_dir = os.path.join(
-            paths.docker().output_dir, config["eval_id"]
+            paths.runtime_paths().output_dir, config["eval_id"]
         )
 
-        self.scenario_tmp_dir = os.path.join(paths.docker().tmp_dir, config["eval_id"])
+        self.scenario_tmp_dir = os.path.join(
+            paths.runtime_paths().tmp_dir, config["eval_id"]
+        )
         os.makedirs(self.scenario_output_dir, exist_ok=True)
         os.makedirs(self.scenario_tmp_dir, exist_ok=True)
         logger.warning(f"Outputs will be written to {self.scenario_output_dir}")
@@ -149,5 +151,5 @@ if __name__ == "__main__":
     )
     args = parser.parse_args()
     coloredlogs.install(level=args.log_level)
-    paths.no_docker = args.no_docker
+    paths.NO_DOCKER = args.no_docker
     run_config(args.config, args.from_file)

--- a/armory/utils/external_repo.py
+++ b/armory/utils/external_repo.py
@@ -24,7 +24,7 @@ def download_and_extract_repo(
     :param external_repo_name: String name of "organization/repo-name"
     """
     if external_repo_dir is None:
-        external_repo_dir = paths.host().external_repo_dir
+        external_repo_dir = paths.HostPaths().external_repo_dir
 
     os.makedirs(external_repo_dir, exist_ok=True)
     headers = {}

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -103,17 +103,13 @@ When using these paths in code, armory provides a programatic way to access thes
 directories.
 
 #### Utilizing the paths
-Code that runs on host (e.g debugging outside of container):
 ```
 from armory import paths
-paths.host().dataset_dir
+runtime_paths= paths.runtime_paths()
+runtime_paths.dataset_dir
+runtime_paths.saved_model_dir
 ```
 
-Code that runs in container (e.g within an evaluation):
-```
-from armory import paths
-paths.docker().dataset_dir
-```
 
 ## Using GPUs with Docker
 Armory uses the nvidia runtime to use GPUs inside of Docker containers.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,9 +10,10 @@ def ensure_armory_dirs(request):
     """
     CI doesn't mount volumes
     """
-    saved_model_dir = paths.docker().saved_model_dir
-    dataset_dir = paths.docker().dataset_dir
-    output_dir = paths.docker().output_dir
+    docker_paths = paths.DockerPaths()
+    saved_model_dir = docker_paths.saved_model_dir
+    dataset_dir = docker_paths.dataset_dir
+    output_dir = docker_paths.output_dir
 
     os.makedirs(saved_model_dir, exist_ok=True)
     os.makedirs(dataset_dir, exist_ok=True)

--- a/tests/test_docker/test_dataset.py
+++ b/tests/test_docker/test_dataset.py
@@ -10,7 +10,7 @@ import numpy as np
 from armory.data import datasets
 from armory import paths
 
-DATASET_DIR = paths.docker().dataset_dir
+DATASET_DIR = paths.DockerPaths().dataset_dir
 
 
 def test_mnist():

--- a/tests/test_docker/test_weight_download.py
+++ b/tests/test_docker/test_weight_download.py
@@ -8,7 +8,7 @@ from armory.data.utils import download_file_from_s3
 
 @pytest.mark.usefixtures("ensure_armory_dirs")
 def test_download():
-    saved_model_dir = paths.docker().saved_model_dir
+    saved_model_dir = paths.DockerPaths().saved_model_dir
 
     weights_file = "resnet50_imagenet_v1.h5"
 

--- a/tests/test_host/test_external_repo.py
+++ b/tests/test_host/test_external_repo.py
@@ -6,6 +6,8 @@ import shutil
 from armory import paths
 from armory.utils.external_repo import download_and_extract_repo
 
+HOST_PATHS = paths.HostPaths()
+
 
 def set_github_token():
     """
@@ -24,7 +26,7 @@ def set_github_token():
 def test_download():
     set_github_token()
     test_external_repo_dir = pathlib.Path(
-        paths.host().tmp_dir, "test-external-repo-subdir"
+        HOST_PATHS.tmp_dir, "test-external-repo-subdir"
     )
     repo = "twosixlabs/armory-example"
     repo_name = repo.split("/")[-1]
@@ -42,7 +44,7 @@ def test_download():
 def test_download_branch():
     set_github_token()
     test_external_repo_dir = pathlib.Path(
-        paths.host().tmp_dir, "test-external-repo-subdir"
+        HOST_PATHS.tmp_dir, "test-external-repo-subdir"
     )
     repo = "twosixlabs/armory-example@master"
     org_repo_name = repo.split("@")[0]

--- a/tests/test_pytorch/test_framework_dataset.py
+++ b/tests/test_pytorch/test_framework_dataset.py
@@ -7,7 +7,7 @@ import pytest
 from armory.data import datasets
 from armory import paths
 
-DATASET_DIR = paths.docker().dataset_dir
+DATASET_DIR = paths.DockerPaths().dataset_dir
 
 
 def test_pytorch_generator():

--- a/tests/test_pytorch/test_pytorch_models.py
+++ b/tests/test_pytorch/test_pytorch_models.py
@@ -6,7 +6,7 @@ import pytest
 from armory.data import datasets
 from armory import paths
 
-DATASET_DIR = paths.docker().dataset_dir
+DATASET_DIR = paths.DockerPaths().dataset_dir
 
 
 @pytest.mark.usefixtures("ensure_armory_dirs")

--- a/tests/test_tf1/test_framework_dataset.py
+++ b/tests/test_tf1/test_framework_dataset.py
@@ -7,7 +7,7 @@ import tensorflow as tf
 from armory.data import datasets
 from armory import paths
 
-DATASET_DIR = paths.docker().dataset_dir
+DATASET_DIR = paths.DockerPaths().dataset_dir
 
 
 def test_tf_generator():

--- a/tests/test_tf1/test_keras_models.py
+++ b/tests/test_tf1/test_keras_models.py
@@ -6,7 +6,7 @@ import pytest
 from armory.data import datasets
 from armory import paths
 
-DATASET_DIR = paths.docker().dataset_dir
+DATASET_DIR = paths.DockerPaths().dataset_dir
 
 
 @pytest.mark.usefixtures("ensure_armory_dirs")


### PR DESCRIPTION
* Moves global configuration into its own module instead of handled within path objects
* Removes verify_ssl from paths
* Creates new access point `runtime_paths` instead of overloading docker()
* Uses standard python classes / inheritance to hold the path information
* Fixes ResNet50 weights loading to utilize shared utility.