### PR TITLE
Allow separate models for training on poisoned and cleaned datasets

### DIFF
--- a/armory/scenarios/poisoning_gtsrb_scenario.py
+++ b/armory/scenarios/poisoning_gtsrb_scenario.py
@@ -122,16 +122,21 @@ class GTSRB(Scenario):
 
         if use_poison_filtering_defense:
             defense_config = config["defense"]
+
+            defense_model_config = config_adhoc.get("defense_model", model_config)
+            defense_train_epochs = config_adhoc.get(
+                "defense_train_epochs", train_epochs
+            )
+            classifier_for_defense, _ = load_model(defense_model_config)
             logger.info(
-                f"Fitting model {model_config['module']}.{model_config['name']} "
+                f"Fitting model {defense_model_config['module']}.{defense_model_config['name']} "
                 f"for defense {defense_config['name']}..."
             )
-            classifier_for_defense, _ = load_model(model_config)
             classifier_for_defense.fit(
                 x_train_all,
                 y_train_all_categorical,
                 batch_size=batch_size,
-                nb_epochs=train_epochs,
+                nb_epochs=defense_train_epochs,
                 verbose=False,
             )
             defense_fn = load_fn(defense_config)

--- a/docs/configuration_files.md
+++ b/docs/configuration_files.md
@@ -127,3 +127,17 @@ All configuration files are verified against the jsonschema definition at run ti
 
 To run with a custom Docker image, replace the `["sys_config"]["docker_image"]` field
 to your custom docker image name `<your_image/name:your_tag>`.
+
+### Additional configuration settings for poisoning scenario
+
+Some settings specific to the poisoning scenario are not applicable to the other 
+scenarios and are thus found in "ad-hoc" subfield of the configuration file.
+
+For a poison filtering defense, Armory supports using a model for filtering that 
+differs from the model used at training time. The model used at training time should 
+still be stored in the field "model" as described in the config schema. However, if a 
+different model is used for the filtering defense, it should be entered in the "ad-hoc" 
+field of the configuration file under the subfield "defense_model," with the number of
+epochs of training under the subfield "defense_model_train_epochs." A concrete example
+of a configuration with this field is available in the armory-example
+[repo](https://github.com/twosixlabs/armory-example/tree/master/example_scenario_configs).

--- a/docs/configuration_files.md
+++ b/docs/configuration_files.md
@@ -131,7 +131,7 @@ to your custom docker image name `<your_image/name:your_tag>`.
 ### Additional configuration settings for poisoning scenario
 
 Some settings specific to the poisoning scenario are not applicable to the other 
-scenarios and are thus found in "ad-hoc" subfield of the configuration file.
+scenarios and are thus found in "adhoc" subfield of the configuration file.
 
 For a poison filtering defense, Armory supports using a model for filtering that 
 differs from the model used at training time. The model used at training time should 


### PR DESCRIPTION
Closes #582, with concurrent PR 46 in armory-examples.