### PR TITLE
Separate scaling for SAR/EO

### DIFF
--- a/armory/baseline_models/keras/so2sat.py
+++ b/armory/baseline_models/keras/so2sat.py
@@ -25,14 +25,16 @@ def make_model(**kwargs):
 
     input_shape = [32, 32, 14]
     concat_input = Input(input_shape)
-    renorm_input = Lambda(lambda x: x * 115.25348)(concat_input)
 
-    SAR_input = Lambda(
+    SAR_slice = Lambda(
         lambda concat_input: slice(concat_input, [0, 0, 0, 0], [-1, 32, 32, 4])
-    )(renorm_input)
-    EO_input = Lambda(
+    )(concat_input)
+    EO_slice = Lambda(
         lambda concat_input: slice(concat_input, [0, 0, 0, 4], [-1, 32, 32, 10])
-    )(renorm_input)
+    )(concat_input)
+
+    SAR_input = Lambda(lambda x: x * 128)(SAR_slice)
+    EO_input = Lambda(lambda x: x * 4)(EO_slice)
 
     encoded_SAR = SAR_model(SAR_input)
     encoded_EO = EO_model(EO_input)

--- a/armory/data/datasets.py
+++ b/armory/data/datasets.py
@@ -956,8 +956,12 @@ class So2SatContext:
             32,
             14,
         )
-        self.quantization = (
-            115.25348  # max absolute value across all channels in train/validation
+        self.quantization = np.concatenate(
+            (
+                128 * np.ones((1, 1, 1, 4), dtype=np.float32),
+                4 * np.ones((1, 1, 1, 10), dtype=np.float32),
+            ),
+            axis=-1,
         )
 
 


### PR DESCRIPTION
Closes #781 

We found the following minimum/maximum values for each channel, computed across the entire dataset.
```
SAR Channel 1, Min: -107.636246, Max: 67.136765
SAR Channel 2, Min: -107.636246, Max: 107.63296
SAR Channel 3, Min: -115.25347, Max: 115.00613
SAR Channel 4, Min: -114.72947, Max: 115.00594
Optical Channel 1, Min: 1e-04, Max: 2.8
Optical Channel 2, Min: 1e-04, Max: 2.8
Optical Channel 3, Min: 1e-04, Max: 2.8 
Optical Channel 4, Min: 1e-04, Max: 2.8001
Optical Channel 5, Min: 1e-04, Max: 2.8002
Optical Channel 6, Min: 1e-04, Max: 2.8003
Optical Channel 7, Min: 1e-04, Max: 2.8001
Optical Channel 8, Min: 1e-04, Max: 2.8005
Optical Channel 9, Min: 1e-04, Max: 2.8001
Optical Channel 10, Min: 1e-04, Max: 2.8
```
To minimize floating point errors, we scale SAR channels by 128 and optical channels by 4.