### PR TITLE
Exit with a non-zero status code if the scenario in armory run errors

### DIFF
--- a/armory/__main__.py
+++ b/armory/__main__.py
@@ -252,6 +252,8 @@ def run(command_args, prog, description):
         check_run=args.check,
         num_eval_batches=args.num_eval_batches,
     )
+    if not rig.clean_exit:
+        sys.exit(1)
 
 
 def _pull_docker_images(docker_client=None):

--- a/armory/__main__.py
+++ b/armory/__main__.py
@@ -245,15 +245,14 @@ def run(command_args, prog, description):
     _set_outputs(config, args.output_dir, args.output_filename)
 
     rig = Evaluator(config, no_docker=args.no_docker, root=args.root)
-    rig.run(
+    exit_code = rig.run(
         interactive=args.interactive,
         jupyter=args.jupyter,
         host_port=args.port,
         check_run=args.check,
         num_eval_batches=args.num_eval_batches,
     )
-    if not rig.clean_exit:
-        sys.exit(1)
+    sys.exit(exit_code)
 
 
 def _pull_docker_images(docker_client=None):
@@ -326,7 +325,8 @@ def download(command_args, prog, description):
             f'model_weights.download_all("{args.download_config}", "{args.scenario}")',
         ]
     )
-    rig.run(command=f"python -c '{cmd}'")
+    exit_code = rig.run(command=f"python -c '{cmd}'")
+    sys.exit(exit_code)
 
 
 def clean(command_args, prog, description):
@@ -490,12 +490,13 @@ def launch(command_args, prog, description):
     _set_gpus(config, args.use_gpu, args.gpus)
 
     rig = Evaluator(config, root=args.root)
-    rig.run(
+    exit_code = rig.run(
         interactive=args.interactive,
         jupyter=args.jupyter,
         host_port=args.port,
         command="true # No-op",
     )
+    sys.exit(exit_code)
 
 
 def exec(command_args, prog, description):
@@ -530,7 +531,8 @@ def exec(command_args, prog, description):
     _set_gpus(config, args.use_gpu, args.gpus)
 
     rig = Evaluator(config, root=args.root)
-    rig.run(command=command)
+    exit_code = rig.run(command=command)
+    sys.exit(exit_code)
 
 
 # command, (function, description)

--- a/armory/docker/host_management.py
+++ b/armory/docker/host_management.py
@@ -10,17 +10,16 @@ class HostArmoryInstance:
         self.env = os.environ
         for k, v in envs.items():
             self.env[k] = v
-        self.clean_exit = False
 
     def exec_cmd(self, cmd: str, user=""):
         if user:
             raise ValueError("HostArmoryInstance does not support the user input")
         completion = subprocess.run(cmd, env=self.env, shell=True)
-        if not completion.returncode:
-            logger.info("Command exited cleanly")
-            self.clean_exit = True
-        else:
+        if completion.returncode:
             logger.error("Command did not finish cleanly")
+        else:
+            logger.info("Command exited cleanly")
+        return completion.returncode
 
 
 class HostManagementInstance:

--- a/armory/docker/host_management.py
+++ b/armory/docker/host_management.py
@@ -10,11 +10,17 @@ class HostArmoryInstance:
         self.env = os.environ
         for k, v in envs.items():
             self.env[k] = v
+        self.clean_exit = False
 
     def exec_cmd(self, cmd: str, user=""):
         if user:
             raise ValueError("HostArmoryInstance does not support the user input")
-        subprocess.run(cmd, env=self.env, shell=True)
+        completion = subprocess.run(cmd, env=self.env, shell=True)
+        if not completion.returncode:
+            logger.info("Command exited cleanly")
+            self.clean_exit = True
+        else:
+            logger.error("Command did not finish cleanly")
 
 
 class HostManagementInstance:

--- a/armory/docker/management.py
+++ b/armory/docker/management.py
@@ -6,7 +6,7 @@ import logging
 
 import docker
 
-from armory import paths
+from armory import paths, scenarios
 
 
 logger = logging.getLogger(__name__)
@@ -27,6 +27,7 @@ class ArmoryInstance(object):
         user: str = "",
     ):
         self.docker_client = docker.from_env(version="auto")
+        self.clean_exit = False  # did the most recent command run in the container exit cleanly?
 
         host_paths = paths.HostPaths()
         docker_paths = paths.DockerPaths()
@@ -70,12 +71,23 @@ class ArmoryInstance(object):
         logger.info(f"ARMORY Instance {self.docker_container.short_id} created.")
 
     def exec_cmd(self, cmd: str, user=""):
+        # We would like to check the return code to see if the command ran cleanly,
+        #  but `exec_run()` cannot both return the code and stream logs
+        # https://docker-py.readthedocs.io/en/stable/containers.html#docker.models.containers.Container.exec_run
         log = self.docker_container.exec_run(
             cmd, stdout=True, stderr=True, stream=True, tty=True, user=user,
         )
 
+        last_output = ""
         for out in log.output:
-            print(out.decode())
+            last_output = out.decode().rstrip()
+            print(last_output)
+
+        if last_output == scenarios.base.END_SENTINEL:
+            logger.info("Command exited cleanly")
+            self.clean_exit = True
+        else:
+            logger.error("Command did not finish cleanly")
 
     def __del__(self):
         # Needed if there is an error in __init__

