### PR TITLE
maybe download weights from s3

### DIFF
--- a/armory/utils/config_loading.py
+++ b/armory/utils/config_loading.py
@@ -78,7 +78,6 @@ def load_model(model_config):
     model = model_fn(
         model_config["model_kwargs"], model_config["wrapper_kwargs"], weights_file
     )
-
     if not isinstance(model, Classifier):
         raise TypeError(f"{model} is not an instance of {Classifier}")
     if not weights_file and not model_config["fit"]:


### PR DESCRIPTION
This is done in model_loading, but should be backwards compatible (as long as their weights are used and in the saved_model_dir) since I do not update to pass in paths.

Fixes #646 