### PR TITLE
Windows compatible output_dir/eval_id

### DIFF
--- a/armory/eval/evaluator.py
+++ b/armory/eval/evaluator.py
@@ -39,7 +39,7 @@ class Evaluator(object):
         else:
             self.armory_global_config = {"verify_ssl": True}
 
-        date_time = datetime.datetime.utcnow().isoformat()
+        date_time = datetime.datetime.utcnow().isoformat().replace(":", "")
         output_dir = self.config["sysconfig"].get("output_dir", None)
         eval_id = f"{output_dir}_{date_time}" if output_dir else date_time
 


### PR DESCRIPTION
Removes Windows incompatible colon from directory name. See also https://github.com/twosixlabs/armory/issues/636#issuecomment-645530025