### PR TITLE
mongodb instructions updated

### DIFF
--- a/armory/scenarios/base.py
+++ b/armory/scenarios/base.py
@@ -24,6 +24,7 @@ from typing import Optional
 import coloredlogs
 import pymongo
 import pymongo.errors
+import re
 
 import armory
 from armory import paths
@@ -119,12 +120,11 @@ class Scenario(abc.ABC):
         """
         Send results to a Mongo database at mongo_host
         """
-        client = pymongo.MongoClient(mongo_host, MONGO_PORT)
+        client=pymongo.MongoClient(mongo_host,MONGO_PORT)
         db = client[MONGO_DATABASE]
         col = db[MONGO_COLLECTION]
-        logger.info(
-            f"Sending evaluation results to MongoDB instance {mongo_host}:{MONGO_PORT}"
-        )
+        mongo_ip=re.findall(r"@([^@]*$)", mongo_host)[0]
+        logger.info(f"Sending evaluation results to MongoDB instance {mongo_ip}:{MONGO_PORT}")
         try:
             col.insert_one(output)
         except pymongo.errors.PyMongoError as e:
@@ -208,7 +208,7 @@ if __name__ == "__main__":
         "--mongo",
         dest="mongo_host",
         default=None,
-        help="Send scenario results to a MongoDB instance at the given host (eg 'localhost', '1.2.3.4', 'mongodb://USER:PASS@5.6.7.8')",
+        help="Send scenario results to a MongoDB instance at the given host (eg mongodb://USER:PASS@5.6.7.8')",
     )
     parser.add_argument(
         "--check",

--- a/armory/scenarios/base.py
+++ b/armory/scenarios/base.py
@@ -124,7 +124,9 @@ class Scenario(abc.ABC):
         db = client[MONGO_DATABASE]
         col = db[MONGO_COLLECTION]
         mongo_ip = re.findall(r"@([^@]*$)", mongo_host)[0]
-        logger.info(f"Sending evaluation results to MongoDB instance {mongo_ip}:{MONGO_PORT}")
+        logger.info(
+            f"Sending evaluation results to MongoDB instance {mongo_ip}:{MONGO_PORT}"
+        )
         try:
             col.insert_one(output)
         except pymongo.errors.PyMongoError as e:

--- a/armory/scenarios/base.py
+++ b/armory/scenarios/base.py
@@ -123,6 +123,7 @@ class Scenario(abc.ABC):
         client = pymongo.MongoClient(mongo_host, MONGO_PORT)
         db = client[MONGO_DATABASE]
         col = db[MONGO_COLLECTION]
+        # strip user/pass off of mongodb url for logging
         tail_of_host = re.findall(r"@([^@]*$)", mongo_host)
         if len(tail_of_host) > 0:
             mongo_ip = tail_of_host[0]

--- a/armory/scenarios/base.py
+++ b/armory/scenarios/base.py
@@ -123,7 +123,11 @@ class Scenario(abc.ABC):
         client = pymongo.MongoClient(mongo_host, MONGO_PORT)
         db = client[MONGO_DATABASE]
         col = db[MONGO_COLLECTION]
-        mongo_ip = re.findall(r"@([^@]*$)", mongo_host)[0]
+        tail_of_host = re.findall(r"@([^@]*$)", mongo_host)
+        if len(tail_of_host) > 0:
+            mongo_ip = tail_of_host[0]
+        else:
+            mongo_ip = mongo_host
         logger.info(
             f"Sending evaluation results to MongoDB instance {mongo_ip}:{MONGO_PORT}"
         )

--- a/armory/scenarios/base.py
+++ b/armory/scenarios/base.py
@@ -120,7 +120,7 @@ class Scenario(abc.ABC):
         """
         Send results to a Mongo database at mongo_host
         """
-        client = pymongo.MongoClient(mongo_host,MONGO_PORT)
+        client = pymongo.MongoClient(mongo_host, MONGO_PORT)
         db = client[MONGO_DATABASE]
         col = db[MONGO_COLLECTION]
         mongo_ip = re.findall(r"@([^@]*$)", mongo_host)[0]

--- a/armory/scenarios/base.py
+++ b/armory/scenarios/base.py
@@ -120,10 +120,10 @@ class Scenario(abc.ABC):
         """
         Send results to a Mongo database at mongo_host
         """
-        client=pymongo.MongoClient(mongo_host,MONGO_PORT)
+        client = pymongo.MongoClient(mongo_host,MONGO_PORT)
         db = client[MONGO_DATABASE]
         col = db[MONGO_COLLECTION]
-        mongo_ip=re.findall(r"@([^@]*$)", mongo_host)[0]
+        mongo_ip = re.findall(r"@([^@]*$)", mongo_host)[0]
         logger.info(f"Sending evaluation results to MongoDB instance {mongo_ip}:{MONGO_PORT}")
         try:
             col.insert_one(output)


### PR DESCRIPTION
The old MongoDB instructions work for the username / password authentication, provided those are passed with the mongodb url. The instructions are updated, and a regex is included in _save_to_mongo that will strip the username /password from the mongodb host name in the logs. 