### PR TITLE
Use maybe_download_weights_from_s3() when loading models

### DIFF
--- a/armory/baseline_models/keras/cifar.py
+++ b/armory/baseline_models/keras/cifar.py
@@ -7,8 +7,6 @@ from tensorflow.keras.models import Sequential
 from tensorflow.keras.layers import Dense, Flatten, Conv2D, MaxPooling2D
 from art.classifiers import KerasClassifier
 
-from armory.data.utils import maybe_download_weights_from_s3
-
 
 def make_cifar_model(**kwargs) -> tf.keras.Model:
     model = Sequential()
@@ -44,11 +42,10 @@ def make_cifar_model(**kwargs) -> tf.keras.Model:
     return model
 
 
-def get_art_model(model_kwargs, wrapper_kwargs, weights_file=None):
+def get_art_model(model_kwargs, wrapper_kwargs, weights_path=None):
     model = make_cifar_model(**model_kwargs)
-    if weights_file:
-        filepath = maybe_download_weights_from_s3(weights_file)
-        model.load_weights(filepath)
+    if weights_path:
+        model.load_weights(weights_path)
 
     wrapped_model = KerasClassifier(model, clip_values=(0.0, 1.0), **wrapper_kwargs)
     return wrapped_model

--- a/armory/baseline_models/keras/densenet121_resisc45.py
+++ b/armory/baseline_models/keras/densenet121_resisc45.py
@@ -10,8 +10,6 @@ from tensorflow.keras.applications.densenet import DenseNet121
 from tensorflow.keras.models import Model
 from tensorflow.keras.layers import GlobalAveragePooling2D, Dense, Lambda
 
-from armory.data.utils import maybe_download_weights_from_s3
-
 num_classes = 45
 
 
@@ -65,11 +63,10 @@ def make_densenet121_resisc_model(**model_kwargs) -> tf.keras.Model:
     return new_model
 
 
-def get_art_model(model_kwargs, wrapper_kwargs, weights_file):
+def get_art_model(model_kwargs, wrapper_kwargs, weights_path):
     model = make_densenet121_resisc_model(**model_kwargs)
-    if weights_file:
-        filepath = maybe_download_weights_from_s3(weights_file)
-        model.load_weights(filepath)
+    if weights_path:
+        model.load_weights(weights_path)
 
     mean, std = mean_std()
     wrapped_model = KerasClassifier(

--- a/armory/baseline_models/keras/inception_resnet_v2.py
+++ b/armory/baseline_models/keras/inception_resnet_v2.py
@@ -7,10 +7,8 @@ from tensorflow.keras.applications.inception_resnet_v2 import InceptionResNetV2
 from tensorflow.keras.layers import Lambda
 from tensorflow.keras.models import Model
 
-from armory.data.utils import maybe_download_weights_from_s3
 
-
-def get_art_model(model_kwargs, wrapper_kwargs, weights_file=None):
+def get_art_model(model_kwargs, wrapper_kwargs, weights_path=None):
     input = tf.keras.Input(shape=(224, 224, 3))
 
     # Preprocessing layers
@@ -25,9 +23,8 @@ def get_art_model(model_kwargs, wrapper_kwargs, weights_file=None):
         weights=None, input_tensor=img_normalized, **model_kwargs
     )
     model = Model(inputs=input, outputs=inception_resnet_v2.output)
-    if weights_file:
-        filepath = maybe_download_weights_from_s3(weights_file)
-        model.load_weights(filepath)
+    if weights_path:
+        model.load_weights(weights_path)
 
     wrapped_model = KerasClassifier(model, clip_values=(-1.0, 1.0), **wrapper_kwargs)
     return wrapped_model

--- a/armory/baseline_models/keras/micronnet_gtsrb.py
+++ b/armory/baseline_models/keras/micronnet_gtsrb.py
@@ -76,7 +76,7 @@ def make_model(**kwargs) -> tf.keras.Model:
     return model
 
 
-def get_art_model(model_kwargs, wrapper_kwargs, weights=None):
+def get_art_model(model_kwargs, wrapper_kwargs, weights_path=None):
     model = make_model(**model_kwargs)
     wrapped_model = KerasClassifier(model, clip_values=(0.0, 255.0), **wrapper_kwargs)
     return wrapped_model

