### PR TITLE
Download no docker

### DIFF
--- a/armory/__main__.py
+++ b/armory/__main__.py
@@ -149,6 +149,14 @@ def _docker_image(parser):
     )
 
 
+def _no_docker(parser):
+    parser.add_argument(
+        "--no-docker",
+        action="store_true",
+        help="Whether to use Docker or the local host environment",
+    )
+
+
 # Config
 
 
@@ -180,11 +188,7 @@ def run(command_args, prog, description):
     _port(parser)
     _use_gpu(parser)
     _gpus(parser)
-    parser.add_argument(
-        "--no-docker",
-        action="store_true",
-        help="Whether to use Docker or a local environment with armory run",
-    )
+    _no_docker(parser)
 
     args = parser.parse_args(command_args)
     coloredlogs.install(level=args.log_level)
@@ -230,7 +234,6 @@ def download(command_args, prog, description):
         action=DownloadConfig,
         help=f"Configuration for download of data. See {DEFAULT_SCENARIO}. Note: file must be under current working directory.",
     )
-
     parser.add_argument(
         metavar="<scenario>",
         dest="scenario",
@@ -239,9 +242,19 @@ def download(command_args, prog, description):
         help="scenario for which to download data, 'list' for available scenarios, or blank to download all scenarios",
         nargs="?",
     )
+    _no_docker(parser)
 
     args = parser.parse_args(command_args)
     coloredlogs.install(level=args.log_level)
+
+    if args.no_docker:
+        logger.info("Downloading requested datasets and model weights in host mode...")
+        from armory.data import datasets
+        from armory.data import model_weights
+
+        datasets.download_all(args.download_config, args.scenario)
+        model_weights.download_all(args.download_config, args.scenario)
+        return
 
     if not armory.is_dev():
         logger.info("Downloading all docker images....")
@@ -255,7 +268,7 @@ def download(command_args, prog, description):
         [
             "import logging",
             "import coloredlogs",
-            "coloredlogs.install(logging.INFO)",
+            f"coloredlogs.install({args.log_level})",
             "from armory.data import datasets",
             "from armory.data import model_weights",
             f'datasets.download_all("{args.download_config}", "{args.scenario}")',

--- a/armory/__main__.py
+++ b/armory/__main__.py
@@ -249,6 +249,7 @@ def download(command_args, prog, description):
 
     if args.no_docker:
         logger.info("Downloading requested datasets and model weights in host mode...")
+        paths.set_mode("host")
         from armory.data import datasets
         from armory.data import model_weights
 

--- a/armory/data/model_weights.py
+++ b/armory/data/model_weights.py
@@ -31,7 +31,13 @@ def _download_weights(weights_file, force_download=False):
     saved_model_dir = paths.runtime_paths().saved_model_dir
     filepath = os.path.join(saved_model_dir, weights_file)
 
-    if not os.path.isfile(filepath) and not force_download:
+    if os.path.isfile(filepath) and not force_download:
+        logger.info(f"Model weights file {filepath} found, skipping.")
+    else:
+        if os.path.isfile(filepath):
+            logger.info("Forcing overwrite of old file.")
+            os.remove(filepath)
+
         logger.info(f"Downloading weights file {weights_file} from s3...")
 
         download_file_from_s3(

--- a/armory/paths.py
+++ b/armory/paths.py
@@ -12,6 +12,20 @@ logger = logging.getLogger(__name__)
 NO_DOCKER = False
 
 
+def set_mode(mode):
+    """
+    Set path mode to "docker" or "host"
+    """
+    MODES = ("docker", "host")
+    global NO_DOCKER
+    if mode == "docker":
+        NO_DOCKER = False
+    elif mode == "host":
+        NO_DOCKER = True
+    else:
+        raise ValueError(f"mode {mode} is not in {MODES}")
+
+
 def runtime_paths():
     """
     Delegates armory evaluation paths to be either Host or Docker paths.

--- a/armory/scenarios/base.py
+++ b/armory/scenarios/base.py
@@ -155,5 +155,6 @@ if __name__ == "__main__":
     )
     args = parser.parse_args()
     coloredlogs.install(level=args.log_level)
-    paths.NO_DOCKER = args.no_docker
+    if args.no_docker:
+        paths.set_mode("host")
     run_config(args.config, args.from_file)

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -217,6 +217,26 @@ Armory has partial support for users wishing to run without docker. Currently, t
 docker, either set the `docker_image` field to be null in the scenario
 configuration json file, or call `armory run` with the --no-docker option.
 
+Armory can also download and use datasets without docker. To use the download command,
+simply add the `--no-docker` option, which will skip downloading the images and
+run it in host mode:
+```
+armory download <path/to/scenario-set1.json> --no-docker
+```
+
+After datasets have been downloaded, they can be used outside of docker by setting
+the pathing mode to host in python:
+```python
+from armory import paths
+paths.set_mode("host")
+from armory import datasets
+ds = datasets.mnist()
+x, y = next(ds)
+```
+
+NOTE: when running Armory without docker, you will need to manually install the 
+requirements in `host-requirements.txt` that match your framework (TF1, TF2, PyTorch).
+
 ### Environment setup
 The listing of libraries needed for Armory when run on host is available at
 `host-requirements.txt`. 

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -229,14 +229,12 @@ the pathing mode to host in python:
 ```python
 from armory import paths
 paths.set_mode("host")
-from armory import datasets
+from armory.data import datasets
 ds = datasets.mnist()
 x, y = next(ds)
 ```
 
-NOTE: when running Armory without docker, you will need to manually install the 
-requirements in `host-requirements.txt` that match your framework (TF1, TF2, PyTorch).
-
 ### Environment setup
-The listing of libraries needed for Armory when run on host is available at
-`host-requirements.txt`. 
+NOTE: The listing of libraries needed for Armory when run on host is available at
+`host-requirements.txt`. You will need to manually install the requirements in
+that file that match your framework (TF1, TF2, PyTorch).


### PR DESCRIPTION
Fixes #511 
Fixes #506

Should be able to test with
```
armory download scenarios-set1.json --no-docker
```

This enables users to set the mode from paths as follows:
```
from armory import paths
paths.set_mode("host")
```
I find this preferable to directly modifying the `NO_DOCKER` flag. This way we can make additional pathing changes in the future for, say, AWS mode, in the future.