### PR TITLE
Increase default SHM size

### DIFF
--- a/armory/docker/management.py
+++ b/armory/docker/management.py
@@ -50,6 +50,7 @@ class ArmoryInstance(object):
                 host_output_dir: {"bind": docker_paths.output_dir, "mode": "rw"},
                 host_tmp_dir: {"bind": docker_paths.tmp_dir, "mode": "rw"},
             },
+            "shm_size": "16G",
         }
         if ports is not None:
             container_args["ports"] = ports


### PR DESCRIPTION
So went through a couple of iterations on deciding if we wanted to introduce docker configs to the scenario configurations. Ideally, we don't since they require special parsing from ECS task conversion. Looking into /dev/shm and the tempfs spec it doesn't appear to have negative consequences to hard code this as a higher value:
https://unix.stackexchange.com/questions/259823/if-tmpfs-has-bigger-size-than-your-ram-how-much-ram-does-it-use-are-applicatio

I tried setting this to 64GB (2x my laptops memory) and everything worked fine so shouldn't be an issue for systems < 16GB RAM. This guide also recommends increasing shm by default:
https://www.pugetsystems.com/labs/hpc/How-To-Setup-NVIDIA-Docker-and-NGC-Registry-on-your-Workstation---Part-5-Docker-Performance-and-Resource-Tuning-1119/

@adamj26 should this get merged we'll need to hardcode this into the ECS task conversion.

Closes #535