### PR TITLE
Dataset index and slicing

### DIFF
--- a/armory/data/adversarial_datasets.py
+++ b/armory/data/adversarial_datasets.py
@@ -56,7 +56,7 @@ def apricot_canonical_preprocessing(batch):
 
 
 def imagenet_adversarial(
-    split_type: str = "adversarial",
+    split: str = "adversarial",
     epochs: int = 1,
     batch_size: int = 1,
     dataset_dir: str = None,
@@ -86,7 +86,7 @@ def imagenet_adversarial(
 
     return datasets._generator_from_tfds(
         "imagenet_adversarial:1.1.0",
-        split_type=split_type,
+        split=split,
         batch_size=batch_size,
         epochs=epochs,
         dataset_dir=dataset_dir,
@@ -99,7 +99,7 @@ def imagenet_adversarial(
 
 
 def librispeech_adversarial(
-    split_type: str = "adversarial",
+    split: str = "adversarial",
     epochs: int = 1,
     batch_size: int = 1,
     dataset_dir: str = None,
@@ -115,7 +115,7 @@ def librispeech_adversarial(
     Adversarial dataset based on Librispeech-dev-clean including clean,
     Universal Perturbation using PGD, and PGD.
 
-    split_type - one of ("adversarial")
+    split - one of ("adversarial")
 
     returns:
         Generator
@@ -130,7 +130,7 @@ def librispeech_adversarial(
 
     return datasets._generator_from_tfds(
         "librispeech_adversarial:1.1.0",
-        split_type=split_type,
+        split=split,
         batch_size=batch_size,
         epochs=epochs,
         dataset_dir=dataset_dir,
@@ -146,7 +146,7 @@ def librispeech_adversarial(
 
 
 def resisc45_adversarial_224x224(
-    split_type: str = "adversarial",
+    split: str = "adversarial",
     epochs: int = 1,
     batch_size: int = 1,
     dataset_dir: str = None,
@@ -185,7 +185,7 @@ def resisc45_adversarial_224x224(
 
     return datasets._generator_from_tfds(
         "resisc45_densenet121_univpatch_and_univperturbation_adversarial224x224:1.0.2",
-        split_type=split_type,
+        split=split,
         batch_size=batch_size,
         epochs=epochs,
         dataset_dir=dataset_dir,
@@ -201,7 +201,7 @@ def resisc45_adversarial_224x224(
 
 
 def ucf101_adversarial_112x112(
-    split_type: str = "adversarial",
+    split: str = "adversarial",
     epochs: int = 1,
     batch_size: int = 1,
     dataset_dir: str = None,
@@ -242,7 +242,7 @@ def ucf101_adversarial_112x112(
 
     return datasets._generator_from_tfds(
         "ucf101_mars_perturbation_and_patch_adversarial112x112:1.1.0",
-        split_type=split_type,
+        split=split,
         batch_size=batch_size,
         epochs=epochs,
         dataset_dir=dataset_dir,
@@ -258,7 +258,7 @@ def ucf101_adversarial_112x112(
 
 
 def gtsrb_poison(
-    split_type: str = "poison",
+    split: str = "poison",
     epochs: int = 1,
     batch_size: int = 1,
     dataset_dir: str = None,
@@ -277,7 +277,7 @@ def gtsrb_poison(
     """
     return datasets._generator_from_tfds(
         "gtsrb_bh_poison_micronnet:1.0.0",
-        split_type=split_type,
+        split=split,
         batch_size=batch_size,
         epochs=epochs,
         dataset_dir=dataset_dir,
@@ -293,7 +293,7 @@ def gtsrb_poison(
 
 
 def apricot_dev_adversarial(
-    split_type: str = "adversarial",
+    split: str = "adversarial",
     epochs: int = 1,
     batch_size: int = 1,
     dataset_dir: str = None,
@@ -323,7 +323,7 @@ def apricot_dev_adversarial(
 
     return datasets._generator_from_tfds(
         "apricot_dev:1.0.1",
-        split_type=split_type,
+        split=split,
         batch_size=batch_size,
         epochs=epochs,
         dataset_dir=dataset_dir,

--- a/armory/data/datasets.py
+++ b/armory/data/datasets.py
@@ -9,7 +9,9 @@ The 'downloads' subdirectory under <dataset_dir> is reserved for caching.
 """
 
 import logging
+import json
 import os
+import re
 from typing import Callable, Union
 
 import numpy as np
@@ -203,6 +205,66 @@ class EvalGenerator(DataGenerator):
         return self.num_eval_batches
 
 
+def _parse_token(token: str):
+    """
+    Token from parse_split index
+
+    Return parsed token
+    """
+    if not token:
+        raise ValueError("empty token found")
+
+    left = token.find("[")
+    if left == -1:
+        return token
+
+    right = token.rfind("]")
+    if right != len(token) - 1:
+        raise ValueError(f"could not parse token {token} - mismatched brackets")
+    name = token[:left]
+    index = token[left + 1 : right]  # remove brackets
+    if not name:
+        raise ValueError(f"empty split name: {token}")
+    if not index:
+        raise ValueError(f"empty index found: {token}")
+    if index.count(":") == 2:
+        raise NotImplementedError(f"slice 'step' not enabled: {token}")
+    elif index == "[]":
+        raise ValueError(f"empty list index found: {token}")
+
+    if re.match(r"^\d+$", index):
+        # single index
+        i = int(index)
+        return f"{name}[{i}:{i+1}]"
+    elif re.match(r"^\[\d+(\s*,\s*\d+)*\]$", index):
+        # list index of nonnegative integer indices
+        index_list = json.loads(index)
+        index_list = sorted(set(index_list))
+        token_list = [f"{name}[{i}:{i+1}]" for i in index_list]
+        if not token_list:
+            raise ValueError
+        return "+".join(token_list)
+
+    return token
+
+
+def parse_split_index(split: str):
+    """
+    Take a TFDS split argument and rewrite index arguments such as:
+        test[10] --> test[10:11]
+        test[[1, 5, 7]] --> test[1:2]+test[5:6]+test[7:8]
+    """
+    if not isinstance(split, str):
+        raise ValueError(f"split must be str, not {type(split)}")
+    if not split.strip():
+        raise ValueError("split cannot be empty")
+
+    tokens = split.split("+")
+    tokens = [x.strip() for x in tokens]
+    output_tokens = [_parse_token(x) for x in tokens]
+    return "+".join(output_tokens)
+
+
 def _generator_from_tfds(
     dataset_name: str,
     split: str,
@@ -239,15 +301,36 @@ def _generator_from_tfds(
 
     default_graph = tf.compat.v1.keras.backend.get_session().graph
 
-    ds, ds_info = tfds.load(
-        dataset_name,
-        split=split,
-        as_supervised=as_supervised,
-        data_dir=dataset_dir,
-        with_info=True,
-        download_and_prepare_kwargs=download_and_prepare_kwargs,
-        shuffle_files=shuffle_files,
-    )
+    if not isinstance(split, str):
+        raise ValueError(f"split must be str, not {type(split)}")
+
+    try:
+        ds, ds_info = tfds.load(
+            dataset_name,
+            split=split,
+            as_supervised=as_supervised,
+            data_dir=dataset_dir,
+            with_info=True,
+            download_and_prepare_kwargs=download_and_prepare_kwargs,
+            shuffle_files=shuffle_files,
+        )
+    except AssertionError as e:
+        if not str(e).startswith("Unrecognized instruction format: "):
+            raise
+        logger.warning(f"Caught AssertionError in TFDS load split argument: {e}")
+        logger.warning(f"Attempting to parse split {split}")
+        split = parse_split_index(split)
+        logger.warning(f"Replacing split with {split}")
+        ds, ds_info = tfds.load(
+            dataset_name,
+            split=split,
+            as_supervised=as_supervised,
+            data_dir=dataset_dir,
+            with_info=True,
+            download_and_prepare_kwargs=download_and_prepare_kwargs,
+            shuffle_files=shuffle_files,
+        )
+
     if not as_supervised:
         try:
             x_key, y_key = supervised_xy_keys

--- a/armory/data/datasets.py
+++ b/armory/data/datasets.py
@@ -238,8 +238,8 @@ def _parse_token(token: str):
         return f"{name}[{i}:{i+1}]"
     elif re.match(r"^\[\d+(\s*,\s*\d+)*\]$", index):
         # list index of nonnegative integer indices
+        # out-of-order and duplicate indices are allowed
         index_list = json.loads(index)
-        index_list = sorted(set(index_list))
         token_list = [f"{name}[{i}:{i+1}]" for i in index_list]
         if not token_list:
             raise ValueError

--- a/armory/data/digit/digit.py
+++ b/armory/data/digit/digit.py
@@ -80,7 +80,7 @@ class Digit(tfds.core.GeneratorBasedBuilder):
         elif split is tfds.Split.TEST:
             samples = range(5)
         else:
-            raise ValueError(f"split_type {split} not in ('train', 'test')")
+            raise ValueError(f"split {split} not in ('train', 'test')")
 
         for digit, user, sample in itertools.product(_DIGITS, _USERS, samples):
             filename = f"{digit}_{user}_{sample}.wav"

--- a/armory/data/german_traffic_sign/german_traffic_sign.py
+++ b/armory/data/german_traffic_sign/german_traffic_sign.py
@@ -88,4 +88,4 @@ class GermanTrafficSign(tfds.core.GeneratorBasedBuilder):
             for x in _read_images(prefix, gtFile):
                 yield x
         else:
-            raise ValueError(f"split_type {split} not in ('train', 'test')")
+            raise ValueError(f"split {split} not in ('train', 'test')")

--- a/armory/scenarios/audio_asr.py
+++ b/armory/scenarios/audio_asr.py
@@ -58,7 +58,7 @@ class AutomaticSpeechRecognition(Scenario):
             train_data = load_dataset(
                 config["dataset"],
                 epochs=fit_kwargs["nb_epochs"],
-                split_type=config["dataset"].get("train_split", "train_clean100"),
+                split=config["dataset"].get("train_split", "train_clean100"),
                 preprocessing_fn=fit_preprocessing_fn,
                 shuffle_files=True,
             )
@@ -101,7 +101,7 @@ class AutomaticSpeechRecognition(Scenario):
             test_data = load_dataset(
                 config["dataset"],
                 epochs=1,
-                split_type=eval_split,
+                split=eval_split,
                 num_batches=num_eval_batches,
                 shuffle_files=False,
             )
@@ -134,7 +134,7 @@ class AutomaticSpeechRecognition(Scenario):
             test_data = load_adversarial_dataset(
                 attack_config,
                 epochs=1,
-                split_type="adversarial",
+                split="adversarial",
                 num_batches=num_eval_batches,
                 shuffle_files=False,
             )
@@ -147,7 +147,7 @@ class AutomaticSpeechRecognition(Scenario):
             test_data = load_dataset(
                 config["dataset"],
                 epochs=1,
-                split_type=eval_split,
+                split=eval_split,
                 num_batches=num_eval_batches,
                 shuffle_files=False,
             )

--- a/armory/scenarios/audio_classification.py
+++ b/armory/scenarios/audio_classification.py
@@ -55,7 +55,7 @@ class AudioClassificationTask(Scenario):
             train_data = load_dataset(
                 config["dataset"],
                 epochs=fit_kwargs["nb_epochs"],
-                split="train",
+                split=config["dataset"].get("train_split", "train"),
                 preprocessing_fn=fit_preprocessing_fn,
                 shuffle_files=True,
             )
@@ -82,6 +82,7 @@ class AudioClassificationTask(Scenario):
         if config["dataset"]["batch_size"] != 1:
             logger.warning("Evaluation batch_size != 1 may not be supported.")
 
+        eval_split = config["dataset"].get("eval_split", "test")
         if skip_benign:
             logger.info("Skipping benign classification...")
         else:
@@ -90,7 +91,7 @@ class AudioClassificationTask(Scenario):
             test_data = load_dataset(
                 config["dataset"],
                 epochs=1,
-                split="test",
+                split=eval_split,
                 num_batches=num_eval_batches,
                 shuffle_files=False,
             )
@@ -133,7 +134,7 @@ class AudioClassificationTask(Scenario):
             test_data = load_dataset(
                 config["dataset"],
                 epochs=1,
-                split="test",
+                split=eval_split,
                 num_batches=num_eval_batches,
                 shuffle_files=False,
             )

--- a/armory/scenarios/audio_classification.py
+++ b/armory/scenarios/audio_classification.py
@@ -55,7 +55,7 @@ class AudioClassificationTask(Scenario):
             train_data = load_dataset(
                 config["dataset"],
                 epochs=fit_kwargs["nb_epochs"],
-                split_type="train",
+                split="train",
                 preprocessing_fn=fit_preprocessing_fn,
                 shuffle_files=True,
             )
@@ -90,7 +90,7 @@ class AudioClassificationTask(Scenario):
             test_data = load_dataset(
                 config["dataset"],
                 epochs=1,
-                split_type="test",
+                split="test",
                 num_batches=num_eval_batches,
                 shuffle_files=False,
             )
@@ -120,7 +120,7 @@ class AudioClassificationTask(Scenario):
             test_data = load_adversarial_dataset(
                 attack_config,
                 epochs=1,
-                split_type="adversarial",
+                split="adversarial",
                 num_batches=num_eval_batches,
                 shuffle_files=False,
             )
@@ -133,7 +133,7 @@ class AudioClassificationTask(Scenario):
             test_data = load_dataset(
                 config["dataset"],
                 epochs=1,
-                split_type="test",
+                split="test",
                 num_batches=num_eval_batches,
                 shuffle_files=False,
             )

--- a/armory/scenarios/image_classification.py
+++ b/armory/scenarios/image_classification.py
@@ -54,7 +54,7 @@ class ImageClassificationTask(Scenario):
                 train_data = load_dataset(
                     config["dataset"],
                     epochs=fit_kwargs["nb_epochs"],
-                    split="train",
+                    split=config["dataset"].get("train_split", "train"),
                     shuffle_files=True,
                 )
                 if defense_type == "Trainer":

--- a/armory/scenarios/image_classification.py
+++ b/armory/scenarios/image_classification.py
@@ -54,7 +54,7 @@ class ImageClassificationTask(Scenario):
                 train_data = load_dataset(
                     config["dataset"],
                     epochs=fit_kwargs["nb_epochs"],
-                    split_type="train",
+                    split="train",
                     shuffle_files=True,
                 )
                 if defense_type == "Trainer":
@@ -96,7 +96,7 @@ class ImageClassificationTask(Scenario):
             test_data = load_dataset(
                 config["dataset"],
                 epochs=1,
-                split_type=eval_split,
+                split=eval_split,
                 num_batches=num_eval_batches,
                 shuffle_files=False,
             )
@@ -127,7 +127,7 @@ class ImageClassificationTask(Scenario):
             test_data = load_adversarial_dataset(
                 attack_config,
                 epochs=1,
-                split_type="adversarial",
+                split="adversarial",
                 num_batches=num_eval_batches,
                 shuffle_files=False,
             )
@@ -140,7 +140,7 @@ class ImageClassificationTask(Scenario):
             test_data = load_dataset(
                 config["dataset"],
                 epochs=1,
-                split_type=eval_split,
+                split=eval_split,
                 num_batches=num_eval_batches,
                 shuffle_files=False,
             )

--- a/armory/scenarios/poisoning_gtsrb_scenario.py
+++ b/armory/scenarios/poisoning_gtsrb_scenario.py
@@ -102,7 +102,7 @@ class GTSRB(Scenario):
         clean_data = load_dataset(
             config["dataset"],
             epochs=1,
-            split_type="train",
+            split="train",
             preprocessing_fn=preprocessing_fn,
             shuffle_files=False,
         )
@@ -134,7 +134,7 @@ class GTSRB(Scenario):
             poison_data = load_dataset(
                 config["adhoc"]["poison_samples"],
                 epochs=1,
-                split_type="poison",
+                split="poison",
                 preprocessing_fn=None,
             )
 
@@ -258,7 +258,7 @@ class GTSRB(Scenario):
         test_data = load_dataset(
             config["dataset"],
             epochs=1,
-            split_type="test",
+            split="test",
             preprocessing_fn=preprocessing_fn,
             shuffle_files=False,
         )
@@ -293,7 +293,7 @@ class GTSRB(Scenario):
             test_data_poison = load_dataset(
                 config_adhoc["poison_samples"],
                 epochs=1,
-                split_type="poison_test",
+                split="poison_test",
                 preprocessing_fn=None,
             )
             for x_poison_test, y_poison_test in tqdm(
@@ -307,7 +307,7 @@ class GTSRB(Scenario):
             test_data_clean = load_dataset(
                 config["dataset"],
                 epochs=1,
-                split_type="test",
+                split="test",
                 preprocessing_fn=preprocessing_fn,
                 shuffle_files=False,
             )
@@ -323,7 +323,7 @@ class GTSRB(Scenario):
             test_data = load_dataset(
                 config["dataset"],
                 epochs=1,
-                split_type="test",
+                split="test",
                 preprocessing_fn=preprocessing_fn,
                 shuffle_files=False,
             )

--- a/armory/scenarios/poisoning_gtsrb_scenario.py
+++ b/armory/scenarios/poisoning_gtsrb_scenario.py
@@ -102,7 +102,7 @@ class GTSRB(Scenario):
         clean_data = load_dataset(
             config["dataset"],
             epochs=1,
-            split="train",
+            split=config["dataset"].get("train_split", "train"),
             preprocessing_fn=preprocessing_fn,
             shuffle_files=False,
         )
@@ -258,7 +258,7 @@ class GTSRB(Scenario):
         test_data = load_dataset(
             config["dataset"],
             epochs=1,
-            split="test",
+            split=config["dataset"].get("eval_split", "test"),
             preprocessing_fn=preprocessing_fn,
             shuffle_files=False,
         )
@@ -307,7 +307,7 @@ class GTSRB(Scenario):
             test_data_clean = load_dataset(
                 config["dataset"],
                 epochs=1,
-                split="test",
+                split=config["dataset"].get("eval_split", "test"),
                 preprocessing_fn=preprocessing_fn,
                 shuffle_files=False,
             )
@@ -323,7 +323,7 @@ class GTSRB(Scenario):
             test_data = load_dataset(
                 config["dataset"],
                 epochs=1,
-                split="test",
+                split=config["dataset"].get("eval_split", "test"),
                 preprocessing_fn=preprocessing_fn,
                 shuffle_files=False,
             )

--- a/armory/scenarios/video_ucf101_scenario.py
+++ b/armory/scenarios/video_ucf101_scenario.py
@@ -62,7 +62,7 @@ class Ucf101(Scenario):
             train_data = load_dataset(
                 config["dataset"],
                 epochs=fit_kwargs["nb_epochs"],
-                split="train",
+                split=config["dataset"].get("train_split", "train"),
                 preprocessing_fn=fit_preprocessing_fn,
                 shuffle_files=True,
             )
@@ -89,6 +89,7 @@ class Ucf101(Scenario):
         if config["dataset"]["batch_size"] != 1:
             logger.warning("Evaluation batch_size != 1 may not be supported.")
 
+        eval_split = config["dataset"].get("eval_split", "test")
         if skip_benign:
             logger.info("Skipping benign classification...")
         else:
@@ -97,7 +98,7 @@ class Ucf101(Scenario):
             test_data = load_dataset(
                 config["dataset"],
                 epochs=1,
-                split="test",
+                split=eval_split,
                 num_batches=num_eval_batches,
                 shuffle_files=False,
             )
@@ -140,7 +141,7 @@ class Ucf101(Scenario):
             test_data = load_dataset(
                 config["dataset"],
                 epochs=1,
-                split="test",
+                split=eval_split,
                 num_batches=num_eval_batches,
                 shuffle_files=False,
             )

--- a/armory/scenarios/video_ucf101_scenario.py
+++ b/armory/scenarios/video_ucf101_scenario.py
@@ -62,7 +62,7 @@ class Ucf101(Scenario):
             train_data = load_dataset(
                 config["dataset"],
                 epochs=fit_kwargs["nb_epochs"],
-                split_type="train",
+                split="train",
                 preprocessing_fn=fit_preprocessing_fn,
                 shuffle_files=True,
             )
@@ -97,7 +97,7 @@ class Ucf101(Scenario):
             test_data = load_dataset(
                 config["dataset"],
                 epochs=1,
-                split_type="test",
+                split="test",
                 num_batches=num_eval_batches,
                 shuffle_files=False,
             )
@@ -127,7 +127,7 @@ class Ucf101(Scenario):
             test_data = load_adversarial_dataset(
                 attack_config,
                 epochs=1,
-                split_type="adversarial",
+                split="adversarial",
                 num_batches=num_eval_batches,
                 shuffle_files=False,
             )
@@ -140,7 +140,7 @@ class Ucf101(Scenario):
             test_data = load_dataset(
                 config["dataset"],
                 epochs=1,
-                split_type="test",
+                split="test",
                 num_batches=num_eval_batches,
                 shuffle_files=False,
             )

--- a/docs/configuration_files.md
+++ b/docs/configuration_files.md
@@ -26,6 +26,8 @@ All configuration files are verified against the jsonschema definition at run ti
     module: [String] Python module to load dataset from 
     name: [String] Name of the dataset function
     framework: [String] Framework to return Tensors in. <`tf`|`pytorch`|`numpy`>. `numpy` by default.
+    train_split: [Optional String] Training split in dataset. Typically defaults to `train`. Can use fancy slicing via [TFDS slicing API](https://www.tensorflow.org/datasets/splits#slicing_api)
+    eval_split: [Optional String] Eval split in dataset. Typically defaults to `test`. Can use fancy slicing via [TFDS slicing API](https://www.tensorflow.org/datasets/splits#slicing_api)
   }
 `defense`: [Object or null]
   {

--- a/tests/test_docker/test_dataset.py
+++ b/tests/test_docker/test_dataset.py
@@ -52,11 +52,34 @@ def test_parse_split_index():
         datasets.parse_split_index("test[10:20:2]")
 
 
+def test_parse_split_index_ordering():
+    """
+    Ensure that output order is deterministic for multiple splits
+    """
+    index = [5, 37, 38, 56, 111]  # test has max index 9999
+    split = "test"
+    kwargs = dict(epochs=1, batch_size=1, dataset_dir=DATASET_DIR, shuffle_files=False)
+    ds = datasets.mnist(split=split, **kwargs)
+    fixed_order = []
+    for i, (x, y) in enumerate(ds):
+        if i in index:
+            fixed_order.append(x)
+        if i >= max(index):
+            break
+
+    sliced_split = f"{split}[{index}]"
+    ds = datasets.mnist(split=sliced_split, **kwargs)
+    output_x = [x for (x, y) in ds]
+    assert len(fixed_order) == len(output_x)
+    for x_i, x_j in zip(fixed_order, output_x):
+        assert (x_i == x_j).all()
+
+
 def test_mnist():
     batch_size = 600
     for split, size in [("train", 60000), ("test", 10000)]:
         dataset = datasets.mnist(
-            split_type=split, epochs=1, batch_size=batch_size, dataset_dir=DATASET_DIR,
+            split=split, epochs=1, batch_size=batch_size, dataset_dir=DATASET_DIR,
         )
         assert dataset.size == size
         assert dataset.batch_size == batch_size
@@ -73,7 +96,7 @@ def test_cifar():
     batch_size = 500
     for split, size in [("train", 50000), ("test", 10000)]:
         dataset = datasets.cifar10(
-            split_type=split, epochs=1, batch_size=batch_size, dataset_dir=DATASET_DIR,
+            split=split, epochs=1, batch_size=batch_size, dataset_dir=DATASET_DIR,
         )
         assert dataset.size == size
         assert dataset.batch_size == batch_size
@@ -97,10 +120,7 @@ def test_digit():
         ("test", 5 * num_users * 10),
     ]:
         dataset = datasets.digit(
-            split_type=split,
-            epochs=epochs,
-            batch_size=batch_size,
-            dataset_dir=DATASET_DIR,
+            split=split, epochs=epochs, batch_size=batch_size, dataset_dir=DATASET_DIR,
         )
         assert dataset.size == size
         assert dataset.batch_size == batch_size
@@ -117,7 +137,7 @@ def test_imagenet_adv():
     total_size = 1000
     test_dataset = adversarial_datasets.imagenet_adversarial(
         dataset_dir=DATASET_DIR,
-        split_type="adversarial",
+        split="adversarial",
         batch_size=batch_size,
         epochs=1,
         adversarial_key="adversarial",
@@ -139,10 +159,7 @@ def test_german_traffic_sign():
         batch_size = 1
         epochs = 1
         dataset = datasets.german_traffic_sign(
-            split_type=split,
-            epochs=epochs,
-            batch_size=batch_size,
-            dataset_dir=DATASET_DIR,
+            split=split, epochs=epochs, batch_size=batch_size, dataset_dir=DATASET_DIR,
         )
         assert dataset.size == size
 
@@ -160,10 +177,7 @@ def test_imagenette():
         batch_size = 1
         epochs = 1
         dataset = datasets.imagenette(
-            split_type=split,
-            epochs=epochs,
-            batch_size=batch_size,
-            dataset_dir=DATASET_DIR,
+            split=split, epochs=epochs, batch_size=batch_size, dataset_dir=DATASET_DIR,
         )
         assert dataset.size == size
 
@@ -181,10 +195,7 @@ def test_ucf101():
         batch_size = 1
         epochs = 1
         dataset = datasets.ucf101(
-            split_type=split,
-            epochs=epochs,
-            batch_size=batch_size,
-            dataset_dir=DATASET_DIR,
+            split=split, epochs=epochs, batch_size=batch_size, dataset_dir=DATASET_DIR,
         )
         assert dataset.size == size
 
@@ -206,7 +217,7 @@ def test_librispeech():
 
     for split, size, min_dim1, max_dim1 in zip(splits, sizes, min_dim1s, max_dim1s):
         dataset = datasets.librispeech_dev_clean(
-            split_type=split, epochs=1, batch_size=batch_size, dataset_dir=DATASET_DIR,
+            split=split, epochs=1, batch_size=batch_size, dataset_dir=DATASET_DIR,
         )
         assert dataset.size == size
         assert dataset.batch_size == batch_size
@@ -231,10 +242,7 @@ def test_resisc45():
         batch_size = 16
         epochs = 1
         dataset = datasets.resisc45(
-            split_type=split,
-            epochs=epochs,
-            batch_size=batch_size,
-            dataset_dir=DATASET_DIR,
+            split=split, epochs=epochs, batch_size=batch_size, dataset_dir=DATASET_DIR,
         )
         assert dataset.size == size
         assert dataset.batch_size == batch_size
@@ -260,7 +268,7 @@ def test_librispeech_adversarial():
     split = "adversarial"
 
     dataset = adversarial_datasets.librispeech_adversarial(
-        split_type=split,
+        split=split,
         epochs=1,
         batch_size=batch_size,
         dataset_dir=DATASET_DIR,
@@ -284,7 +292,7 @@ def test_resisc45_adversarial_224x224():
     epochs = 1
     for adversarial_key in ("adversarial_univpatch", "adversarial_univperturbation"):
         dataset = adversarial_datasets.resisc45_adversarial_224x224(
-            split_type=split,
+            split=split,
             epochs=epochs,
             batch_size=batch_size,
             dataset_dir=DATASET_DIR,
@@ -316,9 +324,9 @@ def test_ucf101_adversarial_112x112():
         batch_size = 1
         epochs = 1
         size = 505
-        split_type = "adversarial"
+        split = "adversarial"
         dataset = adversarial_datasets.ucf101_adversarial_112x112(
-            split_type=split_type,
+            split=split,
             epochs=epochs,
             batch_size=batch_size,
             dataset_dir=DATASET_DIR,
@@ -340,7 +348,7 @@ def test_variable_length():
     size = 1350
     batch_size = 4
     dataset = datasets.digit(
-        split_type="train", epochs=1, batch_size=batch_size, dataset_dir=DATASET_DIR,
+        split="train", epochs=1, batch_size=batch_size, dataset_dir=DATASET_DIR,
     )
     assert dataset.batches_per_epoch == (size // batch_size + bool(size % batch_size))
 
@@ -357,7 +365,7 @@ def test_generator():
     batch_size = 600
     for split, size in [("train", 60000)]:
         dataset = datasets.mnist(
-            split_type=split, epochs=1, batch_size=batch_size, dataset_dir=DATASET_DIR,
+            split=split, epochs=1, batch_size=batch_size, dataset_dir=DATASET_DIR,
         )
 
         for x, y in dataset:
@@ -368,7 +376,7 @@ def test_generator():
 
 def test_numpy_generator():
     dataset = datasets.mnist(
-        split_type="train",
+        split="train",
         epochs=1,
         batch_size=16,
         dataset_dir=DATASET_DIR,

--- a/tests/test_pytorch/test_framework_dataset.py
+++ b/tests/test_pytorch/test_framework_dataset.py
@@ -14,7 +14,7 @@ DATASET_DIR = paths.DockerPaths().dataset_dir
 def test_pytorch_generator_cifar10():
     batch_size = 16
     dataset = datasets.cifar10(
-        split_type="train",
+        split="train",
         epochs=1,
         batch_size=batch_size,
         dataset_dir=DATASET_DIR,
@@ -35,7 +35,7 @@ def test_pytorch_generator_cifar10():
 def test_pytorch_generator_mnist():
     batch_size = 16
     dataset = datasets.mnist(
-        split_type="train",
+        split="train",
         epochs=1,
         batch_size=batch_size,
         dataset_dir=DATASET_DIR,
@@ -56,7 +56,7 @@ def test_pytorch_generator_mnist():
 def test_pytorch_generator_resisc():
     batch_size = 16
     dataset = datasets.resisc45(
-        split_type="train",
+        split="train",
         epochs=1,
         batch_size=batch_size,
         dataset_dir=DATASET_DIR,
@@ -77,7 +77,7 @@ def test_pytorch_generator_resisc():
 def test_pytorch_generator_epochs():
     batch_size = 10
     dataset = datasets.mnist(
-        split_type="test",
+        split="test",
         epochs=2,
         batch_size=batch_size,
         dataset_dir=DATASET_DIR,
@@ -103,7 +103,7 @@ def test_tf_pytorch_equality():
 
     batch_size = 10
     ds_tf = datasets.mnist(
-        split_type="test",
+        split="test",
         batch_size=batch_size,
         dataset_dir=DATASET_DIR,
         framework="tf",
@@ -114,7 +114,7 @@ def test_tf_pytorch_equality():
 
     ds_pytorch = iter(
         datasets.mnist(
-            split_type="test",
+            split="test",
             batch_size=batch_size,
             dataset_dir=DATASET_DIR,
             framework="pytorch",

--- a/tests/test_pytorch/test_pytorch_models.py
+++ b/tests/test_pytorch/test_pytorch_models.py
@@ -19,10 +19,10 @@ def test_pytorch_mnist():
     classifier = classifier_fn(model_kwargs={}, wrapper_kwargs={})
 
     train_dataset = datasets.mnist(
-        split_type="train", epochs=1, batch_size=600, dataset_dir=DATASET_DIR,
+        split="train", epochs=1, batch_size=600, dataset_dir=DATASET_DIR,
     )
     test_dataset = datasets.mnist(
-        split_type="test", epochs=1, batch_size=100, dataset_dir=DATASET_DIR,
+        split="test", epochs=1, batch_size=100, dataset_dir=DATASET_DIR,
     )
 
     classifier.fit_generator(
@@ -47,7 +47,7 @@ def test_pytorch_mnist_pretrained():
     )
 
     test_dataset = datasets.mnist(
-        split_type="test", epochs=1, batch_size=100, dataset_dir=DATASET_DIR,
+        split="test", epochs=1, batch_size=100, dataset_dir=DATASET_DIR,
     )
 
     accuracy = 0
@@ -65,10 +65,10 @@ def test_keras_cifar():
     classifier = classifier_fn(model_kwargs={}, wrapper_kwargs={})
 
     train_dataset = datasets.cifar10(
-        split_type="train", epochs=1, batch_size=500, dataset_dir=DATASET_DIR,
+        split="train", epochs=1, batch_size=500, dataset_dir=DATASET_DIR,
     )
     test_dataset = datasets.cifar10(
-        split_type="test", epochs=1, batch_size=100, dataset_dir=DATASET_DIR,
+        split="test", epochs=1, batch_size=100, dataset_dir=DATASET_DIR,
     )
 
     classifier.fit_generator(
@@ -104,7 +104,7 @@ def test_pytorch_xview_pretrained():
     test_dataset = load_dataset(
         dataset_config,
         epochs=1,
-        split_type="test",
+        split="test",
         num_batches=NUM_TEST_SAMPLES,
         shuffle_files=False,
     )

--- a/tests/test_tf1/test_framework_dataset.py
+++ b/tests/test_tf1/test_framework_dataset.py
@@ -12,7 +12,7 @@ DATASET_DIR = paths.DockerPaths().dataset_dir
 
 def test_tf_generator():
     dataset = datasets.mnist(
-        split_type="train",
+        split="train",
         epochs=1,
         batch_size=16,
         dataset_dir=DATASET_DIR,

--- a/tests/test_tf1/test_keras_models.py
+++ b/tests/test_tf1/test_keras_models.py
@@ -18,10 +18,10 @@ def test_keras_mnist():
     classifier = classifier_fn(model_kwargs={}, wrapper_kwargs={})
 
     train_dataset = datasets.mnist(
-        split_type="train", epochs=1, batch_size=600, dataset_dir=DATASET_DIR,
+        split="train", epochs=1, batch_size=600, dataset_dir=DATASET_DIR,
     )
     test_dataset = datasets.mnist(
-        split_type="test", epochs=1, batch_size=100, dataset_dir=DATASET_DIR,
+        split="test", epochs=1, batch_size=100, dataset_dir=DATASET_DIR,
     )
 
     classifier.fit_generator(
@@ -46,7 +46,7 @@ def test_keras_mnist_pretrained():
     )
 
     test_dataset = datasets.mnist(
-        split_type="test", epochs=1, batch_size=100, dataset_dir=DATASET_DIR,
+        split="test", epochs=1, batch_size=100, dataset_dir=DATASET_DIR,
     )
 
     accuracy = 0
@@ -64,10 +64,10 @@ def test_keras_cifar():
     classifier = classifier_fn(model_kwargs={}, wrapper_kwargs={})
 
     train_dataset = datasets.cifar10(
-        split_type="train", epochs=1, batch_size=500, dataset_dir=DATASET_DIR,
+        split="train", epochs=1, batch_size=500, dataset_dir=DATASET_DIR,
     )
     test_dataset = datasets.cifar10(
-        split_type="test", epochs=1, batch_size=100, dataset_dir=DATASET_DIR,
+        split="test", epochs=1, batch_size=100, dataset_dir=DATASET_DIR,
     )
 
     classifier.fit_generator(
@@ -92,7 +92,7 @@ def test_keras_imagenet():
     )
 
     dataset = adversarial_datasets.imagenet_adversarial(
-        split_type="adversarial", epochs=1, batch_size=100, dataset_dir=DATASET_DIR,
+        split="adversarial", epochs=1, batch_size=100, dataset_dir=DATASET_DIR,
     )
 
     accuracy_clean = 0
@@ -119,7 +119,7 @@ def test_keras_imagenet_transfer():
     )
 
     dataset = adversarial_datasets.imagenet_adversarial(
-        split_type="adversarial", epochs=1, batch_size=100, dataset_dir=DATASET_DIR,
+        split="adversarial", epochs=1, batch_size=100, dataset_dir=DATASET_DIR,
     )
     accuracy_clean = 0
     accuracy_adv = 0

--- a/tests/test_tf1/test_tf1_models.py
+++ b/tests/test_tf1/test_tf1_models.py
@@ -17,10 +17,10 @@ def test_tf1_mnist():
     classifier = classifier_fn(model_kwargs={}, wrapper_kwargs={})
 
     train_dataset = datasets.mnist(
-        split_type="train", epochs=1, batch_size=600, dataset_dir=DATASET_DIR,
+        split="train", epochs=1, batch_size=600, dataset_dir=DATASET_DIR,
     )
     test_dataset = datasets.mnist(
-        split_type="test", epochs=1, batch_size=100, dataset_dir=DATASET_DIR,
+        split="test", epochs=1, batch_size=100, dataset_dir=DATASET_DIR,
     )
 
     classifier.fit_generator(
@@ -42,7 +42,7 @@ def test_tf1_apricot():
     detector = detector_fn(model_kwargs={}, wrapper_kwargs={})
 
     test_dataset = adversarial_datasets.apricot_dev_adversarial(
-        split_type="adversarial",
+        split="adversarial",
         epochs=1,
         batch_size=1,
         dataset_dir=DATASET_DIR,


### PR DESCRIPTION
Fixes #871 

This PR does a few related things:
1) Renames "split_type" to "split" to make it clear that it is verbatim what is given to TFDS load (same kwarg name)
https://www.tensorflow.org/datasets/api_docs/python/tfds/load

2) Modifies scenarios so that configs can override the train and eval splits. This enables TFDS slicing operations on them such as `"test[:10]"` or `"train_clean100+train_clean360+train_other500"`:
https://www.tensorflow.org/datasets/splits#examples

3) Adds additional parsing of splits to enable individual indexing for a specific data point, such as "test[355]", and indexing based off of a list, "test[[1, 4, 5, 7, 9]]". Under the hood, these are translated to single-element slices. Advanced slicing operations involving a `step` parameter, such as "test[10:20:2]" are not permitted, and raise a NotImplementedError.