### PR TITLE
update flake8

### DIFF
--- a/armory/__init__.py
+++ b/armory/__init__.py
@@ -22,7 +22,7 @@ try:
 except ImportError as e:
     module = e.name
     print(f"ERROR: cannot import '{module}' module")
-    print(f"    Please run: $ pip install -r requirements.txt")
+    print("    Please run: $ pip install -r requirements.txt")
     raise
 
 

--- a/armory/eval/evaluator.py
+++ b/armory/eval/evaluator.py
@@ -80,7 +80,7 @@ class Evaluator(object):
             logger.info(f"Image {image_name} was not found. Downloading...")
             docker_api.pull_verbose(docker_client, image_name)
         except requests.exceptions.ConnectionError:
-            logger.error(f"Docker connection refused. Is Docker Daemon running?")
+            logger.error("Docker connection refused. Is Docker Daemon running?")
             raise
 
         self.manager = ManagementInstance(**kwargs)

--- a/armory/scenarios/audio_classification.py
+++ b/armory/scenarios/audio_classification.py
@@ -55,7 +55,7 @@ class AudioClassificationTask(Scenario):
                 defense = load_defense_wrapper(config["defense"], classifier)
                 defense.fit_generator(train_data, **fit_kwargs)
             else:
-                logger.info(f"Fitting classifier on clean train dataset...")
+                logger.info("Fitting classifier on clean train dataset...")
                 classifier.fit_generator(train_data, **fit_kwargs)
 
         if defense_type == "Transform":

--- a/armory/scenarios/image_classification.py
+++ b/armory/scenarios/image_classification.py
@@ -55,7 +55,7 @@ class ImageClassificationTask(Scenario):
                 defense = load_defense_wrapper(config["defense"], classifier)
                 defense.fit_generator(train_data, **fit_kwargs)
             else:
-                logger.info(f"Fitting classifier on clean train dataset...")
+                logger.info("Fitting classifier on clean train dataset...")
                 classifier.fit_generator(train_data, **fit_kwargs)
 
         if defense_type == "Transform":

--- a/armory/scenarios/poisoning_gtsrb_scenario.py
+++ b/armory/scenarios/poisoning_gtsrb_scenario.py
@@ -133,7 +133,7 @@ class GTSRB(Scenario):
         else:
             logger.warning("All data points filtered by defense. Skipping training")
 
-        logger.info(f"Validating on clean test data")
+        logger.info("Validating on clean test data")
         test_data = load_dataset(
             config["dataset"],
             epochs=1,
@@ -148,7 +148,7 @@ class GTSRB(Scenario):
         results = {"validation_accuracy": validation_metric.mean()}
 
         if poison_dataset_flag:
-            logger.info(f"Testing on poisoned test data")
+            logger.info("Testing on poisoned test data")
             test_data = load_dataset(
                 config["dataset"],
                 epochs=1,

--- a/armory/scenarios/video_ucf101_scenario.py
+++ b/armory/scenarios/video_ucf101_scenario.py
@@ -59,7 +59,7 @@ class Ucf101(Scenario):
                 logger.info(f"Training with {defense_type} defense...")
                 defense = load_defense_wrapper(config["defense"], classifier)
             else:
-                logger.info(f"Fitting classifier on clean train dataset...")
+                logger.info("Fitting classifier on clean train dataset...")
 
             for epoch in range(train_epochs):
                 classifier.set_learning_phase(True)

--- a/armory/utils/config_loading.py
+++ b/armory/utils/config_loading.py
@@ -74,7 +74,7 @@ def load_attack(attack_config, classifier):
 
 def load_adversarial_dataset(config, preprocessing_fn=None, **kwargs):
     if config.get("type") != "preloaded":
-        raise ValueError(f"attack type must be 'preloaded'")
+        raise ValueError(f"attack type must be 'preloaded', not {config.get('type')}")
     dataset_module = import_module(config["module"])
     dataset_fn = getattr(dataset_module, config["name"])
     dataset_kwargs = config["kwargs"]


### PR DESCRIPTION
Due to flake8 update to version 3.7.9, additional default rule F541 was added, which broke CI testing on master:
```
(armory) davidslater@aleph-5:~/git/davidslater/armory$ flake8
./armory/__init__.py:25:11: F541 f-string is missing placeholders
./armory/utils/config_loading.py:77:26: F541 f-string is missing placeholders
./armory/scenarios/video_ucf101_scenario.py:62:29: F541 f-string is missing placeholders
./armory/scenarios/image_classification.py:58:29: F541 f-string is missing placeholders
./armory/scenarios/audio_classification.py:58:29: F541 f-string is missing placeholders
./armory/scenarios/poisoning_gtsrb_scenario.py:136:21: F541 f-string is missing placeholders
./armory/scenarios/poisoning_gtsrb_scenario.py:151:25: F541 f-string is missing placeholders
./armory/eval/evaluator.py:83:26: F541 f-string is missing placeholders
```