### PR TITLE
Initial PyTorch dataloaders from TFRecords

### DIFF
--- a/armory/data/adversarial_datasets.py
+++ b/armory/data/adversarial_datasets.py
@@ -33,11 +33,6 @@ def imagenet_adversarial(
         Attack step size = 2
         Targeted = True
     """
-    if framework == "pytorch":
-        raise NotImplementedError(
-            "PyTorch DataLoader for `imagenet_adversarial` not yet available."
-        )
-
     if clean_key != "clean":
         raise ValueError(f"{clean_key} != 'clean'")
     if adversarial_key != "adversarial":
@@ -77,11 +72,6 @@ def librispeech_adversarial(
     returns:
         Generator
     """
-    if framework == "pytorch":
-        raise NotImplementedError(
-            "PyTorch DataLoader for `librispeech_adversarial` not yet available."
-        )
-
     if clean_key != "clean":
         raise ValueError(f"{clean_key} != 'clean'")
     if adversarial_key != "adversarial":
@@ -119,11 +109,6 @@ def resisc45_adversarial_224x224(
     including clean, adversarial universal perturbation, and
     adversarial patched
     """
-    if framework == "pytorch":
-        raise NotImplementedError(
-            "PyTorch DataLoader for `resisc45_adversarial_224x224` not yet available."
-        )
-
     if clean_key != "clean":
         raise ValueError(f"{clean_key} != 'clean'")
     adversarial_keys = ("adversarial_univpatch", "adversarial_univperturbation")
@@ -164,11 +149,6 @@ def ucf101_adversarial_112x112(
 
     DataGenerator returns batches of ((x_clean, x_adversarial), y)
     """
-    if framework == "pytorch":
-        raise NotImplementedError(
-            "PyTorch DataLoader for `ucf101_adversarial_112x112` not yet available."
-        )
-
     if clean_key != "clean":
         raise ValueError(f"{clean_key} != 'clean'")
     adversarial_keys = ("adversarial_patch", "adversarial_perturbation")

--- a/armory/data/adversarial_datasets.py
+++ b/armory/data/adversarial_datasets.py
@@ -33,6 +33,11 @@ def imagenet_adversarial(
         Attack step size = 2
         Targeted = True
     """
+    if framework == "pytorch":
+        raise NotImplementedError(
+            "PyTorch DataLoader for `imagenet_adversarial` not yet available."
+        )
+
     if clean_key != "clean":
         raise ValueError(f"{clean_key} != 'clean'")
     if adversarial_key != "adversarial":
@@ -72,6 +77,11 @@ def librispeech_adversarial(
     returns:
         Generator
     """
+    if framework == "pytorch":
+        raise NotImplementedError(
+            "PyTorch DataLoader for `librispeech_adversarial` not yet available."
+        )
+
     if clean_key != "clean":
         raise ValueError(f"{clean_key} != 'clean'")
     if adversarial_key != "adversarial":
@@ -109,6 +119,11 @@ def resisc45_adversarial_224x224(
     including clean, adversarial universal perturbation, and
     adversarial patched
     """
+    if framework == "pytorch":
+        raise NotImplementedError(
+            "PyTorch DataLoader for `resisc45_adversarial_224x224` not yet available."
+        )
+
     if clean_key != "clean":
         raise ValueError(f"{clean_key} != 'clean'")
     adversarial_keys = ("adversarial_univpatch", "adversarial_univperturbation")
@@ -149,6 +164,11 @@ def ucf101_adversarial_112x112(
 
     DataGenerator returns batches of ((x_clean, x_adversarial), y)
     """
+    if framework == "pytorch":
+        raise NotImplementedError(
+            "PyTorch DataLoader for `ucf101_adversarial_112x112` not yet available."
+        )
+
     if clean_key != "clean":
         raise ValueError(f"{clean_key} != 'clean'")
     adversarial_keys = ("adversarial_patch", "adversarial_perturbation")

--- a/armory/data/datasets.py
+++ b/armory/data/datasets.py
@@ -212,9 +212,9 @@ def _generator_from_tfds(
                 f"PyTorch DataLoader for `{ds_name}` not yet available."
             )
 
-        ds = dataset_map[ds_name](ds_name, ds_version, split_type)
+        ds = dataset_map[ds_name](ds_name, ds_version, split_type, epochs)
         generator = torch.utils.data.DataLoader(
-            ds, batch_size=batch_size, num_workers=2
+            ds, batch_size=batch_size, num_workers=0
         )
     else:
         default_graph = tf.compat.v1.keras.backend.get_session().graph

--- a/armory/data/datasets.py
+++ b/armory/data/datasets.py
@@ -201,6 +201,9 @@ def _generator_from_tfds(
         )
 
     if framework == "pytorch":
+        logger.warning(
+            "PyTorch Dataset loaders are experimental!! Support for multi-worker loading is still to come."
+        )
 
         if not shuffle_files:
             raise ValueError(
@@ -599,4 +602,8 @@ def _download_data(dataset_name):
 def _get_pytorch_dataset_map():
     import armory.data.pytorch_loaders as ptl
 
-    return {"cifar10": ptl.ImageTFRecordDataSet, "mnist": ptl.ImageTFRecordDataSet}
+    return {
+        "cifar10": ptl.ImageTFRecordDataSet,
+        "mnist": ptl.ImageTFRecordDataSet,
+        "resisc45_split": ptl.ImageTFRecordDataSet,
+    }

--- a/armory/data/datasets.py
+++ b/armory/data/datasets.py
@@ -34,7 +34,6 @@ from armory.data.librispeech import librispeech_dev_clean_split  # noqa: F401
 from armory.data.resisc45 import resisc45_split  # noqa: F401
 from armory.data.german_traffic_sign import german_traffic_sign as gtsrb  # noqa: F401
 from armory.data.digit import digit as digit_tfds  # noqa: F401
-from armory.data.pytorch_loaders import ImageTFRecordDataSet
 
 
 os.environ["KMP_WARNINGS"] = "0"
@@ -208,6 +207,8 @@ def _generator_from_tfds(
         )
 
     if framework == "pytorch":
+        from armory.data.pytorch_loaders import ImageTFRecordDataSet
+
         if not shuffle_files:
             raise ValueError("PyTorch DataLoaders from Armory are shuffled by default")
         ds_name, ds_version = dataset_name.split(":")

--- a/armory/data/datasets.py
+++ b/armory/data/datasets.py
@@ -207,7 +207,7 @@ def _generator_from_tfds(
 
         if not shuffle_files:
             raise ValueError(
-                "Armory PyTorch DataLoaders use darblopy which shuffles reads from TFRecord files by default"
+                "Armory PyTorch DataLoaders use dareblopy which shuffles reads from TFRecord files by default"
             )
 
         ds_name, ds_version = dataset_name.split(":")

--- a/armory/data/datasets.py
+++ b/armory/data/datasets.py
@@ -203,7 +203,9 @@ def _generator_from_tfds(
     if framework == "pytorch":
 
         if not shuffle_files:
-            raise ValueError("PyTorch DataLoaders from Armory are shuffled by default")
+            raise ValueError(
+                "Armory PyTorch DataLoaders use darblopy which shuffles reads from TFRecord files by default"
+            )
 
         ds_name, ds_version = dataset_name.split(":")
         dataset_map = _get_pytorch_dataset_map()

--- a/armory/data/datasets.py
+++ b/armory/data/datasets.py
@@ -192,12 +192,6 @@ def _generator_from_tfds(
         output batches are 1D np.arrays of objects
     lambda_map - if not None, mapping function to apply to dataset elements
     """
-    supported_frameworks = ["tf", "pytorch", "numpy"]
-    if framework not in supported_frameworks:
-        raise ValueError(
-            f"Dataset framework field {framework} must be one of {supported_frameworks}"
-        )
-
     if not dataset_dir:
         dataset_dir = paths.runtime_paths().dataset_dir
 
@@ -276,7 +270,7 @@ def _generator_from_tfds(
 
         else:
             raise ValueError(
-                f"framework must be one of ['tf', 'pytorch', 'numpy']. Found {framework}"
+                f"`framework` must be one of ['tf', 'pytorch', 'numpy']. Found {framework}"
             )
 
     return generator
@@ -601,6 +595,6 @@ def _download_data(dataset_name):
 
 
 def _get_pytorch_dataset_map():
-    from armory.data.pytorch_loaders import ImageTFRecordDataSet
+    import armory.data.pytorch_loaders as ptl
 
-    return {"cifar10": ImageTFRecordDataSet, "mnist": ImageTFRecordDataSet}
+    return {"cifar10": ptl.ImageTFRecordDataSet, "mnist": ptl.ImageTFRecordDataSet}

--- a/armory/data/pytorch_loaders.py
+++ b/armory/data/pytorch_loaders.py
@@ -1,0 +1,50 @@
+import glob
+import os
+
+import torch
+import dareblopy as db
+from PIL import Image
+from io import BytesIO
+import numpy as np
+
+from armory import paths
+
+
+def locate_data(dataset_name, dataset_ver, split):
+    data_dir = paths.runtime_paths().dataset_dir
+    ds_dir = os.path.join(data_dir, dataset_name, dataset_ver)
+
+    return list(glob.glob(f"{ds_dir}/*{split}*.tfrecord*"))
+
+
+class ImageTFRecordDataSet(torch.utils.data.IterableDataset):
+    def __init__(self, dataset_name, dataset_ver, split):
+        self.data_files = locate_data(dataset_name, dataset_ver, split)
+        self.features = {
+            "label": db.FixedLenFeature([], db.int64),
+            "image": db.FixedLenFeature([], db.string),
+        }
+
+        # Note this is shuffled by default
+        self.loader = db.ParsedTFRecordsDatasetIterator(
+            self.data_files, self.features, batch_size=1, buffer_size=32,
+        )
+
+    @staticmethod
+    def decode_image(bytes_img):
+        return np.array(Image.open(BytesIO(bytes_img[0])))
+
+    def preprocess(self, x):
+        label, image = x
+        image = self.decode_image(image)
+
+        if image.ndim == 2:
+            image = np.expand_dims(image, axis=-1)
+
+        # TODO: permute the shape to channels first as is typical for PyTorch???
+
+        return label, image
+
+    def __iter__(self):
+        decoded_iter = map(self.preprocess, self.loader)
+        return decoded_iter

--- a/armory/data/pytorch_loaders.py
+++ b/armory/data/pytorch_loaders.py
@@ -1,6 +1,7 @@
 import glob
 import os
 from itertools import chain
+from random import randint
 
 import torch
 import dareblopy as db
@@ -47,7 +48,11 @@ class ImageTFRecordDataSet(torch.utils.data.IterableDataset):
 
             # Note this is shuffled by default
             loader = db.ParsedTFRecordsDatasetIterator(
-                self.data_files, self.features, batch_size=1, buffer_size=32,
+                self.data_files,
+                self.features,
+                batch_size=1,
+                buffer_size=32,
+                seed=randint(0, 10000),
             )
             decoded_iter = map(self.preprocess, loader)
             iters.append(decoded_iter)

--- a/docker/pytorch/Dockerfile
+++ b/docker/pytorch/Dockerfile
@@ -10,6 +10,8 @@ RUN /opt/conda/bin/conda install tensorflow==1.15.0 \
  cudatoolkit=10.1 -c pytorch && \
     /opt/conda/bin/conda clean --all
 
+RUN pip install --no-cache-dir dareblopy==0.0.3
+
 ########## PyTorch 1.4 Release #################
 
 FROM armory-pytorch-base AS armory-pytorch

--- a/tests/test_pytorch/test_framework_dataset.py
+++ b/tests/test_pytorch/test_framework_dataset.py
@@ -2,7 +2,7 @@
 Test cases for framework specific ARMORY datasets.
 """
 
-import pytest
+import torch
 
 from armory.data import datasets
 from armory import paths
@@ -10,12 +10,39 @@ from armory import paths
 DATASET_DIR = paths.DockerPaths().dataset_dir
 
 
-def test_pytorch_generator():
-    with pytest.raises(NotImplementedError):
-        _ = datasets.mnist(
-            split_type="train",
-            epochs=1,
-            batch_size=16,
-            dataset_dir=DATASET_DIR,
-            framework="pytorch",
-        )
+def test_pytorch_generator_cifar10():
+    batch_size = 16
+    dataset = datasets.cifar10(
+        split_type="train",
+        epochs=1,
+        batch_size=batch_size,
+        dataset_dir=DATASET_DIR,
+        framework="pytorch",
+    )
+
+    assert isinstance(dataset, torch.utils.data.DataLoader)
+    labels, images = next(iter(dataset))
+    assert labels.dtype == torch.int64
+    assert labels.shape == (batch_size, 1)
+
+    assert images.dtype == torch.uint8
+    assert images.shape == (batch_size, 32, 32, 3)
+
+
+def test_pytorch_generator_mnist():
+    batch_size = 16
+    dataset = datasets.mnist(
+        split_type="train",
+        epochs=1,
+        batch_size=batch_size,
+        dataset_dir=DATASET_DIR,
+        framework="pytorch",
+    )
+
+    assert isinstance(dataset, torch.utils.data.DataLoader)
+    labels, images = next(iter(dataset))
+    assert labels.dtype == torch.int64
+    assert labels.shape == (batch_size, 1)
+
+    assert images.dtype == torch.uint8
+    assert images.shape == (batch_size, 28, 28, 1)

--- a/tests/test_pytorch/test_framework_dataset.py
+++ b/tests/test_pytorch/test_framework_dataset.py
@@ -48,6 +48,25 @@ def test_pytorch_generator_mnist():
     assert images.shape == (batch_size, 28, 28, 1)
 
 
+def test_pytorch_generator_resisc():
+    batch_size = 16
+    dataset = datasets.resisc45(
+        split_type="train",
+        epochs=1,
+        batch_size=batch_size,
+        dataset_dir=DATASET_DIR,
+        framework="pytorch",
+    )
+
+    assert isinstance(dataset, torch.utils.data.DataLoader)
+    labels, images = next(iter(dataset))
+    assert labels.dtype == torch.int64
+    assert labels.shape == (batch_size, 1)
+
+    assert images.dtype == torch.uint8
+    assert images.shape == (batch_size, 256, 256, 3)
+
+
 def test_pytorch_generator_epochs():
     batch_size = 10
     dataset = datasets.mnist(

--- a/tests/test_pytorch/test_framework_dataset.py
+++ b/tests/test_pytorch/test_framework_dataset.py
@@ -46,3 +46,20 @@ def test_pytorch_generator_mnist():
 
     assert images.dtype == torch.uint8
     assert images.shape == (batch_size, 28, 28, 1)
+
+
+def test_pytorch_generator_epochs():
+    batch_size = 10
+    dataset = datasets.mnist(
+        split_type="test",
+        epochs=2,
+        batch_size=batch_size,
+        dataset_dir=DATASET_DIR,
+        framework="pytorch",
+    )
+
+    cnt = 0
+    for images, labels in dataset:
+        cnt += 1
+
+    assert cnt == 2000

--- a/tests/test_pytorch/test_framework_dataset.py
+++ b/tests/test_pytorch/test_framework_dataset.py
@@ -60,6 +60,12 @@ def test_pytorch_generator_epochs():
 
     cnt = 0
     for images, labels in dataset:
+        if cnt == 0:
+            first_batch = labels
+
+        if cnt == 1000:
+            second_batch = labels
         cnt += 1
 
     assert cnt == 2000
+    assert not torch.all(torch.eq(first_batch, second_batch))


### PR DESCRIPTION
Closes #455 

Works for cifar10 and mnist. Some design decisions we'd need to make and then we can expand this to other datasets.