### PR TITLE
Clean up of __main__ and interface with evaluator

### DIFF
--- a/armory/__main__.py
+++ b/armory/__main__.py
@@ -10,6 +10,7 @@ This runs an arbitrary config file. Results are output to the `outputs/` directo
 """
 
 import argparse
+import json
 import logging
 import os
 import sys
@@ -24,6 +25,9 @@ from armory.configuration import save_config
 from armory.eval import Evaluator
 from armory.docker import images
 from armory.utils import docker_api
+from armory.utils.configuration import load_config
+
+logger = logging.getLogger(__name__)
 
 
 class PortNumber(argparse.Action):
@@ -76,11 +80,10 @@ class DownloadConfig(argparse.Action):
             )
 
 
-def run(command_args, prog, description):
-    parser = argparse.ArgumentParser(prog=prog, description=description)
-    parser.add_argument(
-        "filepath", metavar="<json_config>", type=str, help="json config file"
-    )
+# Helper functions for parsers
+
+
+def _debug(parser):
     parser.add_argument(
         "-d",
         "--debug",
@@ -90,6 +93,9 @@ def run(command_args, prog, description):
         default=logging.INFO,
         help="Debug output (logging=DEBUG)",
     )
+
+
+def _interactive(parser):
     parser.add_argument(
         "-i",
         "--interactive",
@@ -99,6 +105,9 @@ def run(command_args, prog, description):
         default=False,
         help="Whether to allow interactive access to container",
     )
+
+
+def _jupyter(parser):
     parser.add_argument(
         "-j",
         "--jupyter",
@@ -108,6 +117,9 @@ def run(command_args, prog, description):
         default=False,
         help="Whether to set up Jupyter notebook from container",
     )
+
+
+def _port(parser):
     parser.add_argument(
         "-p",
         "--port",
@@ -118,6 +130,67 @@ def run(command_args, prog, description):
         default=8888,
         help="Port number {0, ..., 65535} to connect to Jupyter on",
     )
+
+
+def _use_gpu(parser):
+    parser.add_argument(
+        "--use-gpu",
+        dest="use_gpu",
+        action="store_const",
+        const=True,
+        default=False,
+        help="Whether to use GPU(s)",
+    )
+
+
+def _gpus(parser):
+    parser.add_argument(
+        "--gpus",
+        dest="gpus",
+        type=str,
+        help="Which specific GPU(s) to use, such as '3', '1,5', or 'all'",
+    )
+
+
+def _docker_image(parser):
+    parser.add_argument(
+        "docker_image",
+        metavar="<docker image>",
+        type=str,
+        help="docker image framework: 'tf1', 'tf2', or 'pytorch'",
+        action=DockerImage,
+    )
+
+
+# Config
+
+
+def _set_gpus(config, use_gpu, gpus):
+    """
+    Set gpu values from parser in config
+    """
+    if gpus:
+        if not use_gpu:
+            logger.info("--gpus field specified. Setting --use-gpu to True")
+            use_gpu = True
+        config["sysconfig"]["gpus"] = gpus
+    config["sysconfig"]["use_gpu"] = use_gpu
+
+
+# Commands
+
+
+def run(command_args, prog, description):
+    parser = argparse.ArgumentParser(prog=prog, description=description)
+    parser.add_argument(
+        "filepath", metavar="<json_config>", type=str, help="json config file"
+    )
+    _debug(parser)
+    _interactive(parser)
+    _jupyter(parser)
+    _port(parser)
+    _use_gpu(parser)
+    _gpus(parser)
     parser.add_argument(
         "--no-docker",
         dest="no_docker",
@@ -126,34 +199,20 @@ def run(command_args, prog, description):
         default=False,
         help="Whether to use Docker or a local environment with armory run",
     )
-    parser.add_argument(
-        "--use-gpu",
-        dest="use_gpu",
-        action="store_const",
-        const=True,
-        default=False,
-        help="Whether to force use of the GPU, overriding the gpu field in the config",
-    )
-    parser.add_argument(
-        "--gpus",
-        dest="gpus",
-        type=str,
-        help="Whether to force use of specific GPUs, overriding the gpus field in the config",
-    )
 
     args = parser.parse_args(command_args)
-
-    if not args.use_gpu and args.gpus:
-        print("gpus field overriden. Also overriding use_gpu")
-        args.use_gpu = True
-
     coloredlogs.install(level=args.log_level)
-    rig = Evaluator(
-        args.filepath,
-        no_docker=args.no_docker,
-        gpu_override=args.use_gpu,
-        gpus_override=args.gpus,
-    )
+
+    try:
+        config = load_config(args.filepath)
+    except json.decoder.JSONDecodeError:
+        logger.exception(f"Could not decode {args.filepath} as a json file.")
+        if not args.filepath.lower().endswith(".json"):
+            logger.warning(f"{args.filepath} is not a '*.json' file")
+        sys.exit(1)
+    _set_gpus(config, args.use_gpu, args.gpus)
+
+    rig = Evaluator(config, no_docker=args.no_docker)
     rig.run(interactive=args.interactive, jupyter=args.jupyter, host_port=args.port)
 
 
@@ -168,7 +227,7 @@ def _pull_docker_images(docker_client=None):
                 raise ValueError(
                     "For '-dev', please run 'docker/build-dev.sh' locally before running armory"
                 )
-            print(f"Image {image} was not found. Downloading...")
+            logger.info(f"Image {image} was not found. Downloading...")
             docker_api.pull_verbose(docker_client, image)
 
 
@@ -177,15 +236,7 @@ def download(command_args, prog, description):
     Script to download all datasets and model weights for offline usage.
     """
     parser = argparse.ArgumentParser(prog=prog, description=description)
