### PR TITLE
Fix pytorch loader

### DIFF
--- a/armory/data/datasets.py
+++ b/armory/data/datasets.py
@@ -268,6 +268,9 @@ def _generator_from_tfds(
         ds = ds.batch(batch_size, drop_remainder=False)
     ds = ds.prefetch(tf.data.experimental.AUTOTUNE)
 
+    if framework != "numpy" and (preprocessing_fn is not None or label_preprocessing_fn is not None):
+        raise ValueError(f"Data/label preprocessing functions only supported for numpy framework.  Selected {framework} framework")
+
     if framework == "numpy":
         ds = tfds.as_numpy(ds, graph=default_graph)
         generator = ArmoryDataGenerator(

--- a/armory/data/datasets.py
+++ b/armory/data/datasets.py
@@ -268,8 +268,12 @@ def _generator_from_tfds(
         ds = ds.batch(batch_size, drop_remainder=False)
     ds = ds.prefetch(tf.data.experimental.AUTOTUNE)
 
-    if framework != "numpy" and (preprocessing_fn is not None or label_preprocessing_fn is not None):
-        raise ValueError(f"Data/label preprocessing functions only supported for numpy framework.  Selected {framework} framework")
+    if framework != "numpy" and (
+        preprocessing_fn is not None or label_preprocessing_fn is not None
+    ):
+        raise ValueError(
+            f"Data/label preprocessing functions only supported for numpy framework.  Selected {framework} framework"
+        )
 
     if framework == "numpy":
         ds = tfds.as_numpy(ds, graph=default_graph)

--- a/armory/data/pytorch_loader.py
+++ b/armory/data/pytorch_loader.py
@@ -26,7 +26,9 @@ class TFToTorchGenerator(torch.utils.data.IterableDataset):
                     if isinstance(v, tf.Tensor):
                         y_torch[k] = torch.from_numpy(v.numpy())
                     else:
-                        y_torch[k] = v
+                        raise ValueError(
+                            f"Expected all values to be of type tf.Tensor, but value at key {k} is of type {type(v)}"
+                        )
             else:
                 y_torch = torch.from_numpy(y.numpy())
 

--- a/armory/data/pytorch_loader.py
+++ b/armory/data/pytorch_loader.py
@@ -1,4 +1,5 @@
 import torch
+import tensorflow as tf
 
 
 class TFToTorchGenerator(torch.utils.data.IterableDataset):
@@ -9,12 +10,21 @@ class TFToTorchGenerator(torch.utils.data.IterableDataset):
     def __iter__(self):
         for ex in self.tf_dataset.take(-1):
             x, y = ex
-            # manually handle adverarial dataset
+            # separately handle benign/adversarial data formats
             if isinstance(x, tuple):
-                x = (torch.from_numpy(x[0].numpy()), torch.from_numpy(x[1].numpy()))
-                y = torch.from_numpy(y.numpy())
-            # non-adversarial dataset
+                x_torch = (torch.from_numpy(x[0].numpy()), torch.from_numpy(x[1].numpy()))
             else:
-                x = torch.from_numpy(x.numpy())
-                y = torch.from_numpy(y.numpy())
-            yield x, y
+                x_torch = torch.from_numpy(x.numpy())
+            
+            # separately handle tensor/object detection label formats
+            if isinstance(y, dict):
+                y_torch = {}
+                for k, v in y.items():
+                    if isinstance(v, tf.Tensor):
+                        y_torch[k] = torch.from_numpy(v.numpy())
+                    else:
+                        y_torch[k] = v
+            else:
+                y_torch = torch.from_numpy(y.numpy())
+            
+            yield x_torch, y_torch

--- a/armory/data/pytorch_loader.py
+++ b/armory/data/pytorch_loader.py
@@ -12,10 +12,13 @@ class TFToTorchGenerator(torch.utils.data.IterableDataset):
             x, y = ex
             # separately handle benign/adversarial data formats
             if isinstance(x, tuple):
-                x_torch = (torch.from_numpy(x[0].numpy()), torch.from_numpy(x[1].numpy()))
+                x_torch = (
+                    torch.from_numpy(x[0].numpy()),
+                    torch.from_numpy(x[1].numpy()),
+                )
             else:
                 x_torch = torch.from_numpy(x.numpy())
-            
+
             # separately handle tensor/object detection label formats
             if isinstance(y, dict):
                 y_torch = {}
@@ -26,5 +29,5 @@ class TFToTorchGenerator(torch.utils.data.IterableDataset):
                         y_torch[k] = v
             else:
                 y_torch = torch.from_numpy(y.numpy())
-            
+
             yield x_torch, y_torch

--- a/tests/test_pytorch/test_framework_dataset.py
+++ b/tests/test_pytorch/test_framework_dataset.py
@@ -19,6 +19,8 @@ def test_pytorch_generator_cifar10():
         batch_size=batch_size,
         dataset_dir=DATASET_DIR,
         framework="pytorch",
+        preprocessing_fn=None,
+        fit_preprocessing_fn=None,
     )
 
     assert isinstance(dataset, torch.utils.data.DataLoader)
@@ -38,6 +40,8 @@ def test_pytorch_generator_mnist():
         batch_size=batch_size,
         dataset_dir=DATASET_DIR,
         framework="pytorch",
+        preprocessing_fn=None,
+        fit_preprocessing_fn=None,
     )
 
     assert isinstance(dataset, torch.utils.data.DataLoader)
@@ -57,6 +61,8 @@ def test_pytorch_generator_resisc():
         batch_size=batch_size,
         dataset_dir=DATASET_DIR,
         framework="pytorch",
+        preprocessing_fn=None,
+        fit_preprocessing_fn=None,
     )
 
     assert isinstance(dataset, torch.utils.data.DataLoader)
@@ -76,6 +82,8 @@ def test_pytorch_generator_epochs():
         batch_size=batch_size,
         dataset_dir=DATASET_DIR,
         framework="pytorch",
+        preprocessing_fn=None,
+        fit_preprocessing_fn=None,
     )
 
     cnt = 0
@@ -100,6 +108,8 @@ def test_tf_pytorch_equality():
         dataset_dir=DATASET_DIR,
         framework="tf",
         shuffle_files=False,
+        preprocessing_fn=None,
+        fit_preprocessing_fn=None,
     )
 
     ds_pytorch = iter(
@@ -109,6 +119,8 @@ def test_tf_pytorch_equality():
             dataset_dir=DATASET_DIR,
             framework="pytorch",
             shuffle_files=False,
+            preprocessing_fn=None,
+            fit_preprocessing_fn=None,
         )
     )
 

--- a/tests/test_tf1/test_framework_dataset.py
+++ b/tests/test_tf1/test_framework_dataset.py
@@ -17,5 +17,7 @@ def test_tf_generator():
         batch_size=16,
         dataset_dir=DATASET_DIR,
         framework="tf",
+        preprocessing_fn=None,
+        fit_preprocessing_fn=None,
     )
     assert isinstance(dataset, (tf.compat.v2.data.Dataset, tf.compat.v1.data.Dataset))


### PR DESCRIPTION
Closes #807 by 

1.  Throwing an error if the user selects pytorch or tf framework and applies a data or label preprocessing_fn
2.  For pytorch datasets, check if the labels are in dictionary format and, if so, convert each stored value that is a tensorflow tensor.