### PR TITLE
Fix TORCH_HOME to work in the container

### DIFF
--- a/armory/baseline_models/pytorch/xview_frcnn.py
+++ b/armory/baseline_models/pytorch/xview_frcnn.py
@@ -40,16 +40,7 @@ def make_fastrcnn_model(weights_path=None):
 
 
 def get_art_model(model_kwargs, wrapper_kwargs, weights_path=None):
-    try:
-        model = make_fastrcnn_model(weights_path=weights_path, **model_kwargs)
-    except PermissionError:
-        raise PermissionError(
-            "Tried writing pretrained weights to directory without write "
-            "permissions. To fix this error, either run the scenario with "
-            "--root or run in --interactive mode and inside the container "
-            "set the TORCH_HOME environment variable to a directory with "
-            "write permissions. "
-        )
+    model = make_fastrcnn_model(weights_path=weights_path, **model_kwargs)
     model.to(DEVICE)
 
     # This model receives inputs in the canonical form of [0,1], so no further

--- a/armory/eval/evaluator.py
+++ b/armory/eval/evaluator.py
@@ -123,6 +123,10 @@ class Evaluator(object):
         if self.config["sysconfig"].get("set_pythonhashseed"):
             self.extra_env_vars["PYTHONHASHSEED"] = "0"
 
+        # Because we may want to allow specification of ARMORY_TORCH_HOME
+        # this constant path is placed here among the other imports
+        self.extra_env_vars["TORCH_HOME"] = paths.runtime_paths().pytorch_dir
+
         self.extra_env_vars[environment.ARMORY_VERSION] = armory.__version__
 
     def _cleanup(self):

--- a/armory/paths.py
+++ b/armory/paths.py
@@ -43,6 +43,7 @@ class DockerPaths:
         self.dataset_dir = armory_dir + "/datasets"
         self.local_git_dir = armory_dir + "/git"
         self.saved_model_dir = armory_dir + "/saved_models"
+        self.pytorch_dir = self.saved_model_dir + "/pytorch"
         self.tmp_dir = armory_dir + "/tmp"
         self.output_dir = armory_dir + "/outputs"
         self.external_repo_dir = self.tmp_dir + "/external"
@@ -57,6 +58,7 @@ class HostDefaultPaths:
         self.dataset_dir = os.path.join(self.armory_dir, "datasets")
         self.local_git_dir = os.path.join(self.armory_dir, "git")
         self.saved_model_dir = os.path.join(self.armory_dir, "saved_models")
+        self.pytorch_dir = os.path.join(self.armory_dir, "saved_models", "pytorch")
         self.tmp_dir = os.path.join(self.armory_dir, "tmp")
         self.output_dir = os.path.join(self.armory_dir, "outputs")
         self.external_repo_dir = os.path.join(self.tmp_dir, "external")
@@ -72,6 +74,8 @@ class HostPaths(HostDefaultPaths):
                 "dataset_dir",
                 "local_git_dir",
                 "saved_model_dir",
+                # pytorch_dir should not be found in the config file
+                # because it is not configurable (yet)
                 "output_dir",
                 "tmp_dir",
             ):
@@ -83,5 +87,6 @@ class HostPaths(HostDefaultPaths):
         os.makedirs(self.dataset_dir, exist_ok=True)
         os.makedirs(self.local_git_dir, exist_ok=True)
         os.makedirs(self.saved_model_dir, exist_ok=True)
+        os.makedirs(self.pytorch_dir, exist_ok=True)
         os.makedirs(self.tmp_dir, exist_ok=True)
         os.makedirs(self.output_dir, exist_ok=True)

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -97,10 +97,18 @@ The defaults are shown below:
 | ~/.armory/saved_models | /armory/saved_models |
 | ~/.armory/outputs | /armory/outputs |
 
-<br>
 
 When using these paths in code, armory provides a programatic way to access these 
 directories.
+
+### PyTorch model persistent storage
+
+If you are using the Armory PyTorch container, published models from PyTorch Hub
+will often need to be retieved from a remote source. To avoid re-download of
+that data on each container run, these will be stored in the
+`/armory/saved_models/pytorch` container directory which is normally mapped to
+`~/.armory/saved_models` on the host as shown in the table above. 
+
 
 #### Utilizing the paths
 ```

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,9 +12,11 @@ def ensure_armory_dirs(request):
     """
     docker_paths = paths.DockerPaths()
     saved_model_dir = docker_paths.saved_model_dir
+    pytorch_dir = docker_paths.pytorch_dir
     dataset_dir = docker_paths.dataset_dir
     output_dir = docker_paths.output_dir
 
     os.makedirs(saved_model_dir, exist_ok=True)
+    os.makedirs(pytorch_dir, exist_ok=True)
     os.makedirs(dataset_dir, exist_ok=True)
     os.makedirs(output_dir, exist_ok=True)


### PR DESCRIPTION
Fixes #779 

Clears the defect by passing pass a TORCH_HOME of `…/saved_models/pytorch` into container execution.
I've left breadcrumbs in where we might allow a run-time override as suggested by @davidslater .