### PR TITLE
Save deep speech model weights in armory directory

### DIFF
--- a/armory/baseline_models/pytorch/deep_speech.py
+++ b/armory/baseline_models/pytorch/deep_speech.py
@@ -4,6 +4,25 @@ Automatic speech recognition model
 Model contributed by: MITRE Corporation
 """
 
+# BEGIN hacks
+# Save deep speech model to armory
+# This can be made less hacky after this ART issue:
+# https://github.com/Trusted-AI/adversarial-robustness-toolbox/issues/693
+import os
+import logging
+
+logger = logging.getLogger(__name__)
+
+from armory import paths
+
+ART_DATA_PATH = os.path.join(paths.runtime_paths().saved_model_dir, "art")
+os.makedirs(ART_DATA_PATH, exist_ok=True)
+from art.estimators.speech_recognition import pytorch_deep_speech
+
+pytorch_deep_speech.ART_DATA_PATH = ART_DATA_PATH
+logger.warning(f"Saving art deep speech model weights to {ART_DATA_PATH}")
+# END hacks
+
 from art.estimators.speech_recognition import PyTorchDeepSpeech
 
 


### PR DESCRIPTION
Fixes #856 

There is a more permanent solution in #805 , but that requires a 1.5 update in ART.