### PR TITLE
Update to ART 1.4.1 branch (placeholder until release)

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -21,12 +21,13 @@ RUN /opt/conda/bin/pip install --no-cache-dir \
     tensorflow-datasets==3.2.0 \
     jupyterlab==1.2.6 \
     boto3==1.11.13 \
-    adversarial-robustness-toolbox==1.3.1 \
     Pillow==7.1.2 \
     pydub==0.24.1 \
     apache-beam==2.22.0 \
     dill==0.3.1.1 \
     pytest==5.3.5
+
+RUN /opt/conda/bin/pip install git+https://github.com/Trusted-AI/adversarial-robustness-toolbox.git@c9f3bdeb79f2fd392c449bbcf2714cf11c485610
 
 RUN /opt/conda/bin/conda install -c conda-forge ffmpeg==4.2.3 && \
     /opt/conda/bin/conda clean --all


### PR DESCRIPTION
Pins ART to 1.4.1_dev branch to resolve [import error](https://github.com/Trusted-AI/adversarial-robustness-toolbox/issues/607) when torch and kornia are not installed. Placeholder until ART 1.4.1 is released.