### PR TITLE
UCF101 shape bug

### DIFF
--- a/armory/data/datasets.py
+++ b/armory/data/datasets.py
@@ -434,7 +434,7 @@ cifar10_context = ImageContext(x_shape=(32, 32, 3))
 resisc45_context = ImageContext(x_shape=(256, 256, 3))
 imagenette_context = ImageContext(x_shape=(None, None, 3))
 xview_context = ImageContext(x_shape=(None, None, 3))
-ucf101_context = VideoContext(x_shape=(None, 240, 320, 3), frame_rate=25)
+ucf101_context = VideoContext(x_shape=(None, None, None, 3), frame_rate=25)
 
 
 def mnist_canonical_preprocessing(batch):

--- a/docs/datasets.md
+++ b/docs/datasets.md
@@ -39,7 +39,10 @@ These tfrecord files will be pulled from S3 if not available on your
 ### Video Datasets
 | Dataset    | Description | x_shape | x_dtype  | y_shape  | y_dtype | splits |
 |:----------: |:-----------: |:-------: |:--------: |:--------: |:-------: |:------: |
-| [ucf101](https://www.crcv.ucf.edu/data/UCF101.php) | UCF 101 Action Recognition | (N, variable_frames, 240, 320, 3) | float32 | (N,) | int64 | train, test |
+| [ucf101](https://www.crcv.ucf.edu/data/UCF101.php) | UCF 101 Action Recognition | (N, variable_frames, None, None, 3) | float32 | (N,) | int64 | train, test |
+
+NOTE: The dimension of UCF101 videos is `(N, variable_frames, 240, 320, 3)` for the entire training set and all of the test set except for 4 examples.
+For those, the dimensions are `(N, variable_frames, 226, 400, 3)`. If not shuffled, these correspond to (0-indexed) examples 333, 694, 1343, and 3218.
 
 <br>
 

--- a/scenario_configs/ucf101_baseline_finetune.json
+++ b/scenario_configs/ucf101_baseline_finetune.json
@@ -34,7 +34,7 @@
     "model": {
         "fit": true,
         "fit_kwargs": {
-            "fit_batch_size": 16,
+            "fit_batch_size": 2,
             "nb_epochs": 10
         },
         "model_kwargs": {

--- a/scenario_configs/ucf101_baseline_finetune.json
+++ b/scenario_configs/ucf101_baseline_finetune.json
@@ -34,7 +34,7 @@
     "model": {
         "fit": true,
         "fit_kwargs": {
-            "fit_batch_size": 2,
+            "fit_batch_size": 16,
             "nb_epochs": 10
         },
         "model_kwargs": {


### PR DESCRIPTION
Fixes #843 

Updates the dataset canonical preprocessing and mars-specific preprocessing to handle the 4 test samples of shape 226x400 (the rest are 240x320).