### PR TITLE
Docker root and command line docs

### DIFF
--- a/armory/__main__.py
+++ b/armory/__main__.py
@@ -161,6 +161,12 @@ def _no_docker(parser):
     )
 
 
+def _root(parser):
+    parser.add_argument(
+        "--root", action="store_true", help="Whether to run docker as root",
+    )
+
+
 # Config
 
 
@@ -200,6 +206,7 @@ def run(command_args, prog, description):
     _use_gpu(parser)
     _gpus(parser)
     _no_docker(parser)
+    _root(parser)
     parser.add_argument(
         "--output-dir", type=str, help="Override of default output directory prefix",
     )
@@ -237,7 +244,7 @@ def run(command_args, prog, description):
     _set_gpus(config, args.use_gpu, args.gpus)
     _set_outputs(config, args.output_dir, args.output_filename)
 
-    rig = Evaluator(config, no_docker=args.no_docker)
+    rig = Evaluator(config, no_docker=args.no_docker, root=args.root)
     rig.run(
         interactive=args.interactive,
         jupyter=args.jupyter,
@@ -472,6 +479,7 @@ def launch(command_args, prog, description):
     _port(parser)
     _use_gpu(parser)
     _gpus(parser)
+    _root(parser)
 
     args = parser.parse_args(command_args)
     coloredlogs.install(level=args.log_level)
@@ -479,7 +487,7 @@ def launch(command_args, prog, description):
     config = {"sysconfig": {"docker_image": args.docker_image}}
     _set_gpus(config, args.use_gpu, args.gpus)
 
-    rig = Evaluator(config)
+    rig = Evaluator(config, root=args.root)
     rig.run(
         interactive=args.interactive,
         jupyter=args.jupyter,
@@ -496,6 +504,7 @@ def exec(command_args, prog, description):
     _debug(parser)
     _use_gpu(parser)
     _gpus(parser)
+    _root(parser)
 
     try:
         index = command_args.index(delimiter)
@@ -518,7 +527,7 @@ def exec(command_args, prog, description):
     config = {"sysconfig": {"docker_image": args.docker_image}}
     _set_gpus(config, args.use_gpu, args.gpus)
 
-    rig = Evaluator(config)
+    rig = Evaluator(config, root=args.root)
     rig.run(command=command)
 
 

--- a/armory/docker/management.py
+++ b/armory/docker/management.py
@@ -3,7 +3,6 @@ Docker orchestration managers for ARMORY.
 """
 
 import logging
-import os
 
 import docker
 
@@ -25,13 +24,12 @@ class ArmoryInstance(object):
         envs: dict = None,
         ports: dict = None,
         command: str = "tail -f /dev/null",
+        user: str = "",
     ):
         self.docker_client = docker.from_env(version="auto")
 
         host_paths = paths.HostPaths()
         docker_paths = paths.DockerPaths()
-        host_tmp_dir = host_paths.tmp_dir
-        host_output_dir = host_paths.output_dir
 
         container_args = {
             "runtime": runtime,
@@ -47,30 +45,24 @@ class ArmoryInstance(object):
                     "bind": docker_paths.local_git_dir,
                     "mode": "rw",
                 },
+                host_paths.output_dir: {"bind": docker_paths.output_dir, "mode": "rw"},
                 host_paths.saved_model_dir: {
                     "bind": docker_paths.saved_model_dir,
                     "mode": "rw",
                 },
-                host_output_dir: {"bind": docker_paths.output_dir, "mode": "rw"},
-                host_tmp_dir: {"bind": docker_paths.tmp_dir, "mode": "rw"},
+                host_paths.tmp_dir: {"bind": docker_paths.tmp_dir, "mode": "rw"},
             },
             "shm_size": "16G",
         }
+
         if ports is not None:
             container_args["ports"] = ports
         if command is not None:
             container_args["command"] = command
-
-        # Windows docker does not require syncronizing file and
-        # directoriy permissions via uid and gid.
-        if os.name != "nt":
-            user_id = os.getuid()
-            group_id = os.getgid()
-            container_args["user"] = f"{user_id}:{group_id}"
-
+        if user:
+            container_args["user"] = user
         if envs:
             container_args["environment"] = envs
-
         self.docker_container = self.docker_client.containers.run(
             image_name, **container_args
         )
@@ -79,7 +71,7 @@ class ArmoryInstance(object):
 
     def exec_cmd(self, cmd: str, user=""):
         log = self.docker_container.exec_run(
-            cmd, stdout=True, stderr=True, stream=True, user=user
+            cmd, stdout=True, stderr=True, stream=True, user=user,
         )
 
         for out in log.output:
@@ -102,10 +94,10 @@ class ManagementInstance(object):
         self.name = image_name
 
     def start_armory_instance(
-        self, envs: dict = None, ports: dict = None
+        self, envs: dict = None, ports: dict = None, root: bool = False,
     ) -> ArmoryInstance:
         temp_inst = ArmoryInstance(
-            self.name, runtime=self.runtime, envs=envs, ports=ports,
+            self.name, runtime=self.runtime, envs=envs, ports=ports, root=root,
         )
         self.instances[temp_inst.docker_container.short_id] = temp_inst
         return temp_inst

--- a/armory/docker/management.py
+++ b/armory/docker/management.py
@@ -94,10 +94,10 @@ class ManagementInstance(object):
         self.name = image_name
 
     def start_armory_instance(
-        self, envs: dict = None, ports: dict = None, root: bool = False,
+        self, envs: dict = None, ports: dict = None, user: str = "",
     ) -> ArmoryInstance:
         temp_inst = ArmoryInstance(
-            self.name, runtime=self.runtime, envs=envs, ports=ports, root=root,
+            self.name, runtime=self.runtime, envs=envs, ports=ports, user=user,
         )
         self.instances[temp_inst.docker_container.short_id] = temp_inst
         return temp_inst

--- a/armory/eval/evaluator.py
+++ b/armory/eval/evaluator.py
@@ -225,6 +225,9 @@ class Evaluator(object):
         options = ""
         if self.no_docker:
             options += " --no-docker"
+            kwargs = {}
+        else:
+            kwargs = {"user": self.get_id()}
         if check_run:
             options += " --check"
         if logger.level == logging.DEBUG:
@@ -233,7 +236,7 @@ class Evaluator(object):
             options += f" --num-eval-batches {num_eval_batches}"
 
         runner.exec_cmd(
-            f"python -m armory.scenarios.base {b64_config}{options}", user=self.get_id()
+            f"python -m armory.scenarios.base {b64_config}{options}", **kwargs
         )
 
     def _run_command(self, runner: ArmoryInstance, command: str) -> None:

--- a/armory/eval/evaluator.py
+++ b/armory/eval/evaluator.py
@@ -146,9 +146,7 @@ class Evaluator(object):
                 raise ValueError(
                     "jupyter, interactive, or bash commands only supported when running Docker containers."
                 )
-            runner = self.manager.start_armory_instance(
-                envs=self.extra_env_vars, user=self.get_id(),
-            )
+            runner = self.manager.start_armory_instance(envs=self.extra_env_vars,)
             try:
                 self._run_config(
                     runner, check_run=check_run, num_eval_batches=num_eval_batches

--- a/armory/eval/evaluator.py
+++ b/armory/eval/evaluator.py
@@ -25,7 +25,7 @@ logger = logging.getLogger(__name__)
 
 class Evaluator(object):
     def __init__(
-        self, config: dict, no_docker: bool = False,
+        self, config: dict, no_docker: bool = False, root: bool = False,
     ):
         if not isinstance(config, dict):
             raise ValueError(f"config {config} must be a dict")
@@ -54,12 +54,15 @@ class Evaluator(object):
         image_name = self.config["sysconfig"].get("docker_image")
         kwargs["image_name"] = image_name
         self.no_docker = not image_name or no_docker
+        self.root = root
 
         # Retrieve environment variables that should be used in evaluation
         self.extra_env_vars = dict()
         self._gather_env_variables()
 
         if self.no_docker:
+            if self.root:
+                raise ValueError("running with --root is incompatible with --no-docker")
             self.manager = HostManagementInstance()
             return
 
@@ -143,7 +146,9 @@ class Evaluator(object):
                 raise ValueError(
                     "jupyter, interactive, or bash commands only supported when running Docker containers."
                 )
-            runner = self.manager.start_armory_instance(envs=self.extra_env_vars)
+            runner = self.manager.start_armory_instance(
+                envs=self.extra_env_vars, root=self.root
+            )
             try:
                 self._run_config(
                     runner, check_run=check_run, num_eval_batches=num_eval_batches
@@ -171,7 +176,7 @@ class Evaluator(object):
 
         try:
             runner = self.manager.start_armory_instance(
-                envs=self.extra_env_vars, ports=ports
+                envs=self.extra_env_vars, ports=ports, root=self.root,
             )
             try:
                 if jupyter:
@@ -229,15 +234,30 @@ class Evaluator(object):
         if num_eval_batches:
             options += f" --num-eval-batches {num_eval_batches}"
 
-        runner.exec_cmd(f"python -m armory.scenarios.base {b64_config}{options}")
+        runner.exec_cmd(
+            f"python -m armory.scenarios.base {b64_config}{options}", user=self.get_id()
+        )
 
     def _run_command(self, runner: ArmoryInstance, command: str) -> None:
         logger.info(bold(red(f"Running bash command: {command}")))
-        runner.exec_cmd(command)
+        runner.exec_cmd(command, user=self.get_id())
+
+    def get_id(self):
+        """
+        Return uid, gid
+        """
+        # Windows docker does not require synchronizing file and
+        # directoriy permissions via uid and gid.
+        if os.name == "nt" or self.root:
+            user_id = 0
+            group_id = 0
+        else:
+            user_id = os.getuid()
+            group_id = os.getgid()
+        return f"{user_id}:{group_id}"
 
     def _run_interactive_bash(self, runner: ArmoryInstance) -> None:
-        user_id = os.getuid() if os.name != "nt" else 0
-        group_id = os.getgid() if os.name != "nt" else 0
+        user_group_id = self.get_id()
         lines = [
             "Container ready for interactive use.",
             bold(
@@ -245,7 +265,7 @@ class Evaluator(object):
             ),
             bold(
                 red(
-                    f"    docker exec -it -u {user_id}:{group_id} {runner.docker_container.short_id} bash"
+                    f"    docker exec -it -u {user_group_id} {runner.docker_container.short_id} bash"
                 )
             ),
         ]
@@ -278,20 +298,20 @@ class Evaluator(object):
             time.sleep(1)
 
     def _run_jupyter(self, runner: ArmoryInstance, ports: dict) -> None:
-        user_id = os.getuid() if os.name != "nt" else 0
-        group_id = os.getgid() if os.name != "nt" else 0
+        user_group_id = self.get_id()
         port = list(ports.keys())[0]
         lines = [
             "About to launch jupyter.",
             bold("*** To connect on the command line as well, in a new terminal, run:"),
             bold(
-                f"    docker exec -it -u {user_id}:{group_id} {runner.docker_container.short_id} bash"
+                f"    docker exec -it -u {user_group_id} {runner.docker_container.short_id} bash"
             ),
             bold("*** To gracefully shut down container, press: Ctrl-C"),
             "",
             "Jupyter notebook log:",
         ]
         logger.info("\n".join(lines))
+        # TODO: fix jupyter launch to run in non-root mode
         runner.exec_cmd(
             f"jupyter lab --ip=0.0.0.0 --port {port} --no-browser --allow-root",
             user="root",

--- a/docs/command_line.md
+++ b/docs/command_line.md
@@ -1,0 +1,73 @@
+# Command Line Usage
+
+## Root
+* `armory <command> --root [...]`
+Applies to `run`, `launch`, and `exec` commands.
+
+This will run the docker container as root instead of the host user.
+NOTE: this is incompatible with `--no-docker` mode.
+NOTE: `--jupyter` only runs as root currently, and will ignore this argument.
+
+### Example Usage
+
+To run a single scenario as root:
+```
+armory run official_scenario_configs/cifar10_baseline.json --root
+```
+
+To execute the `id` command in the container:
+```
+$ python -m armory exec pytorch --root -- id
+2020-07-15 15:02:20 aleph-5.local armory.docker.management[35987] INFO ARMORY Instance c1045b0ed3 created.
+2020-07-15 15:02:20 aleph-5.local armory.eval.evaluator[35987] INFO Running bash command: id
+uid=0(root) gid=0(root) groups=0(root)
+...
+```
+
+## GPUs
+* `armory <command> --gpus=X [...]`
+* `armory <command> --use-gpu [...]`
+Applies to `run`, `launch`, and `exec` commands.
+
+This will specify whether to run GPUs and which ones to run.
+If the `--gpus` flag is used, it will set `--use-gpu` to True.
+The argument `X` for `--gpus` can be a single number, "all",
+or a comma-separated list of numbers without spaces for multiple GPUs.
+
+The `--use-gpu` flag will simply enable gpus.
+If a config is being run, the gpus used will be pulled from the config.
+If a config is not being run or that field is not in the config, it will default to all.
+
+NOTE: when running a config, these will overwrite the fields inside the config.
+
+### Example Usage
+
+Examples:
+```
+armory run scenario_configs/mnist_baseline.json --use_gpus
+armory launch tf1 --gpus=1,4 --interactive
+armory exec pytorch --gpus=0 -- nvidia-smi
+```
+
+## Check Runs and Number of Examples
+* `armory run <config> --check [...]`
+* `armory run <config> --num-eval-batches=X [...]`
+Applies to `run` command.
+
+The `--check` flag will make every dataset return a single batch,
+which is useful to quickly check whether the entire scenario correctly runs.
+It will also ensure that the number of training epochs is set to 1.
+
+The `--num-eval-batches` argument will truncate the number of batches used in
+both benign and adversarial test sets.
+It is primarily designed for attack development iteration, where it is typically unhelpful
+to run more than 10-100 examples.
+
+NOTE: `--check` will take precedence over the `--num-eval-batches` argument.
+
+### Example Usage
+
+```
+armory run scenario_configs/mnist_baseline.json --check
+armory run scenario_configs/mnist_baseline.json --num-eval-batches=5
+```

--- a/docs/command_line.md
+++ b/docs/command_line.md
@@ -44,7 +44,7 @@ NOTE: when running a config, these will overwrite the fields inside the config.
 
 Examples:
 ```
-armory run scenario_configs/mnist_baseline.json --use_gpus
+armory run scenario_configs/mnist_baseline.json --use-gpu
 armory launch tf1 --gpus=1,4 --interactive
 armory exec pytorch --gpus=0 -- nvidia-smi
 ```

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -151,7 +151,7 @@ and will default to `all` if not present in `run` or when using `launch` and `ex
 
 Examples:
 ```
-armory run scenario_configs/mnist_baseline.json --use_gpus
+armory run scenario_configs/mnist_baseline.json --use-gpu
 armory launch tf1 --gpus=1,4 --interactive
 armory exec pytorch --gpus=0 -- nvidia-smi
 ```

--- a/docs/index.md
+++ b/docs/index.md
@@ -62,6 +62,8 @@ full name: `<your_image/name:your_tag>`. For use with `run`, you will need to mo
 Note: Since ARMORY launches Docker containers, the python package must be ran on 
 system host (i.e. not inside of a docker container).
 
+For more information, see [command line usage](command_line.md).
+
 ### Example usage:
 ```
 pip install armory-testbed

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -10,6 +10,7 @@ nav:
   - Docker: docker.md
   - Metrics: metrics.md
   - Scenarios: scenarios.md
+  - Command Line: command_line.md
   - External Repos: external_repos.md
   - FAQs: faqs.md
   - Contributing: contributing.md


### PR DESCRIPTION
Fixes #679 
Also enables `--root` command line arg to run the docker container as root instead of the current user, which is needed to run custom configs or containers that write to `/`.