-    parser.add_argument(
-        "-d",
-        "--debug",
-        dest="log_level",
-        action="store_const",
-        const=logging.DEBUG,
-        default=logging.INFO,
-        help="Debug output (logging=DEBUG)",
-    )
+    _debug(parser)
     parser.add_argument(
         metavar="<download data config file>",
         dest="download_config",
@@ -203,21 +254,16 @@ def download(command_args, prog, description):
         nargs="?",
     )
 
-    try:
-        args = parser.parse_args(command_args)
-    except SystemExit:
-        parser.print_help()
-        raise
-
+    args = parser.parse_args(command_args)
     coloredlogs.install(level=args.log_level)
-    paths.HostPaths()  # Ensures host directories have been created
 
     if not armory.is_dev():
-        print("Downloading all docker images....")
+        logger.info("Downloading all docker images....")
         _pull_docker_images()
 
-    print("Downloading requested datasets and model weights...")
+    logger.info("Downloading requested datasets and model weights...")
     config = {"sysconfig": {"docker_image": images.TF1}}
+
     rig = Evaluator(config)
     cmd = "; ".join(
         [
@@ -235,15 +281,7 @@ def download(command_args, prog, description):
 
 def clean(command_args, prog, description):
     parser = argparse.ArgumentParser(prog=prog, description=description)
-    parser.add_argument(
-        "-d",
-        "--debug",
-        dest="log_level",
-        action="store_const",
-        const=logging.DEBUG,
-        default=logging.INFO,
-        help="Debug output (logging=DEBUG)",
-    )
+    _debug(parser)
     parser.add_argument(
         "-f",
         "--force",
@@ -261,16 +299,16 @@ def clean(command_args, prog, description):
         default=True,
         help="If set, will not attempt to pull images before removing existing",
     )
-    args = parser.parse_args(command_args)
 
+    args = parser.parse_args(command_args)
     coloredlogs.install(level=args.log_level)
 
     docker_client = docker.from_env(version="auto")
     if args.download:
-        print("Pulling the latest docker images")
+        logger.info("Pulling the latest docker images")
         _pull_docker_images(docker_client)
 
-    print("Deleting old docker images")
+    logger.info("Deleting old docker images")
     tags = set()
     for image in docker_client.images.list():
         tags.update(image.tags)
@@ -278,14 +316,13 @@ def clean(command_args, prog, description):
     # If dev version, only remove old dev-tagged containers
     for tag in sorted(tags):
         if images.is_old(tag):
-            print(f"Attempting to remove tag {tag}")
+            logger.info(f"Attempting to remove tag {tag}")
             try:
                 docker_client.images.remove(tag, force=args.force)
-                print(f"* Tag {tag} removed")
+                logger.info(f"* Tag {tag} removed")
             except docker.errors.APIError as e:
                 if not args.force and "(must force)" in str(e):
-                    print(e)
-                    print(f"Cannot delete tag {tag}. Must use `--force`")
+                    logger.exception(f"Cannot delete tag {tag}. Must use `--force`")
                 else:
                     raise
 
@@ -326,15 +363,8 @@ def _get_verify_ssl():
 
 def configure(command_args, prog, description):
     parser = argparse.ArgumentParser(prog=prog, description=description)
-    parser.add_argument(
-        "-d",
-        "--debug",
-        dest="log_level",
-        action="store_const",
-        const=logging.DEBUG,
-        default=logging.INFO,
-        help="Debug output (logging=DEBUG)",
-    )
+    _debug(parser)
+
     args = parser.parse_args(command_args)
     coloredlogs.install(level=args.log_level)
 
@@ -397,78 +427,19 @@ def configure(command_args, prog, description):
 
 def launch(command_args, prog, description):
     parser = argparse.ArgumentParser(prog=prog, description=description)
-    parser.add_argument(
-        "docker_image",
-        metavar="<docker image>",
-        type=str,
-        help="docker image framework: 'tf1', 'tf2', or 'pytorch'",
-        action=DockerImage,
-    )
-    parser.add_argument(
-        "-d",
-        "--debug",
-        dest="log_level",
-        action="store_const",
-        const=logging.DEBUG,
-        default=logging.INFO,
-        help="Debug output (logging=DEBUG)",
-    )
-    parser.add_argument(
-        "-i",
-        "--interactive",
-        dest="interactive",
-        action="store_const",
-        const=True,
-        default=False,
-        help="Whether to allow interactive access to container",
-    )
-    parser.add_argument(
-        "-j",
-        "--jupyter",
-        dest="jupyter",
-        action="store_const",
-        const=True,
-        default=False,
-        help="Whether to set up Jupyter notebook from container",
-    )
-    parser.add_argument(
-        "-p",
-        "--port",
-        dest="port",
-        type=int,
-        action=PortNumber,
-        metavar="",
-        default=8888,
-        help="Port number {0, ..., 65535} to connect to Jupyter on",
-    )
-    parser.add_argument(
-        "--use-gpu",
-        dest="use_gpu",
-        action="store_const",
-        const=True,
-        default=False,
-        help="Whether to use GPU when launching",
-    )
-    parser.add_argument(
-        "--gpus",
-        dest="gpus",
-        type=str,
-        help="Whether to use specific GPUs when launching",
-    )
+    _docker_image(parser)
+    _debug(parser)
+    _interactive(parser)
+    _jupyter(parser)
+    _port(parser)
+    _use_gpu(parser)
+    _gpus(parser)
 
     args = parser.parse_args(command_args)
-
-    if not args.use_gpu and args.gpus:
-        print("gpus field overriden. Also overriding use_gpu")
-        args.use_gpu = True
-
     coloredlogs.install(level=args.log_level)
-    paths.HostPaths()  # Ensures host directories have been created
 
-    config = {"sysconfig": {"use_gpu": args.use_gpu, "docker_image": args.docker_image}}
-
-    if args.use_gpu and args.gpus:
-        config["sysconfig"]["gpus"] = args.gpus
+    config = {"sysconfig": {"docker_image": args.docker_image}}
+    _set_gpus(config, args.use_gpu, args.gpus)
 
     rig = Evaluator(config)
     rig.run(
@@ -481,35 +452,12 @@ def launch(command_args, prog, description):
 
 def exec(command_args, prog, description):
     delimiter = "--"
-    usage = "armory exec <docker image> [-d] [--use-gpu] -- <exec command>"
+    usage = f"armory exec <docker image> [-d] [--use-gpu] {delimiter} <exec command>"
     parser = argparse.ArgumentParser(prog=prog, description=description, usage=usage)
-    parser.add_argument(
-        "docker_image",
-        metavar="<docker image>",
-        type=str,
-        help="docker image framework: 'tf1', 'tf2', or 'pytorch'",
-        action=DockerImage,
-    )
-    parser.add_argument(
-        "-d",
-        "--debug",
-        dest="log_level",
-        action="store_const",
-        const=logging.DEBUG,
-        default=logging.INFO,
-        help="Debug output (logging=DEBUG)",
-    )
-    parser.add_argument(
-        "--use-gpu",
-        dest="use_gpu",
-        action="store_const",
-        const=True,
-        default=False,
-        help="Whether to use GPU with exec",
-    )
-    parser.add_argument(
-        "--gpus", dest="gpus", type=str, help="Whether to use specific GPUs with exec",
-    )
+    _docker_image(parser)
+    _debug(parser)
+    _use_gpu(parser)
+    _gpus(parser)
 
     try:
         index = command_args.index(delimiter)
@@ -519,28 +467,21 @@ def exec(command_args, prog, description):
         sys.exit(1)
     exec_args = command_args[index + 1 :]
     armory_args = command_args[:index]
-    if not exec_args:
+    if exec_args:
+        command = " ".join(exec_args)
+    else:
         print("ERROR: exec command required")
         parser.print_help()
         sys.exit(1)
+
     args = parser.parse_args(armory_args)
-
-    if not args.use_gpu and args.gpus:
-        print("gpus field overriden. Also overriding use_gpu")
-        args.use_gpu = True
-
     coloredlogs.install(level=args.log_level)
-    paths.HostPaths()  # Ensures host directories have been created
 
-    config = {
-        "sysconfig": {"use_gpu": args.use_gpu, "docker_image": args.docker_image,}
-    }
-
-    if args.use_gpu and args.gpus:
-        config["sysconfig"]["gpus"] = args.gpus
+    config = {"sysconfig": {"docker_image": args.docker_image}}
+    _set_gpus(config, args.use_gpu, args.gpus)
 
     rig = Evaluator(config)
-    rig.run(command=" ".join(exec_args))
+    rig.run(command=command)
 
 
 # command, (function, description)

--- a/armory/__main__.py
+++ b/armory/__main__.py
@@ -99,10 +99,7 @@ def _interactive(parser):
     parser.add_argument(
         "-i",
         "--interactive",
-        dest="interactive",
-        action="store_const",
-        const=True,
-        default=False,
+        action="store_true",
         help="Whether to allow interactive access to container",
     )
 
@@ -111,10 +108,7 @@ def _jupyter(parser):
     parser.add_argument(
         "-j",
         "--jupyter",
-        dest="jupyter",
-        action="store_const",
-        const=True,
-        default=False,
+        action="store_true",
         help="Whether to set up Jupyter notebook from container",
     )
 
@@ -123,7 +117,6 @@ def _port(parser):
     parser.add_argument(
         "-p",
         "--port",
-        dest="port",
         type=int,
         action=PortNumber,
         metavar="",
@@ -134,19 +127,13 @@ def _port(parser):
 
 def _use_gpu(parser):
     parser.add_argument(
-        "--use-gpu",
-        dest="use_gpu",
-        action="store_const",
-        const=True,
-        default=False,
-        help="Whether to use GPU(s)",
+        "--use-gpu", action="store_true", help="Whether to use GPU(s)",
     )
 
 
 def _gpus(parser):
     parser.add_argument(
         "--gpus",
-        dest="gpus",
         type=str,
         help="Which specific GPU(s) to use, such as '3', '1,5', or 'all'",
     )
@@ -193,10 +180,7 @@ def run(command_args, prog, description):
     _gpus(parser)
     parser.add_argument(
         "--no-docker",
-        dest="no_docker",
-        action="store_const",
-        const=True,
-        default=False,
+        action="store_true",
         help="Whether to use Docker or a local environment with armory run",
     )
 
@@ -285,18 +269,13 @@ def clean(command_args, prog, description):
     parser.add_argument(
         "-f",
         "--force",
-        dest="force",
-        action="store_const",
-        const=True,
-        default=False,
+        action="store_true",
         help="Whether to remove images of running containers",
     )
     parser.add_argument(
         "--no-download",
         dest="download",
-        action="store_const",
-        const=False,
-        default=True,
+        action="store_false",
         help="If set, will not attempt to pull images before removing existing",
     )
 

--- a/armory/configuration.py
+++ b/armory/configuration.py
@@ -1,6 +1,7 @@
 """
 Utilities for handling the global armory configuration file
 """
+
 import logging
 import json
 import os

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -114,6 +114,8 @@ runtime_paths.saved_model_dir
 ## Using GPUs with Docker
 Armory uses the nvidia runtime to use GPUs inside of Docker containers.
 
+### Config GPU usage
+
 This can be specified in JSON config files with "sysconfig" as follows:
 ```
     ...
@@ -129,6 +131,47 @@ The `gpus` flag is optional, and is ignored if `use_gpu` is false. If `use_gpu` 
     If present, the value should be a `,`-separated list of numbers specifying the GPU index in `nvidia-smi`.
     For instance, `"gpus": "2,4,7"` would enable three GPUs with indexes 2, 4, and 7.
     Setting the field to be `all` will enable use of all available gpus, i.e. `"gpus": "all"` will enable all GPUs.
+
+### Command line GPU usage
+
+When using the `armory` commands `run`, `launch`, or `exec`, you can specify or override the above
+`use_gpu` and `gpus` fields in the config with the following command line arguments:
+1) `--use_gpu`
+This will enable gpu usage (it is False by default).
+Using the `--gpus` argument will override this field and set it to True.
+
+2) `--gpus`
+This will enable the specified GPUs, similar to the docker `--gpus` argument.
+The argument of this must be one of the following:
+  a) `--gpus all` - use all GPUs
+  b) `--gpus #` - use the GPU with the specified number. Example: `--gpus 2`
+  c) `--gpus #,#,...,#` - use the GPUs from the comma-separated list. Example: `--gpus 1,3`
+If `--gpus` is not specified, it will default to the config file if present for `run`,
+and will default to `all` if not present in `run` or when using `launch` and `exec`.
+
+Examples:
+```
+armory run scenario_configs/mnist_baseline.json --use_gpus
+armory launch tf1 --gpus=1,4 --interactive
+armory exec pytorch --gpus=0 -- nvidia-smi
+```
+
+### CUDA 
+
+The TensorFlow versions we support require CUDA 10+.
+
+While PyTorch does support CUDA 9, we do not recommend using it unless strictly necessary
+due to an inability to upgrade your local server, and we do not have it baked in to our docker
+containers. To use CUDA 9 in our docker container, you will need to replace the line
+```
+ cudatoolkit=10.1 -c pytorch && \
+```
+with
+```
+ cudatoolkit=9.2 -c pytorch && \
+```
+in `docker/pytorch/Dockerfile` and build them the pytorch container locally.
+
 
 ## Docker Setup
 Depending on the evaluation, you may need to increase the default memory allocation for 

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -170,7 +170,7 @@ with
 ```
  cudatoolkit=9.2 -c pytorch && \
 ```
-in `docker/pytorch/Dockerfile` and build them the pytorch container locally.
+in `docker/pytorch/Dockerfile` and build the pytorch container locally.
 
 
 ## Docker Setup


### PR DESCRIPTION
Primary changes:
* Updated usage of `print` and `logger`, so that the former only happens either before the log hander has been installed or when directly interacting with the user (e.g., in `configure`)
* Making functions for adding parser elements - this cleans up a lot of duplicate code and shortens each of the command functions quite a bit.
* Making a cleaner abstraction between `__main__` and `Evaluator` by making the latter only take a configuration dictionary and removing a lot of the kwargs (except `no_docker`, which can later be expanded to a target, e.g. one of `docker`, `host`, `aws`).
* It also updates documentation for this and using CUDA 9.

Fixes #478 
Closes #292 

It doesn't solve #505 , but would make that transition much easier.