### PR TITLE
Split metrics when targeted attack is present

### DIFF
--- a/armory/scenarios/audio_asr.py
+++ b/armory/scenarios/audio_asr.py
@@ -85,9 +85,14 @@ class AutomaticSpeechRecognition(Scenario):
                 "this is not yet supported for speech recognition models."
             )
 
+        attack_config = config["attack"]
+        attack_type = attack_config.get("type")
+
+        targeted = bool(attack_config.get("targeted"))
         metrics_logger = metrics.MetricsLogger.from_config(
-            config["metric"], skip_benign=skip_benign
+            config["metric"], skip_benign=skip_benign, targeted=targeted
         )
+
         if config["dataset"]["batch_size"] != 1:
             logger.warning("Evaluation batch_size != 1 may not be supported.")
 
@@ -126,10 +131,6 @@ class AutomaticSpeechRecognition(Scenario):
         # Evaluate the ART estimator on adversarial test examples
         logger.info("Generating or loading / testing adversarial examples...")
 
-        attack_config = config["attack"]
-        attack_type = attack_config.get("type")
-
-        targeted = bool(attack_config.get("targeted"))
         if attack_type == "preloaded":
             test_data = load_adversarial_dataset(
                 attack_config,
@@ -175,6 +176,12 @@ class AutomaticSpeechRecognition(Scenario):
             x_adv.flags.writeable = False
             y_pred_adv = estimator.predict(x_adv, **predict_kwargs)
             metrics_logger.update_task(y, y_pred_adv, adversarial=True)
+            if targeted:
+                metrics_logger.update_task(
+                    y_target, y_pred_adv, adversarial=True, targeted=True,
+                )
             metrics_logger.update_perturbation(x, x_adv)
-        metrics_logger.log_task(adversarial=True, targeted=True)
+        metrics_logger.log_task(adversarial=True)
+        if targeted:
+            metrics_logger.log_task(adversarial=True, targeted=True)
         return metrics_logger.results()

--- a/armory/scenarios/audio_classification.py
+++ b/armory/scenarios/audio_classification.py
@@ -75,10 +75,14 @@ class AudioClassificationTask(Scenario):
             classifier = defense()
 
         classifier.set_learning_phase(False)
+        attack_config = config["attack"]
+        attack_type = attack_config.get("type")
 
+        targeted = bool(attack_config.get("kwargs", {}).get("targeted"))
         metrics_logger = metrics.MetricsLogger.from_config(
-            config["metric"], skip_benign=skip_benign
+            config["metric"], skip_benign=skip_benign, targeted=targeted
         )
+
         if config["dataset"]["batch_size"] != 1:
             logger.warning("Evaluation batch_size != 1 may not be supported.")
 
@@ -111,9 +115,6 @@ class AudioClassificationTask(Scenario):
         # Evaluate the ART classifier on adversarial test examples
         logger.info("Generating or loading / testing adversarial examples...")
 
-        attack_config = config["attack"]
-        attack_type = attack_config.get("type")
-        targeted = bool(attack_config.get("kwargs", {}).get("targeted"))
         if targeted and attack_config.get("use_label"):
             raise ValueError("Targeted attacks cannot have 'use_label'")
         if attack_type == "preloaded":
@@ -160,10 +161,13 @@ class AudioClassificationTask(Scenario):
             # Ensure that input sample isn't overwritten by classifier
             x_adv.flags.writeable = False
             y_pred_adv = classifier.predict(x_adv)
+            metrics_logger.update_task(y, y_pred_adv, adversarial=True)
             if targeted:
-                metrics_logger.update_task(y_target, y_pred_adv, adversarial=True)
-            else:
-                metrics_logger.update_task(y, y_pred_adv, adversarial=True)
+                metrics_logger.update_task(
+                    y_target, y_pred_adv, adversarial=True, targeted=True
+                )
             metrics_logger.update_perturbation(x, x_adv)
-        metrics_logger.log_task(adversarial=True, targeted=targeted)
+        metrics_logger.log_task(adversarial=True)
+        if targeted:
+            metrics_logger.log_task(adversarial=True, targeted=True)
         return metrics_logger.results()

--- a/armory/scenarios/outputs.py
+++ b/armory/scenarios/outputs.py
@@ -60,12 +60,16 @@ class Results:
                 self.mean_adversarial_task = self.results[
                     f"adversarial_mean_{self.task}"
                 ]
+                self.mean_targeted_task = self.results.get(
+                    f"targeted_mean_{self.task}", None
+                )
                 self.mean_perturbation = self.results[
                     f"perturbation_mean_{self.perturbation_metric}"
                 ]
             if self.record_metric_per_sample:
                 self.benign_task = self.results[f"benign_{self.task}"]
                 self.adversarial_task = self.results[f"adversarial_{self.task}"]
+                self.targeted_task = self.results.get(f"targeted_{self.task}", None)
                 self.perturbation = self.results[
                     f"perturbation_{self.perturbation_metric}"
                 ]
@@ -82,16 +86,21 @@ class Results:
     def from_mongo(cls, *args, **kwargs):
         raise NotImplementedError("mongo DB connector")
 
-    def perturbation_accuracy(self):
-        return perturbation_accuracy(
-            self.benign_task, self.adversarial_task, self.perturbation
-        )
+    def perturbation_accuracy(self, targeted):
+        if targeted:
+            return perturbation_accuracy(
+                self.benign_task, self.targeted_task, self.perturbation
+            )
+        else:
+            return perturbation_accuracy(
+                self.benign_task, self.adversarial_task, self.perturbation
+            )
 
-    def plot(self, filepath=None, max_epsilon=None):
+    def plot(self, filepath=None, max_epsilon=None, targeted=False):
         """
         Plot example. If filepath is None, show it, else save to filepath
         """
-        epsilons, acc = self.perturbation_accuracy()
+        epsilons, acc = self.perturbation_accuracy(targeted=targeted)
         if max_epsilon is None:
             max_epsilon = max(epsilons)
 

--- a/armory/scenarios/video_ucf101_scenario.py
+++ b/armory/scenarios/video_ucf101_scenario.py
@@ -83,9 +83,14 @@ class Ucf101(Scenario):
 
         classifier.set_learning_phase(False)
 
+        attack_config = config["attack"]
+        attack_type = attack_config.get("type")
+
+        targeted = bool(attack_config.get("kwargs", {}).get("targeted"))
         metrics_logger = metrics.MetricsLogger.from_config(
-            config["metric"], skip_benign=skip_benign
+            config["metric"], skip_benign=skip_benign, targeted=targeted
         )
+
         if config["dataset"]["batch_size"] != 1:
             logger.warning("Evaluation batch_size != 1 may not be supported.")
 
@@ -118,9 +123,6 @@ class Ucf101(Scenario):
         # Evaluate the ART classifier on adversarial test examples
         logger.info("Generating or loading / testing adversarial examples...")
 
-        attack_config = config["attack"]
-        attack_type = attack_config.get("type")
-        targeted = bool(attack_config.get("kwargs", {}).get("targeted"))
         if targeted and attack_config.get("use_label"):
             raise ValueError("Targeted attacks cannot have 'use_label'")
         if attack_type == "preloaded":
@@ -168,10 +170,13 @@ class Ucf101(Scenario):
             # Ensure that input sample isn't overwritten by classifier
             x_adv.flags.writeable = False
             y_pred_adv = classifier.predict(x_adv)
+            metrics_logger.update_task(y, y_pred_adv, adversarial=True)
             if targeted:
-                metrics_logger.update_task(y_target, y_pred_adv, adversarial=True)
-            else:
-                metrics_logger.update_task(y, y_pred_adv, adversarial=True)
+                metrics_logger.update_task(
+                    y_target, y_pred_adv, adversarial=True, targeted=True
+                )
             metrics_logger.update_perturbation(x, x_adv)
-        metrics_logger.log_task(adversarial=True, targeted=targeted)
+        metrics_logger.log_task(adversarial=True)
+        if targeted:
+            metrics_logger.log_task(adversarial=True, targeted=True)
         return metrics_logger.results()

--- a/armory/utils/metrics.py
+++ b/armory/utils/metrics.py
@@ -172,7 +172,12 @@ def word_error_rate(y, y_pred):
 
 
 def _word_error_rate(y_i, y_pred_i):
-    reference = y_i.decode("utf-8").split()
+    if isinstance(y_i, str):
+        reference = y_i.split()
+    elif isinstance(y_i, bytes):
+        reference = y_i.decode("utf-8").split()
+    else:
+        raise TypeError(f"y_i is of type {type(y_i)}, expected string or bytes")
     hypothesis = y_pred_i.split()
     r_length = len(reference)
     h_length = len(hypothesis)
@@ -937,6 +942,7 @@ class MetricsLogger:
         profiler_type=None,
         computational_resource_dict=None,
         skip_benign=None,
+        targeted=False,
         **kwargs,
     ):
         """
@@ -947,6 +953,7 @@ class MetricsLogger:
         """
         self.tasks = [] if skip_benign else self._generate_counters(task)
         self.adversarial_tasks = self._generate_counters(task)
