### PR TITLE
Configurable magic number for Apricot dataset

### DIFF
--- a/armory/data/adversarial_datasets.py
+++ b/armory/data/adversarial_datasets.py
@@ -5,6 +5,7 @@ Adversarial datasets
 from typing import Callable
 
 import numpy as np
+import tensorflow as tf
 
 from armory.data import datasets
 from armory.data.adversarial import (  # noqa: F401
@@ -288,9 +289,19 @@ def apricot_dev_adversarial(
     cache_dataset: bool = True,
     framework: str = "numpy",
     shuffle_files: bool = False,
+    new_adv_patch_category_id=-10,
 ) -> datasets.ArmoryDataGenerator:
     if batch_size != 1:
         raise NotImplementedError("Currently working only with batch size = 1")
+
+    old_adv_patch_category_id = 12
+
+    def replace_magic_val(data, old_val, new_val, sub_key):
+        rhs = data[sub_key]
+        data[sub_key] = tf.where(
+            tf.equal(rhs, old_val), tf.ones_like(rhs, dtype=tf.int64) * new_val, rhs,
+        )
+        return data
 
     return datasets._generator_from_tfds(
         "apricot_dev:1.0.0",
@@ -304,6 +315,12 @@ def apricot_dev_adversarial(
         shuffle_files=shuffle_files,
         cache_dataset=cache_dataset,
         framework=framework,
+        lambda_map=lambda x, y: (
+            x,
+            replace_magic_val(
+                y, old_adv_patch_category_id, new_adv_patch_category_id, "category_id"
+            ),
+        ),
     )
 
 

--- a/armory/data/adversarial_datasets.py
+++ b/armory/data/adversarial_datasets.py
@@ -296,6 +296,10 @@ def apricot_dev_adversarial(
 
     raw_adv_patch_category_id = 12
 
+    # The apricot dataset uses 12 as the label for adversarial patches, which may be used for
+    # meaningful categories for other datasets. This method is applied as a lambda_map to make this
+    # labels field configurable -- we choose a negative integer so it is unlikely there are
+    # collisions with other labels.
     def replace_magic_val(data, raw_val, transformed_val, sub_key):
         rhs = data[sub_key]
         data[sub_key] = tf.where(

--- a/armory/data/adversarial_datasets.py
+++ b/armory/data/adversarial_datasets.py
@@ -289,17 +289,19 @@ def apricot_dev_adversarial(
     cache_dataset: bool = True,
     framework: str = "numpy",
     shuffle_files: bool = False,
-    new_adv_patch_category_id=-10,
+    transformed_adv_patch_category_id=-10,
 ) -> datasets.ArmoryDataGenerator:
     if batch_size != 1:
         raise NotImplementedError("Currently working only with batch size = 1")
 
-    old_adv_patch_category_id = 12
+    raw_adv_patch_category_id = 12
 
-    def replace_magic_val(data, old_val, new_val, sub_key):
+    def replace_magic_val(data, raw_val, transformed_val, sub_key):
         rhs = data[sub_key]
         data[sub_key] = tf.where(
-            tf.equal(rhs, old_val), tf.ones_like(rhs, dtype=tf.int64) * new_val, rhs,
+            tf.equal(rhs, raw_val),
+            tf.ones_like(rhs, dtype=tf.int64) * transformed_val,
+            rhs,
         )
         return data
 
@@ -318,7 +320,10 @@ def apricot_dev_adversarial(
         lambda_map=lambda x, y: (
             x,
             replace_magic_val(
-                y, old_adv_patch_category_id, new_adv_patch_category_id, "category_id"
+                y,
+                raw_adv_patch_category_id,
+                transformed_adv_patch_category_id,
+                "category_id",
             ),
         ),
     )


### PR DESCRIPTION
The apricot dataset uses 12 as the category_id for adversarial patches, which may be used for meaningful categories for other datasets. Add a lambda_map to make this category_id configurable.