--- a/armory/baseline_models/keras/mnist.py
+++ b/armory/baseline_models/keras/mnist.py
@@ -6,8 +6,6 @@ from tensorflow.keras.models import Sequential
 from tensorflow.keras.layers import Dense, Flatten, Conv2D, MaxPooling2D
 from art.classifiers import KerasClassifier
 
-from armory.data.utils import maybe_download_weights_from_s3
-
 
 def make_mnist_model(**kwargs) -> tf.keras.Model:
     model = Sequential()
@@ -43,10 +41,9 @@ def make_mnist_model(**kwargs) -> tf.keras.Model:
     return model
 
 
-def get_art_model(model_kwargs, wrapper_kwargs, weights_file=None):
+def get_art_model(model_kwargs, wrapper_kwargs, weights_path=None):
     model = make_mnist_model(**model_kwargs)
-    if weights_file:
-        filepath = maybe_download_weights_from_s3(weights_file)
-        model.load_weights(filepath)
+    if weights_path:
+        model.load_weights(weights_path)
     wrapped_model = KerasClassifier(model, clip_values=(0.0, 1.0), **wrapper_kwargs)
     return wrapped_model

--- a/armory/baseline_models/keras/resnet50.py
+++ b/armory/baseline_models/keras/resnet50.py
@@ -9,13 +9,11 @@ from tensorflow.keras.applications.resnet50 import ResNet50
 from tensorflow.keras.layers import Lambda
 from tensorflow.keras.models import Model
 
-from armory.data.utils import maybe_download_weights_from_s3
-
 
 IMAGENET_MEANS = [103.939, 116.779, 123.68]
 
 
-def get_art_model(model_kwargs, wrapper_kwargs, weights_file=None):
+def get_art_model(model_kwargs, wrapper_kwargs, weights_path=None):
     input = tf.keras.Input(shape=(224, 224, 3))
 
     # Preprocessing layers
@@ -30,9 +28,8 @@ def get_art_model(model_kwargs, wrapper_kwargs, weights_file=None):
     resnet50 = ResNet50(weights=None, input_tensor=img_normalized, **model_kwargs)
     model = Model(inputs=input, outputs=resnet50.output)
 