+        self.targeted_tasks = self._generate_counters(task) if targeted else []
         self.perturbations = self._generate_counters(perturbation)
         self.means = bool(means)
         self.full = bool(record_metric_per_sample)
@@ -956,7 +963,12 @@ class MetricsLogger:
                 "No per-sample metric results will be produced. "
                 "To change this, set 'means' or 'record_metric_per_sample' to True."
             )
-        if not self.tasks and not self.perturbations and not self.adversarial_tasks:
+        if (
+            not self.tasks
+            and not self.perturbations
+            and not self.adversarial_tasks
+            and not self.targeted_tasks
+        ):
             logger.warning(
                 "No metric results will be produced. "
                 "To change this, set one or more 'task' or 'perturbation' metrics"
@@ -974,17 +986,25 @@ class MetricsLogger:
         return [MetricList(x) for x in names]
 
     @classmethod
-    def from_config(cls, config, skip_benign=None):
+    def from_config(cls, config, skip_benign=None, targeted=False):
         if skip_benign:
             config["skip_benign"] = skip_benign
-        return cls(**config)
+        return cls(**config, targeted=targeted)
 
     def clear(self):
         for metric in self.tasks + self.adversarial_tasks + self.perturbations:
             metric.clear()
 
-    def update_task(self, y, y_pred, adversarial=False):
-        tasks = self.adversarial_tasks if adversarial else self.tasks
+    def update_task(self, y, y_pred, adversarial=False, targeted=False):
+        if targeted and not adversarial:
+            raise ValueError("benign task cannot be targeted")
+        tasks = (
+            self.targeted_tasks
+            if targeted
+            else self.adversarial_tasks
+            if adversarial
+            else self.tasks
+        )
         for metric in tasks:
             if metric.name in [
                 "object_detection_AP_per_class",
@@ -999,29 +1019,33 @@ class MetricsLogger:
             metric.append(x, x_adv)
 
     def log_task(self, adversarial=False, targeted=False):
-        if adversarial:
+        if targeted:
+            if adversarial:
+                metrics = self.targeted_tasks
+                wrt = "target"
+                task_type = "adversarial"
+            else:
+                raise ValueError("benign task cannot be targeted")
+        elif adversarial:
             metrics = self.adversarial_tasks
+            wrt = "ground truth"
             task_type = "adversarial"
         else:
             metrics = self.tasks
+            wrt = "ground truth"
             task_type = "benign"
-        if targeted:
-            if adversarial:
-                task_type = "targeted " + task_type
-            else:
-                raise ValueError("benign task cannot be targeted")
 
         for metric in metrics:
             # Do not calculate mean WER, calcuate total WER
             if metric.name == "word_error_rate":
                 logger.info(
-                    f"Word error rate on {task_type} examples: "
+                    f"Word error rate on {task_type} examples relative to {wrt} labels: "
                     f"{metric.total_wer():.2%}"
                 )
             elif metric.name == "object_detection_AP_per_class":
                 average_precision_by_class = metric.AP_per_class()
                 logger.info(
-                    f"object_detection_mAP on {task_type} examples: "
+                    f"object_detection_mAP on {task_type} examples relative to {wrt} labels: "
                     f"{np.fromiter(average_precision_by_class.values(), dtype=float).mean():.2%}."
                     f" object_detection_AP by class ID: {average_precision_by_class}"
                 )
@@ -1036,7 +1060,7 @@ class MetricsLogger:
                 )
             else:
                 logger.info(
-                    f"Average {metric.name} on {task_type} test examples: "
+                    f"Average {metric.name} on {task_type} test examples relative to {wrt} labels: "
                     f"{metric.mean():.2%}"
                 )
 
@@ -1048,6 +1072,7 @@ class MetricsLogger:
         for metrics, prefix in [
             (self.tasks, "benign"),
             (self.adversarial_tasks, "adversarial"),
+            (self.targeted_tasks, "targeted"),
             (self.perturbations, "perturbation"),
         ]:
             for metric in metrics:

--- a/armory/utils/metrics.py
+++ b/armory/utils/metrics.py
@@ -991,7 +991,7 @@ class MetricsLogger:
         return [MetricList(x) for x in names]
 
     @classmethod
-    def from_config(cls, config, skip_benign=None, skip_attack=None):
+    def from_config(cls, config, skip_benign=None, skip_attack=None, targeted=None):
         if skip_benign:
             config["skip_benign"] = skip_benign
         if skip_attack:

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -39,3 +39,7 @@ is a JSON-able dict.
 
 We have implemented the metrics in numpy, instead of using framework-specific 
 metrics, to prevent expanding the required set of dependencies.
+
+### Targeted vs. Untargeted Attacks
+
+For targeted attacks, each metric will be reported twice for adversarial data: once relative to the ground truth labels and once relative to the target labels.  For untargeted attacks, each metric is only reported relative to the ground truth labels.  Performance relative to ground truth measures the effectiveness of the defense, indicating the ability of the model to make correct predictions despite the perturbed input.  Performance relative to target labels measures the effectiveness of the attack, indicating the ability of the attacker to force the model to make predictions that are not only incorrect, but that align with the attackers chosen output.


### PR DESCRIPTION
Closes #848 

For targeted attacks, this will now compute the selected metrics two different ways:

1. Relative to the ground truth labels (i.e. a measure of the effectiveness of the defense).
2. Relative to the target labels (i.e. a measure of the effectiveness of the attack).

For untargeted attacks, only the first metric is computed.  We could compute the second metric in some cases, such as `1-accuracy` for classification problems, but the desired behavior is less obvious for other problem types (e.g. object detection).

