### PR TITLE
Update config for Librispeech preloaded attack

### DIFF
--- a/scenario_configs/librispeech_baseline_sincnet_adversarial.json
+++ b/scenario_configs/librispeech_baseline_sincnet_adversarial.json
@@ -4,9 +4,9 @@
     "attack": {
         "knowledge": "white",
         "kwargs": {
-            "adversarial_key": "adversarial",
+            "adversarial_key": "adversarial_perturbation",
             "batch_size": 16,
-            "description": "'adversarial_key' must be 'adversarial'"
+            "description": "'adversarial_key' must be 'adversarial_perturbation' or 'adversarial_univperturbation'"
         },
         "module": "armory.data.adversarial_datasets",
         "name": "librispeech_adversarial",


### PR DESCRIPTION
Update config for Librispeech preloaded attack to use "adversarial_perturbation" rather than "adversarial" as adversarial_key -- required for config to work after (#635).