### PR TITLE
SNR: remove constraint on 1D inputs

### DIFF
--- a/armory/utils/metrics.py
+++ b/armory/utils/metrics.py
@@ -133,8 +133,6 @@ def _snr(x_i, x_adv_i):
     x_adv_i = np.asarray(x_adv_i, dtype=float)
     if x_i.shape != x_adv_i.shape:
         raise ValueError(f"x_i.shape {x_i.shape} != x_adv_i.shape {x_adv_i.shape}")
-    elif x_i.ndim != 1:
-        raise ValueError("_snr input must be single dimensional (not multichannel)")
     signal_power = (x_i ** 2).mean()
     noise_power = ((x_i - x_adv_i) ** 2).mean()
     return signal_power / noise_power


### PR DESCRIPTION
Fixes #934

Let me know if this is what you're thinking. To test, try:
```
>>> from armory.utils import metrics
>>> import numpy as np
>>> metrics.snr(*[np.random.random((1, 400)) for i in range(2)]). # 1D inputs
[2.1268499851463973]
>>> metrics.snr(*[np.random.random((1, 20, 20, 3)) for i in range(2)]) # 3-channel image inputs
[2.0411371110126844]
```

It should work for any shape so long as the values are comparable.