-    if weights_file:
-        filepath = maybe_download_weights_from_s3(weights_file)
-        model.load_weights(filepath)
+    if weights_path:
+        model.load_weights(weights_path)
 
     wrapped_model = KerasClassifier(
         model,

--- a/armory/baseline_models/keras/so2sat.py
+++ b/armory/baseline_models/keras/so2sat.py
@@ -5,8 +5,6 @@ from tensorflow.keras.layers import MaxPooling2D, Input, concatenate, Lambda
 from art.estimators.classification import KerasClassifier
 from tensorflow.keras.optimizers import SGD
 
-from armory.data.utils import maybe_download_weights_from_s3
-
 
 def make_model(**kwargs):
     SAR_model = Sequential()
@@ -52,11 +50,10 @@ def make_model(**kwargs):
     return fused_net
 
 
-def get_art_model(model_kwargs, wrapper_kwargs, weights=None):
+def get_art_model(model_kwargs, wrapper_kwargs, weights_path=None):
     model = make_model(**model_kwargs)
-    if weights:
-        filepath = maybe_download_weights_from_s3(weights)
-        model.load_weights(filepath)
+    if weights_path:
+        model.load_weights(weights_path)
 
     wrapped_model = KerasClassifier(model=model, **wrapper_kwargs)
     return wrapped_model

--- a/armory/baseline_models/pytorch/cifar.py
+++ b/armory/baseline_models/pytorch/cifar.py
@@ -6,7 +6,6 @@ import torch.nn as nn
 import torch.nn.functional as F
 from art.classifiers import PyTorchClassifier
 
-from armory.data.utils import maybe_download_weights_from_s3
 
 DEVICE = torch.device("cuda" if torch.cuda.is_available() else "cpu")
 
@@ -39,13 +38,12 @@ def make_cifar_model(**kwargs):
     return Net()
 
 
-def get_art_model(model_kwargs, wrapper_kwargs, weights_file=None):
+def get_art_model(model_kwargs, wrapper_kwargs, weights_path=None):
     model = make_cifar_model(**model_kwargs)
     model.to(DEVICE)
 
-    if weights_file:
-        filepath = maybe_download_weights_from_s3(weights_file)
-        checkpoint = torch.load(filepath, map_location=DEVICE)
+    if weights_path:
+        checkpoint = torch.load(weights_path, map_location=DEVICE)
         model.load_state_dict(checkpoint)
 
     wrapped_model = PyTorchClassifier(

--- a/armory/baseline_models/pytorch/mnist.py
+++ b/armory/baseline_models/pytorch/mnist.py
@@ -6,7 +6,6 @@ import torch.nn as nn
 import torch.nn.functional as F
 from art.classifiers import PyTorchClassifier
 
-from armory.data.utils import maybe_download_weights_from_s3
 
 DEVICE = torch.device("cuda" if torch.cuda.is_available() else "cpu")
 
@@ -39,13 +38,12 @@ def make_mnist_model(**kwargs):
     return Net()
 
 
-def get_art_model(model_kwargs, wrapper_kwargs, weights_file=None):
+def get_art_model(model_kwargs, wrapper_kwargs, weights_path=None):
     model = make_mnist_model(**model_kwargs)
     model.to(DEVICE)
 
-    if weights_file:
-        filepath = maybe_download_weights_from_s3(weights_file)
-        checkpoint = torch.load(filepath, map_location=DEVICE)
+    if weights_path:
+        checkpoint = torch.load(weights_path, map_location=DEVICE)
         model.load_state_dict(checkpoint)
 
     wrapped_model = PyTorchClassifier(

--- a/armory/baseline_models/pytorch/resnet50.py
+++ b/armory/baseline_models/pytorch/resnet50.py
@@ -8,8 +8,6 @@ import numpy as np
 import torch
 from torchvision import models
 
-from armory.data.utils import maybe_download_weights_from_s3
-
 
 logger = logging.getLogger(__name__)
 
@@ -35,13 +33,12 @@ def preprocessing_fn(img):
 
 
 # NOTE: PyTorchClassifier expects numpy input, not torch.Tensor input
-def get_art_model(model_kwargs, wrapper_kwargs, weights_file=None):
+def get_art_model(model_kwargs, wrapper_kwargs, weights_path=None):
     model = models.resnet50(**model_kwargs)
     model.to(DEVICE)
 
-    if weights_file:
-        filepath = maybe_download_weights_from_s3(weights_file)
-        checkpoint = torch.load(filepath, map_location=DEVICE)
+    if weights_path:
+        checkpoint = torch.load(weights_path, map_location=DEVICE)
         model.load_state_dict(checkpoint)
 
     wrapped_model = PyTorchClassifier(

--- a/armory/baseline_models/pytorch/ucf101_mars.py
+++ b/armory/baseline_models/pytorch/ucf101_mars.py
@@ -19,8 +19,6 @@ from MARS.opts import parse_opts
 from MARS.models.model import generate_model
 from MARS.dataset import preprocess_data
 
-from armory.data.utils import maybe_download_weights_from_s3
-
 
 logger = logging.getLogger(__name__)
 
@@ -28,16 +26,13 @@ logger = logging.getLogger(__name__)
 DEVICE = torch.device("cuda" if torch.cuda.is_available() else "cpu")
 
 
-def make_model(model_status="ucf101_trained", weights_file=None):
+def make_model(model_status="ucf101_trained", weights_path=None):
     statuses = ("ucf101_trained", "kinetics_pretrained")
     if model_status not in statuses:
         raise ValueError(f"model_status {model_status} not in {statuses}")
     trained = model_status == "ucf101_trained"
-    if not trained and weights_file is None:
-        raise ValueError("weights_file cannot be None for 'kinetics_pretrained'")
-
-    if weights_file:
-        filepath = maybe_download_weights_from_s3(weights_file)
+    if not trained and weights_path is None:
+        raise ValueError("weights_path cannot be None for 'kinetics_pretrained'")
 
     opt = parse_opts(arguments=[])
     opt.dataset = "UCF101"
@@ -54,13 +49,13 @@ def make_model(model_status="ucf101_trained", weights_file=None):
         opt.batch_size = 32
         opt.ft_begin_index = 4
 
-        opt.pretrain_path = filepath
+        opt.pretrain_path = weights_path
 
     logger.info(f"Loading model... {opt.model} {opt.model_depth}")
     model, parameters = generate_model(opt)
 
-    if trained and weights_file is not None:
-        checkpoint = torch.load(filepath, map_location=DEVICE)
+    if trained and weights_path is not None:
+        checkpoint = torch.load(weights_path, map_location=DEVICE)
         model.load_state_dict(checkpoint["state_dict"])
 
     # Initializing the optimizer
@@ -134,8 +129,8 @@ def preprocessing_fn(inputs):
 
 
 # NOTE: PyTorchClassifier expects numpy input, not torch.Tensor input
-def get_art_model(model_kwargs, wrapper_kwargs, weights_file):
-    model, optimizer = make_model(weights_file=weights_file, **model_kwargs)
+def get_art_model(model_kwargs, wrapper_kwargs, weights_path):
+    model, optimizer = make_model(weights_file=weights_path, **model_kwargs)
     model.to(DEVICE)
 
     activity_means = np.array([114.7748, 107.7354, 99.4750])

--- a/armory/baseline_models/pytorch/ucf101_mars.py
+++ b/armory/baseline_models/pytorch/ucf101_mars.py
@@ -130,7 +130,7 @@ def preprocessing_fn(inputs):
 
 # NOTE: PyTorchClassifier expects numpy input, not torch.Tensor input
 def get_art_model(model_kwargs, wrapper_kwargs, weights_path):
-    model, optimizer = make_model(weights_file=weights_path, **model_kwargs)
+    model, optimizer = make_model(weights_path=weights_path, **model_kwargs)
     model.to(DEVICE)
 
     activity_means = np.array([114.7748, 107.7354, 99.4750])

--- a/armory/baseline_models/pytorch/xview_frcnn.py
+++ b/armory/baseline_models/pytorch/xview_frcnn.py
@@ -8,8 +8,6 @@ import torchvision
 from torchvision.models.detection.faster_rcnn import FastRCNNPredictor
 from art.estimators.object_detection import PyTorchFasterRCNN
 
-from armory.data.utils import maybe_download_weights_from_s3
-
 
 logger = logging.getLogger(__name__)
 
@@ -19,7 +17,7 @@ DEVICE = torch.device("cuda" if torch.cuda.is_available() else "cpu")
 NUM_CLASSES = 63
 
 
-def make_fastrcnn_model(weights_file=None):
+def make_fastrcnn_model(weights_path=None):
     """
     This is an MSCOCO pre-trained model that's fine-tuned on xView.
     This model only performs inference and is not trainable. To perform other
@@ -34,17 +32,16 @@ def make_fastrcnn_model(weights_file=None):
     # replace the pre-trained head with a new one
     model.roi_heads.box_predictor = FastRCNNPredictor(in_features, NUM_CLASSES)
 
-    if weights_file:
-        filepath = maybe_download_weights_from_s3(weights_file)
-        checkpoint = torch.load(filepath, map_location=DEVICE)
+    if weights_path:
+        checkpoint = torch.load(weights_path, map_location=DEVICE)
         model.load_state_dict(checkpoint)
 
     return model
 
 
-def get_art_model(model_kwargs, wrapper_kwargs, weights_file=None):
+def get_art_model(model_kwargs, wrapper_kwargs, weights_path=None):
     try:
-        model = make_fastrcnn_model(weights_file=weights_file, **model_kwargs)
+        model = make_fastrcnn_model(weights_path=weights_path, **model_kwargs)
     except PermissionError:
         raise PermissionError(
             "Tried writing pretrained weights to directory without write "

--- a/armory/baseline_models/tf_graph/mnist.py
+++ b/armory/baseline_models/tf_graph/mnist.py
@@ -7,10 +7,9 @@ import tensorflow.compat.v1 as tf
 from art.classifiers import TFClassifier
 
 from armory import paths
-from armory.data.utils import maybe_download_weights_from_s3
 
 
-def get_art_model(model_kwargs, wrapper_kwargs, weights_file=None):
+def get_art_model(model_kwargs, wrapper_kwargs, weights_path=None):
     input_ph = tf.placeholder(tf.float32, shape=[None, 28, 28, 1])
     labels_ph = tf.placeholder(tf.int32, shape=[None, 10])
     training_ph = tf.placeholder(tf.bool, shape=())
@@ -31,10 +30,9 @@ def get_art_model(model_kwargs, wrapper_kwargs, weights_file=None):
     sess = tf.Session()
     sess.run(tf.global_variables_initializer())
 
-    if weights_file:
+    if weights_path:
         # Load Model using preferred save/restore method
-        filepath = maybe_download_weights_from_s3(weights_file)
-        tar = tarfile.open(filepath)
+        tar = tarfile.open(weights_path)
         tar.extractall(path=paths.runtime_paths().saved_model_dir)
         tar.close()
         # Restore variables...

--- a/armory/utils/config_loading.py
+++ b/armory/utils/config_loading.py
@@ -79,10 +79,9 @@ def load_model(model_config):
     if isinstance(weights_file, str):
         weights_path = maybe_download_weights_from_s3(weights_file)
     elif isinstance(weights_file, list):
-        # TODO: if there are multiple weights files,
-        #  should model_fn() be called for each
-        #  or called once on the list?
         weights_path = [maybe_download_weights_from_s3(w) for w in weights_file]
+    elif isinstance(weights_file, dict):
+        weights_path = [maybe_download_weights_from_s3(w) for w in weights_file.keys()]
     else:
         weights_path = None
 

--- a/armory/utils/config_loading.py
+++ b/armory/utils/config_loading.py
@@ -81,7 +81,9 @@ def load_model(model_config):
     elif isinstance(weights_file, list):
         weights_path = [maybe_download_weights_from_s3(w) for w in weights_file]
     elif isinstance(weights_file, dict):
-        weights_path = {k: maybe_download_weights_from_s3(v) for k, v in weights_file.items()}
+        weights_path = {
+            k: maybe_download_weights_from_s3(v) for k, v in weights_file.items()
+        }
     else:
         weights_path = None
 

--- a/armory/utils/config_loading.py
+++ b/armory/utils/config_loading.py
@@ -28,6 +28,7 @@ from art.defences.trainer import Trainer
 
 from armory.art_experimental.attacks import patch
 from armory.data.datasets import ArmoryDataGenerator, EvalGenerator
+from armory.data.utils import maybe_download_weights_from_s3
 from armory.utils import labels
 
 
@@ -75,8 +76,18 @@ def load_model(model_config):
     model_module = import_module(model_config["module"])
     model_fn = getattr(model_module, model_config["name"])
     weights_file = model_config.get("weights_file", None)
+    if isinstance(weights_file, str):
+        weights_path = maybe_download_weights_from_s3(weights_file)
+    elif isinstance(weights_file, list):
+        # TODO: if there are multiple weights files,
+        #  should model_fn() be called for each
+        #  or called once on the list?
+        weights_path = [maybe_download_weights_from_s3(w) for w in weights_file]
+    else:
+        weights_path = None
+
     model = model_fn(
-        model_config["model_kwargs"], model_config["wrapper_kwargs"], weights_file
+        model_config["model_kwargs"], model_config["wrapper_kwargs"], weights_path
     )
     if not isinstance(model, Classifier):
         raise TypeError(f"{model} is not an instance of {Classifier}")

--- a/armory/utils/config_loading.py
+++ b/armory/utils/config_loading.py
@@ -81,7 +81,7 @@ def load_model(model_config):
     elif isinstance(weights_file, list):
         weights_path = [maybe_download_weights_from_s3(w) for w in weights_file]
     elif isinstance(weights_file, dict):
-        weights_path = [maybe_download_weights_from_s3(w) for w in weights_file.keys()]
+        weights_path = {k: maybe_download_weights_from_s3(v) for k, v in weights_file.items()}
     else:
         weights_path = None
 

--- a/armory/utils/config_schema.json
+++ b/armory/utils/config_schema.json
@@ -146,6 +146,8 @@
                 "weights_file": {
                     "type": [
                         "string",
+                        "array",
+                        "object",
                         "null"
                     ]
                 },

--- a/tests/test_pytorch/test_pytorch_models.py
+++ b/tests/test_pytorch/test_pytorch_models.py
@@ -4,6 +4,7 @@ import numpy as np
 import pytest
 
 from armory.data import datasets
+from armory.data.utils import maybe_download_weights_from_s3
 from armory import paths
 from armory.utils.metrics import _object_detection_get_tp_fp_fn
 
@@ -39,8 +40,9 @@ def test_pytorch_mnist():
 def test_pytorch_mnist_pretrained():
     classifier_module = import_module("armory.baseline_models.pytorch.mnist")
     classifier_fn = getattr(classifier_module, "get_art_model")
+    weights_path = maybe_download_weights_from_s3("undefended_mnist_5epochs.pth")
     classifier = classifier_fn(
-        model_kwargs={}, wrapper_kwargs={}, weights_file="undefended_mnist_5epochs.pth"
+        model_kwargs={}, wrapper_kwargs={}, weights_path=weights_path
     )
 
     test_dataset = datasets.mnist(

--- a/tests/test_pytorch/test_pytorch_models.py
+++ b/tests/test_pytorch/test_pytorch_models.py
@@ -86,10 +86,11 @@ def test_keras_cifar():
 def test_pytorch_xview_pretrained():
     detector_module = import_module("armory.baseline_models.pytorch.xview_frcnn")
     detector_fn = getattr(detector_module, "get_art_model")
+    weights_path = maybe_download_weights_from_s3(
+        "xview_model_state_dict_epoch_99_loss_0p67"
+    )
     detector = detector_fn(
-        model_kwargs={},
-        wrapper_kwargs={},
-        weights_file="xview_model_state_dict_epoch_99_loss_0p67",
+        model_kwargs={}, wrapper_kwargs={}, weights_path=weights_path,
     )
 
     test_dataset = datasets.xview(

--- a/tests/test_tf1/test_keras_models.py
+++ b/tests/test_tf1/test_keras_models.py
@@ -115,9 +115,7 @@ def test_keras_imagenet_transfer():
     classifier_fn = getattr(classifier_module, "get_art_model")
     weights_path = maybe_download_weights_from_s3("inceptionresnetv2_imagenet_v1.h5")
     classifier = classifier_fn(
-        model_kwargs={},
-        wrapper_kwargs={},
-        weights_path=weights_path
+        model_kwargs={}, wrapper_kwargs={}, weights_path=weights_path
     )
 
     dataset = adversarial_datasets.imagenet_adversarial(

--- a/tests/test_tf1/test_keras_models.py
+++ b/tests/test_tf1/test_keras_models.py
@@ -5,6 +5,7 @@ import pytest
 
 from armory.data import datasets
 from armory.data import adversarial_datasets
+from armory.data.utils import maybe_download_weights_from_s3
 from armory import paths
 
 DATASET_DIR = paths.runtime_paths().dataset_dir
@@ -39,8 +40,9 @@ def test_keras_mnist():
 def test_keras_mnist_pretrained():
     classifier_module = import_module("armory.baseline_models.keras.mnist")
     classifier_fn = getattr(classifier_module, "get_art_model")
+    weights_path = maybe_download_weights_from_s3("undefended_mnist_5epochs.h5")
     classifier = classifier_fn(
-        model_kwargs={}, wrapper_kwargs={}, weights_file="undefended_mnist_5epochs.h5"
+        model_kwargs={}, wrapper_kwargs={}, weights_path=weights_path
     )
 
     test_dataset = datasets.mnist(
@@ -84,8 +86,9 @@ def test_keras_cifar():
 def test_keras_imagenet():
     classifier_module = import_module("armory.baseline_models.keras.resnet50")
     classifier_fn = getattr(classifier_module, "get_art_model")
+    weights_path = maybe_download_weights_from_s3("resnet50_imagenet_v1.h5")
     classifier = classifier_fn(
-        model_kwargs={}, wrapper_kwargs={}, weights_file="resnet50_imagenet_v1.h5",
+        model_kwargs={}, wrapper_kwargs={}, weights_path=weights_path
     )
 
     dataset = adversarial_datasets.imagenet_adversarial(
@@ -110,10 +113,11 @@ def test_keras_imagenet_transfer():
         "armory.baseline_models.keras.inception_resnet_v2"
     )
     classifier_fn = getattr(classifier_module, "get_art_model")
+    weights_path = maybe_download_weights_from_s3("inceptionresnetv2_imagenet_v1.h5")
     classifier = classifier_fn(
         model_kwargs={},
         wrapper_kwargs={},
-        weights_file="inceptionresnetv2_imagenet_v1.h5",
+        weights_path=weights_path
     )
 
     dataset = adversarial_datasets.imagenet_adversarial(


### PR DESCRIPTION
Update all baseline models to expect to be given a path as produced by `maybe_download_weights_from_s3()` instead of a file name

Based on #657 

Fixes #646 