### PR TITLE
Update pytorch to `1.6.0` and torchvision to `0.7.0`

### DIFF
--- a/docker/pytorch/Dockerfile
+++ b/docker/pytorch/Dockerfile
@@ -5,8 +5,8 @@ FROM twosixarmory/armory:${armory_version} AS armory-pytorch-base
 
 # TF used for dataset loading
 RUN /opt/conda/bin/conda install tensorflow-gpu==2.2.0 \
- pytorch==1.5 \
- torchvision==0.6.0 \
+ pytorch==1.6 \
+ torchvision==0.7.0 \
  cudatoolkit=10.1 -c pytorch && \
     /opt/conda/bin/conda clean --all
 

--- a/host-requirements.txt
+++ b/host-requirements.txt
@@ -22,8 +22,8 @@ tensorflow-gpu==1.15.0
 ### End TF1 required libraries
 
 ### Begin Pytorch required libraries
-pytorch==1.5
-torchvision==0.6.0
+pytorch==1.6.0
+torchvision==0.7.0
 cudatoolkit==10.1
 ### End Pytorch required libraries
 


### PR DESCRIPTION
Should `cudatoolkit` be updated as well? We're pinned to `10.1`, but `11.0.221` is available on Conda

Note that this PR may cause issues when we update ART to `1.4`, if they're pinned to a different version of `pytorch`