### PR TITLE
Use SSL verification config in external repo download

### DIFF
--- a/armory/configuration.py
+++ b/armory/configuration.py
@@ -9,6 +9,10 @@ import os
 logger = logging.getLogger(__name__)
 
 
+def get_verify_ssl():
+    return os.getenv("VERIFY_SSL") == "true" or os.getenv("VERIFY_SSL") is None
+
+
 # TODO: Validate with JSON schema
 def validate_config(config: dict) -> None:
     if not isinstance(config, dict):

--- a/armory/data/utils.py
+++ b/armory/data/utils.py
@@ -20,12 +20,9 @@ from tqdm import tqdm
 
 from armory import paths
 from armory.data.progress_percentage import ProgressPercentage
+from armory.configuration import get_verify_ssl
 
 logger = logging.getLogger(__name__)
-
-requests.packages.urllib3.disable_warnings(
-    requests.packages.urllib3.exceptions.InsecureRequestWarning
-)
 
 
 def maybe_download_weights_from_s3(weights_file: str) -> str:
@@ -58,7 +55,7 @@ def download_file_from_s3(bucket_name: str, key: str, local_path: str) -> None:
     :param key: S3 File key name
     :param local_path: Local file path to download as
     """
-    verify_ssl = _get_verify_ssl()
+    verify_ssl = get_verify_ssl()
     if not os.path.isfile(local_path):
         client = boto3.client(
             "s3", config=Config(signature_version=UNSIGNED), verify=verify_ssl
@@ -75,12 +72,8 @@ def download_file_from_s3(bucket_name: str, key: str, local_path: str) -> None:
         logger.info(f"Reusing cached file {local_path}...")
 
 
-def _get_verify_ssl():
-    return os.getenv("VERIFY_SSL") == "true" or os.getenv("VERIFY_SSL") is None
-
-
 def download_requests(url: str, dirpath: str, filename: str):
-    verify_ssl = _get_verify_ssl()
+    verify_ssl = get_verify_ssl()
 
     filepath = os.path.join(dirpath, filename)
     chunk_size = 4096

--- a/armory/utils/external_repo.py
+++ b/armory/utils/external_repo.py
@@ -10,6 +10,7 @@ import sys
 import requests
 
 from armory import paths
+from armory.configuration import get_verify_ssl
 
 
 logger = logging.getLogger(__name__)
@@ -25,6 +26,8 @@ def download_and_extract_repo(
     Private repositories require an `ARMORY_GITHUB_TOKEN` environment variable.
     :param external_repo_name: String name of "organization/repo-name"
     """
+    verify_ssl = get_verify_ssl()
+
     if external_repo_dir is None:
         external_repo_dir = paths.HostPaths().external_repo_dir
 
@@ -45,6 +48,7 @@ def download_and_extract_repo(
         f"https://api.github.com/repos/{org_repo_name}/tarball/{branch}",
         headers=headers,
         stream=True,
+        verify=verify_ssl,
     )
 
     if response.status_code == 200:


### PR DESCRIPTION
Previously external repos were always downloaded on host so we didn't notice that we forgot to use SSL verification based on the armory config in order to download external repos.