### PR TITLE
allow manual execution of ci-test workflow

### DIFF
--- a/.github/workflows/ci_test.yml
+++ b/.github/workflows/ci_test.yml
@@ -9,6 +9,8 @@ on:
   pull_request:
     branches:
       - master
+  
+  workflow_dispatch:
 
 env:
   DOCKER_BUILDKIT: 1

--- a/.github/workflows/ci_test.yml
+++ b/.github/workflows/ci_test.yml
@@ -9,7 +9,7 @@ on:
   pull_request:
     branches:
       - master
-  
+
   workflow_dispatch:
 
 env:


### PR DESCRIPTION
flag ci_test workflow to allow manual execution

see https://docs.github.com/en/actions/managing-workflow-runs/manually-running-a-workflow to run once this is merged