### PR TITLE
patch attacks

### DIFF
--- a/armory/art_experimental/attacks/patch.py
+++ b/armory/art_experimental/attacks/patch.py
@@ -1,0 +1,17 @@
+"""
+Support for patch attacks using same interface.
+"""
+
+
+from art.attacks.attack import EvasionAttack
+
+
+class AttackWrapper(EvasionAttack):
+    def __init__(self, attack, apply_patch_args, apply_patch_kwargs):
+        self._attack = attack
+        self.args = apply_patch_args
+        self.kwargs = apply_patch_kwargs
+
+    def generate(self, x, y=None, **kwargs):
+        self._attack.generate(x, y=y, **kwargs)
+        return self._attack.apply_patch(x, *self.args, **self.kwargs)

--- a/armory/utils/config_loading.py
+++ b/armory/utils/config_loading.py
@@ -26,6 +26,7 @@ from art.defences.postprocessor import Postprocessor
 from art.defences.preprocessor import Preprocessor
 from art.defences.trainer import Trainer
 
+from armory.art_experimental.attacks import patch
 from armory.data.datasets import ArmoryDataGenerator, EvalGenerator
 
 
@@ -103,6 +104,14 @@ def load_model(model_config):
 
 
 def load_attack(attack_config, classifier):
+    if attack_config.get("type") == "patch":
+        original_kwargs = attack_config.pop("kwargs")
+        kwargs = original_kwargs.copy()
+        apply_patch_args = kwargs.pop("apply_patch_args", [])
+        apply_patch_kwargs = kwargs.pop("apply_patch_kwargs", {})
+        kwargs.pop("targeted")  # not explicitly used by patch attacks
+        attack_config["kwargs"] = kwargs
+
     attack_module = import_module(attack_config["module"])
     attack_fn = getattr(attack_module, attack_config["name"])
     attack = attack_fn(classifier, **attack_config["kwargs"])
@@ -111,6 +120,9 @@ def load_attack(attack_config, classifier):
             f"attack {attack} is not an instance of {Attack}."
             " Ensure that it implements ART `generate` API."
         )
+    if attack_config.get("type") == "patch":
+        attack_config["kwargs"] = original_kwargs
+        return patch.AttackWrapper(attack, apply_patch_args, apply_patch_kwargs)
     return attack
 
 

--- a/scenario_configs/resisc45_baseline_densenet121_adversarialpatch.json
+++ b/scenario_configs/resisc45_baseline_densenet121_adversarialpatch.json
@@ -1,0 +1,61 @@
+{
+    "_description": "Resisc45 image classification, contributed by MITRE Corporation",
+    "adhoc": null,
+    "attack": {
+        "knowledge": "white",
+        "kwargs": {
+            "apply_patch_args": [],
+            "apply_patch_kwargs": {
+                "scale": 0.3
+            },
+            "batch_size": 1,
+            "learning_rate": 5.0,
+            "max_iter": 3,
+            "rotation_max": 22.5,
+            "scale_max": 0.3,
+            "scale_min": 0.29999,
+            "targeted": false
+        },
+        "module": "art.attacks.evasion",
+        "name": "AdversarialPatch",
+        "type": "patch",
+        "use_label": true
+    },
+    "dataset": {
+        "batch_size": 1,
+        "framework": "numpy",
+        "module": "armory.data.datasets",
+        "name": "resisc45"
+    },
+    "defense": null,
+    "metric": {
+        "means": true,
+        "perturbation": "linf",
+        "record_metric_per_sample": false,
+        "task": [
+            "categorical_accuracy"
+        ]
+    },
+    "model": {
+        "fit": false,
+        "fit_kwargs": {},
+        "model_kwargs": {},
+        "module": "armory.baseline_models.keras.densenet121_resisc45",
+        "name": "get_art_model",
+        "weights_file": "densenet121_resisc45_v1.h5",
+        "wrapper_kwargs": {}
+    },
+    "scenario": {
+        "kwargs": {},
+        "module": "armory.scenarios.image_classification",
+        "name": "ImageClassificationTask"
+    },
+    "sysconfig": {
+        "docker_image": "twosixarmory/tf1:0.11.0-dev",
+        "external_github_repo": null,
+        "gpus": "all",
+        "output_dir": null,
+        "output_filename": null,
+        "use_gpu": false
+    }
+}


### PR DESCRIPTION
Fixes #687

This should enable adversarialpatch attack. See the added config for an example.

Ideally, it should have `"use_label": false` and `"targeted": true`, but that requires the targeted PR #690 to get merged in first. However, I would like to get a review of this soon.