### PR TITLE
Example clean/adversarial label pairing for UCF101

### DIFF
--- a/armory/data/adversarial/ucf101_mars_perturbation_and_patch_adversarial_112x112.py
+++ b/armory/data/adversarial/ucf101_mars_perturbation_and_patch_adversarial_112x112.py
@@ -171,11 +171,17 @@ class Ucf101MarsPerturbationAndPatchAdversarial112x112(tfds.core.GeneratorBasedB
                             shape=(None, 112, 112, 3)
                         ),
                     },
-                    "label": tfds.features.ClassLabel(names=_LABELS),
+                    "labels": {
+                        "clean": tfds.features.ClassLabel(names=_LABELS),
+                        "adversarial_perturbation": tfds.features.ClassLabel(
+                            names=_LABELS
+                        ),
+                        "adversarial_patch": tfds.features.ClassLabel(names=_LABELS),
+                    },
                     "videoname": tfds.features.Text(),
                 }
             ),
-            supervised_keys=("videos", "label"),
+            supervised_keys=("videos", "labels"),
             homepage=_URL,
             citation=_CITATION,
         )
@@ -201,7 +207,7 @@ class Ucf101MarsPerturbationAndPatchAdversarial112x112(tfds.core.GeneratorBasedB
             os.path.join(data_dir_path, root_dir, split_dirs[0])
         )
         labels.sort()
-        for label in labels:
+        for i, label in enumerate(labels):
             videonames = tf.io.gfile.listdir(
                 os.path.join(data_dir_path, root_dir, split_dirs[0], label)
             )
@@ -249,7 +255,11 @@ class Ucf101MarsPerturbationAndPatchAdversarial112x112(tfds.core.GeneratorBasedB
                         "adversarial_perturbation": adv_pert,
                         "adversarial_patch": adv_patch,
                     },
-                    "label": label,
+                    "labels": {
+                        "clean": label,
+                        "adversarial_perturbation": label,  # untargeted, label not used
+                        "adversarial_patch": labels[(i + 1) % len(_LABELS)],  # targeted
+                    },
                     "videoname": videoname,
                 }
                 yield videoname, example

--- a/scenario_configs/ucf101_baseline_adversarial.json
+++ b/scenario_configs/ucf101_baseline_adversarial.json
@@ -5,9 +5,10 @@
         "budget": null,
         "knowledge": "white",
         "kwargs": {
+            "adversarial_goal": "targeted",
             "adversarial_key": "adversarial_patch",
             "batch_size": 1,
-            "description": "'adversarial_key' can be 'adversarial_perturbation' or 'adversarial_patch'"
+            "description": "'adversarial_key':'adversarial_goal' can be 'adversarial_perturbation':'untargeted' or 'adversarial_patch':'targeted'"
         },
         "module": "armory.data.adversarial_datasets",
         "name": "ucf101_adversarial_112x112",


### PR DESCRIPTION
- Modified UCF101 adversarial dataset to return dict for labels

- Added "adversarial_goal" key under "attack/kwargs" in the scenario config.  For "targeted" goal, the clean and adversarial labels can be used to calculate classification accuracy and targeted fooling rate.  For "untargeted" goal, the adversarial labels can be ignored. 