### PR TITLE
updated docker build

### DIFF
--- a/docker/build.sh
+++ b/docker/build.sh
@@ -31,6 +31,6 @@ for framework in "tf1" "tf2" "pytorch"; do
         echo "\n\n\n"
         echo "------------------------------------------------"
         echo "Building docker image for framework: $framework"
-        docker build --cache-from davidslater/${framework}:latest,twosixarmory/armory:${version} --force-rm --file docker/${framework}/Dockerfile --build-arg armory_version=${version} --target armory-${framework} -t davidslater/${framework}:${version} .
+        docker build --cache-from twosixarmory/${framework}:latest,twosixarmory/armory:${version} --force-rm --file docker/${framework}/Dockerfile --build-arg armory_version=${version} --target armory-${framework} -t twosixarmory/${framework}:${version} .
     fi
 done

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -22,12 +22,15 @@ if [[ $version == *"-dev" ]]; then
 fi
 
 # Build images
+echo "\n\n\n"
+echo "------------------------------------------------"
 echo "Building base docker image: armory"
 docker build --cache-from twosixarmory/armory:latest --force-rm --file docker/Dockerfile --target armory -t twosixarmory/armory:${version} .
 for framework in "tf1" "tf2" "pytorch"; do
     if [[ "$1" == "$framework" || "$1" == "all" ]]; then
-        echo "Building docker images for framework: $framework"
-        docker build --cache-from twosixarmory/armory:${version} --cache-from twosixarmory/${framework}:latest --force-rm --file docker/${framework}/Dockerfile --build-arg armory_version=${version} --target armory-${framework}-base -t twosixarmory/${framework}-base:${version} .
-        docker build --cache-from twosixarmory/armory:${version} --cache-from twosixarmory/${framework}:latest --force-rm --file docker/${framework}/Dockerfile --build-arg armory_version=${version} --target armory-${framework} -t twosixarmory/${framework}:${version} .
+        echo "\n\n\n"
+        echo "------------------------------------------------"
+        echo "Building docker image for framework: $framework"
+        docker build --cache-from davidslater/${framework}:latest,twosixarmory/armory:${version} --force-rm --file docker/${framework}/Dockerfile --build-arg armory_version=${version} --target armory-${framework} -t davidslater/${framework}:${version} .
     fi
 done


### PR DESCRIPTION
Fixes #630 

This does two things:
1) Removes the direct build of the intermediate images `<framework>-base`, which were not used. (This caused additional computational due to improper caching.)
2) Reorders the cache arguments. (Framework-specific first, armory second). This should solve the rebuilding issue we were seeing before, since what happened (apparently) was that it would use armory as the cache and not use the framework-specific cache. Now, if all of the lines in the cache match, it will take the longer (framework-specific) one.

The most relevant thread I found was this comment: https://github.com/moby/moby/issues/26065#issuecomment-249046559

"Specifying multiple --cache-from images is bit problematic. If both images match there is no way(without doing multiple passes) to figure out what image to use. So we pick the first one(let user control the priority) but that may not be the longest chain we could have matched in the end. If we allow matching against one image for some commands and later switch to a different image that had a longer chain we risk in leaking some information between images as we only validate history and layers for cache. Currently I left it so that if we get a match we only use this target image for rest of the commands."