--- a/armory/docker/management.py
+++ b/armory/docker/management.py
@@ -83,7 +83,7 @@ class ArmoryInstance(object):
             last_output = out.decode().rstrip()
             print(last_output)
 
-        if last_output == scenarios.base.END_SENTINEL:
+        if last_output == scenarios.END_SENTINEL:
             logger.info("Command exited cleanly")
             self.clean_exit = True
         else:

--- a/armory/docker/management.py
+++ b/armory/docker/management.py
@@ -27,7 +27,7 @@ class ArmoryInstance(object):
         user: str = "",
     ):
         self.docker_client = docker.from_env(version="auto")
-        self.clean_exit = False  # did the most recent command run in the container exit cleanly?
+        self.clean_exit = False  # did the most recent command exit cleanly?
 
         host_paths = paths.HostPaths()
         docker_paths = paths.DockerPaths()

--- a/armory/docker/management.py
+++ b/armory/docker/management.py
@@ -27,7 +27,6 @@ class ArmoryInstance(object):
         user: str = "",
     ):
         self.docker_client = docker.from_env(version="auto")
-        self.clean_exit = False  # did the most recent command exit cleanly?
 
         host_paths = paths.HostPaths()
         docker_paths = paths.DockerPaths()
@@ -85,9 +84,10 @@ class ArmoryInstance(object):
 
         if last_output == scenarios.END_SENTINEL:
             logger.info("Command exited cleanly")
-            self.clean_exit = True
+            return 0
         else:
             logger.error("Command did not finish cleanly")
+            return 1
 
     def __del__(self):
         # Needed if there is an error in __init__

--- a/armory/eval/evaluator.py
+++ b/armory/eval/evaluator.py
@@ -34,7 +34,8 @@ class Evaluator(object):
             raise ValueError(f"config {config} must be a dict")
         self.config = config
 
-        self.clean_exit = False  # did the command exit cleanly? Only used by `armory run`
+        # did the command exit cleanly? Only used by `armory run`
+        self.clean_exit = False
 
         self.host_paths = paths.HostPaths()
         if os.path.exists(self.host_paths.armory_config):

--- a/armory/eval/evaluator.py
+++ b/armory/eval/evaluator.py
@@ -34,6 +34,8 @@ class Evaluator(object):
             raise ValueError(f"config {config} must be a dict")
         self.config = config
 
+        self.clean_exit = False  # did the command exit cleanly? Only used by `armory run`
+
         self.host_paths = paths.HostPaths()
         if os.path.exists(self.host_paths.armory_config):
             self.armory_global_config = load_global_config(
@@ -244,6 +246,8 @@ class Evaluator(object):
 
         cmd = f"{python} -m armory.scenarios.base {b64_config}{options}"
         runner.exec_cmd(cmd, **kwargs)
+        if not self.no_docker:
+            self.clean_exit = runner.clean_exit
 
     def _run_command(self, runner: ArmoryInstance, command: str) -> None:
         logger.info(bold(red(f"Running bash command: {command}")))

--- a/armory/scenarios/__init__.py
+++ b/armory/scenarios/__init__.py
@@ -1,3 +1,5 @@
 """
 Evaluation scenarios for novel defenses
 """
+
+from armory.scenarios import base

--- a/armory/scenarios/__init__.py
+++ b/armory/scenarios/__init__.py
@@ -2,4 +2,4 @@
 Evaluation scenarios for novel defenses
 """
 
-from armory.scenarios import base
+from armory.scenarios.common import END_SENTINEL

--- a/armory/scenarios/base.py
+++ b/armory/scenarios/base.py
@@ -32,6 +32,7 @@ from armory import environment
 from armory.utils import config_loading
 from armory.utils import external_repo
 from armory.utils.configuration import load_config
+from armory.scenarios import END_SENTINEL
 
 
 logger = logging.getLogger(__name__)
@@ -40,8 +41,6 @@ logger = logging.getLogger(__name__)
 MONGO_PORT = 27017
 MONGO_DATABASE = "armory"
 MONGO_COLLECTION = "scenario_results"
-
-END_SENTINEL = "Scenario has finished running cleanly"
 
 
 class Scenario(abc.ABC):

--- a/armory/scenarios/base.py
+++ b/armory/scenarios/base.py
@@ -41,6 +41,8 @@ MONGO_PORT = 27017
 MONGO_DATABASE = "armory"
 MONGO_COLLECTION = "scenario_results"
 
+END_SENTINEL = "Scenario has finished running cleanly"
+
 
 class Scenario(abc.ABC):
     def __init__(self):
@@ -269,3 +271,4 @@ if __name__ == "__main__":
     run_config(
         args.config, args.from_file, args.check, args.mongo_host, args.num_eval_batches
     )
+    print(END_SENTINEL)  # indicates to host that the scenario finished w/out error

--- a/armory/scenarios/common.py
+++ b/armory/scenarios/common.py
@@ -1,0 +1,1 @@
+END_SENTINEL = "Scenario has finished running cleanly"


### PR DESCRIPTION
Modifies the base scenario to print a sentinel value before exiting cleanly. The ArmoryInstance that manages the container then checks for this value

As part of checking for the sentinel value, remove duplicate newlines from container log output

Closes #698 