### PR TITLE
add indexing to datasets

### DIFF
--- a/armory/data/adversarial_datasets.py
+++ b/armory/data/adversarial_datasets.py
@@ -68,6 +68,7 @@ def imagenet_adversarial(
     adversarial_key: str = "adversarial",
     targeted: bool = False,
     shuffle_files: bool = False,
+    **kwargs,
 ) -> datasets.ArmoryDataGenerator:
     """
     ILSVRC12 adversarial image dataset for ResNet50
@@ -97,6 +98,7 @@ def imagenet_adversarial(
         framework=framework,
         lambda_map=lambda x, y: ((x[clean_key], x[adversarial_key]), y),
         context=imagenet_adversarial_context,
+        **kwargs,
     )
 
 
@@ -112,6 +114,7 @@ def librispeech_adversarial(
     adversarial_key: str = "adversarial_perturbation",
     targeted: bool = False,
     shuffle_files: bool = False,
+    **kwargs,
 ) -> datasets.ArmoryDataGenerator:
     """
     Adversarial dataset based on Librispeech-dev-clean including clean,
@@ -145,6 +148,7 @@ def librispeech_adversarial(
         framework=framework,
         lambda_map=lambda x, y: ((x[clean_key], x[adversarial_key]), y),
         context=librispeech_adversarial_context,
+        **kwargs,
     )
 
 
@@ -160,6 +164,7 @@ def resisc45_adversarial_224x224(
     adversarial_key: str = "adversarial_univperturbation",
     targeted: bool = False,
     shuffle_files: bool = False,
+    **kwargs,
 ) -> datasets.ArmoryDataGenerator:
     """
     resisc45 Adversarial Dataset of size (224, 224, 3),
@@ -201,6 +206,7 @@ def resisc45_adversarial_224x224(
         framework=framework,
         lambda_map=lambda_map,
         context=resisc45_adversarial_context,
+        **kwargs,
     )
 
 
@@ -216,6 +222,7 @@ def ucf101_adversarial_112x112(
     adversarial_key: str = "adversarial_perturbation",
     targeted: bool = False,
     shuffle_files: bool = False,
+    **kwargs,
 ) -> datasets.ArmoryDataGenerator:
     """
     UCF 101 Adversarial Dataset of size (112, 112, 3),
@@ -259,6 +266,7 @@ def ucf101_adversarial_112x112(
         framework=framework,
         lambda_map=lambda_map,
         context=ucf101_adversarial_context,
+        **kwargs,
     )
 
 
@@ -273,6 +281,7 @@ def gtsrb_poison(
     clean_key: str = None,
     adversarial_key: str = None,
     shuffle_files: bool = False,
+    **kwargs,
 ) -> datasets.ArmoryDataGenerator:
     """
     German traffic sign poison dataset of size (48, 48, 3),
@@ -294,6 +303,7 @@ def gtsrb_poison(
         cache_dataset=cache_dataset,
         framework=framework,
         lambda_map=lambda x, y: (x, y),
+        **kwargs,
     )
 
 
@@ -317,6 +327,7 @@ def apricot_dev_adversarial(
     cache_dataset: bool = True,
     framework: str = "numpy",
     shuffle_files: bool = False,
+    **kwargs,
 ) -> datasets.ArmoryDataGenerator:
     if batch_size != 1:
         raise NotImplementedError("Currently working only with batch size = 1")
@@ -360,6 +371,7 @@ def apricot_dev_adversarial(
             ),
         ),
         context=apricot_adversarial_context,
+        **kwargs,
     )
 
 
@@ -373,6 +385,7 @@ def apricot_test_adversarial(
     cache_dataset: bool = True,
     framework: str = "numpy",
     shuffle_files: bool = False,
+    **kwargs,
 ) -> datasets.ArmoryDataGenerator:
     if batch_size != 1:
         raise NotImplementedError("Currently working only with batch size = 1")
@@ -416,4 +429,5 @@ def apricot_test_adversarial(
             ),
         ),
         context=apricot_adversarial_context,
+        **kwargs,
     )

--- a/armory/data/datasets.py
+++ b/armory/data/datasets.py
@@ -288,7 +288,7 @@ def filter_by_index(dataset: "tf.data.Dataset", index: list, dataset_size: int):
     def enum_index(i, x):
         i = tf.expand_dims(i, 0)
         out, _ = tf.raw_ops.ListDiff(x=i, y=index_tensor, out_idx=tf.int64)
-        return tf.size(out) == 0
+        return tf.equal(tf.size(out), 0)
 
     return dataset.enumerate().filter(enum_index).map(lambda i, x: x), indexed_size
 

--- a/armory/data/datasets.py
+++ b/armory/data/datasets.py
@@ -287,6 +287,7 @@ def _generator_from_tfds(
     framework: str = "numpy",
     lambda_map: Callable = None,
     context=None,
+    index=None,
 ) -> Union[ArmoryDataGenerator, tf.data.Dataset]:
     """
     If as_supervised=False, must designate keys as a tuple in supervised_xy_keys:
@@ -362,6 +363,18 @@ def _generator_from_tfds(
             ds = ds.map(lambda x: (x[x_key], x[y_key]))
     if lambda_map is not None:
         ds = ds.map(lambda_map)
+
+    # Add index-based filtering
+    if index is not None:
+        # TODO: handle case when index is a string or slice (not a numeric list)
+        index_tensor = tf.constant(index, dtype=tf.int64)
+
+        def enum_index(i, x):
+            i = tf.expand_dims(i, 0)
+            out, _ = tf.raw_ops.ListDiff(x=i, y=index_tensor, out_idx=tf.int64)
+            return tf.size(out) == 0
+
+        ds = ds.enumerate().filter(enum_index).map(lambda i, x: x)
 
     ds = ds.repeat(epochs)
     if shuffle_files:
@@ -631,6 +644,7 @@ def mnist(
     cache_dataset: bool = True,
     framework: str = "numpy",
     shuffle_files: bool = True,
+    **kwargs,
 ) -> ArmoryDataGenerator:
     """
     Handwritten digits dataset:
@@ -649,6 +663,7 @@ def mnist(
         framework=framework,
         shuffle_files=shuffle_files,
         context=mnist_context,
+        **kwargs,
     )
 
 
@@ -662,6 +677,7 @@ def cifar10(
     cache_dataset: bool = True,
     framework: str = "numpy",
     shuffle_files: bool = True,
+    **kwargs,
 ) -> ArmoryDataGenerator:
     """
     Ten class image dataset:
@@ -680,6 +696,7 @@ def cifar10(
         framework=framework,
         shuffle_files=shuffle_files,
         context=cifar10_context,
+        **kwargs,
     )
 
 
@@ -693,6 +710,7 @@ def digit(
     cache_dataset: bool = True,
     framework: str = "numpy",
     shuffle_files: bool = True,
+    **kwargs,
 ) -> ArmoryDataGenerator:
     """
     An audio dataset of spoken digits:
@@ -712,6 +730,7 @@ def digit(
         framework=framework,
         shuffle_files=shuffle_files,
         context=digit_context,
+        **kwargs,
     )
 
 
@@ -725,6 +744,7 @@ def imagenette(
     cache_dataset: bool = True,
     framework: str = "numpy",
     shuffle_files: bool = True,
+    **kwargs,
 ) -> ArmoryDataGenerator:
     """
     Smaller subset of 10 classes of Imagenet
@@ -744,6 +764,7 @@ def imagenette(
         framework=framework,
         shuffle_files=shuffle_files,
         context=imagenette_context,
+        **kwargs,
     )
 
 
@@ -756,6 +777,7 @@ def german_traffic_sign(
     cache_dataset: bool = True,
     framework: str = "numpy",
     shuffle_files: bool = True,
+    **kwargs,
 ) -> ArmoryDataGenerator:
     """
     German traffic sign dataset with 43 classes and over 50,000 images.
@@ -772,6 +794,7 @@ def german_traffic_sign(
         framework=framework,
         shuffle_files=shuffle_files,
         context=gtsrb_context,
+        **kwargs,
     )
 
 
@@ -785,6 +808,7 @@ def librispeech_dev_clean(
     cache_dataset: bool = True,
     framework: str = "numpy",
     shuffle_files: bool = True,
+    **kwargs,
 ):
     """
     Librispeech dev dataset with custom split used for speaker
@@ -815,6 +839,7 @@ def librispeech_dev_clean(
         framework=framework,
         shuffle_files=shuffle_files,
         context=librispeech_dev_clean_context,
+        **kwargs,
     )
 
 
@@ -828,6 +853,7 @@ def librispeech_full(
     cache_dataset: bool = True,
     framework: str = "numpy",
     shuffle_files: bool = True,
+    **kwargs,
 ) -> ArmoryDataGenerator:
     preprocessing_fn = preprocessing_chain(preprocessing_fn, fit_preprocessing_fn)
 
@@ -843,6 +869,7 @@ def librispeech_full(
         framework=framework,
         shuffle_files=shuffle_files,
         context=librispeech_context,
+        **kwargs,
     )
 
 
@@ -856,6 +883,7 @@ def librispeech(
     cache_dataset: bool = True,
     framework: str = "numpy",
     shuffle_files: bool = True,
+    **kwargs,
 ) -> ArmoryDataGenerator:
     flags = []
     dl_config = tfds.download.DownloadConfig(
@@ -888,6 +916,7 @@ def librispeech(
         framework=framework,
         shuffle_files=shuffle_files,
         context=librispeech_context,
+        **kwargs,
     )
 
 
@@ -901,6 +930,7 @@ def librispeech_dev_clean_asr(
     cache_dataset: bool = True,
     framework: str = "numpy",
     shuffle_files: bool = True,
+    **kwargs,
 ):
     """
     Librispeech dev dataset with custom split used for automatic
@@ -933,6 +963,7 @@ def librispeech_dev_clean_asr(
         framework=framework,
         shuffle_files=shuffle_files,
         context=librispeech_dev_clean_context,
+        **kwargs,
     )
 
 
@@ -946,6 +977,7 @@ def resisc45(
     cache_dataset: bool = True,
     framework: str = "numpy",
     shuffle_files: bool = True,
+    **kwargs,
 ) -> ArmoryDataGenerator:
     """
     REmote Sensing Image Scene Classification (RESISC) dataset
@@ -975,6 +1007,7 @@ def resisc45(
         framework=framework,
         shuffle_files=shuffle_files,
         context=resisc45_context,
+        **kwargs,
     )
 
 
@@ -988,6 +1021,7 @@ def ucf101(
     cache_dataset: bool = True,
     framework: str = "numpy",
     shuffle_files: bool = True,
+    **kwargs,
 ) -> ArmoryDataGenerator:
     """
     UCF 101 Action Recognition Dataset
@@ -1009,6 +1043,7 @@ def ucf101(
         framework=framework,
         shuffle_files=shuffle_files,
         context=ucf101_context,
+        **kwargs,
     )
 
 
@@ -1022,6 +1057,7 @@ def ucf101_clean(
     cache_dataset: bool = True,
     framework: str = "numpy",
     shuffle_files: bool = True,
+    **kwargs,
 ) -> ArmoryDataGenerator:
     """
     UCF 101 Action Recognition Dataset with high quality MPEG extraction
@@ -1043,6 +1079,7 @@ def ucf101_clean(
         framework=framework,
         shuffle_files=shuffle_files,
         context=ucf101_context,
+        **kwargs,
     )
 
 
@@ -1080,6 +1117,7 @@ def xview(
     cache_dataset: bool = True,
     framework: str = "numpy",
     shuffle_files: bool = True,
+    **kwargs,
 ) -> ArmoryDataGenerator:
     """
     split - one of ("train", "test")
@@ -1106,6 +1144,7 @@ def xview(
         framework=framework,
         shuffle_files=shuffle_files,
         context=xview_context,
+        **kwargs,
     )
 
 
@@ -1161,6 +1200,7 @@ def so2sat(
     cache_dataset: bool = True,
     framework: str = "numpy",
     shuffle_files: bool = True,
+    **kwargs,
 ) -> ArmoryDataGenerator:
     """
     Multimodal SAR / EO image dataset
@@ -1181,6 +1221,7 @@ def so2sat(
         framework=framework,
         shuffle_files=shuffle_files,
         context=so2sat_context,
+        **kwargs,
     )
 
 

--- a/armory/utils/config_loading.py
+++ b/armory/utils/config_loading.py
@@ -56,6 +56,8 @@ def load_dataset(dataset_config, *args, num_batches=None, **kwargs):
     dataset_module = import_module(dataset_config["module"])
     dataset_fn = getattr(dataset_module, dataset_config["name"])
     batch_size = dataset_config["batch_size"]
+    if "index" not in kwargs and "index" in dataset_config:
+        kwargs["index"] = dataset_config["index"]
     framework = dataset_config.get("framework", "numpy")
     dataset = dataset_fn(batch_size=batch_size, framework=framework, *args, **kwargs)
     if not isinstance(dataset, ArmoryDataGenerator):

--- a/docs/configuration_files.md
+++ b/docs/configuration_files.md
@@ -28,6 +28,7 @@ All configuration files are verified against the jsonschema definition at run ti
     framework: [String] Framework to return Tensors in. <`tf`|`pytorch`|`numpy`>. `numpy` by default.
     train_split: [Optional String] Training split in dataset. Typically defaults to `train`. Can use fancy slicing via [TFDS slicing API](https://www.tensorflow.org/datasets/splits#slicing_api)
     eval_split: [Optional String] Eval split in dataset. Typically defaults to `test`. Can use fancy slicing via [TFDS slicing API](https://www.tensorflow.org/datasets/splits#slicing_api)
+    index: [Optional String or Object] Index into the post-sorted eval dataset. Can use a numeric list like [1, 5, 7] or a simple slice as a string, like "[3:6]" or ":100".
   }
 `defense`: [Object or null]
   {

--- a/tests/test_docker/test_dataset.py
+++ b/tests/test_docker/test_dataset.py
@@ -52,6 +52,78 @@ def test_parse_split_index():
         datasets.parse_split_index("test[10:20:2]")
 
 
+def test_parse_str_slice():
+    for x, y in [
+        ("[2:5]", (2, 5)),
+        ("[:5]", (None, 5)),
+        ("[6:]", (6, None)),
+        ("[[5: 7] ", (5, 7)),
+        (":3", (None, 3)),
+        ("4:5", (4, 5)),
+    ]:
+        assert datasets.parse_str_slice(x) == y
+
+    for x in ("[::3]", "[5:-1]", "-10:", "3:3", "4:3"):
+        with pytest.raises(ValueError):
+            datasets.parse_str_slice(x)
+
+
+def test_filter_by_index():
+    ds = datasets.mnist(
+        "test", shuffle_files=False, preprocessing_fn=None, framework="tf"
+    )
+    dataset_size = 10000
+
+    for index in ([], [-4, 5, 6], ["1:3"]):
+        with pytest.raises(ValueError):
+            datasets.filter_by_index(ds, index, dataset_size)
+
+    ds = datasets.mnist("test", shuffle_files=False, preprocessing_fn=None)
+    assert ds.size == dataset_size
+    ys = np.hstack([next(ds)[1] for i in range(10)])  # first 10 labels
+
+    for index in (
+        [1, 3, 6, 5],
+        [0],
+        [6, 7, 8, 9, 9, 8, 7, 6],
+        list(range(10)),
+    ):
+        ds = datasets.mnist(
+            "test", shuffle_files=False, preprocessing_fn=None, index=index
+        )
+        index = sorted(set(index))
+        assert ds.size == len(index)
+        ys_index = np.hstack([y for (x, y) in ds])
+        # ys_index = np.hstack([next(ds)[1] for i in range(len(index))])
+        assert (ys[index] == ys_index).all()
+
+
+def test_filter_by_str_slice():
+    ds = datasets.mnist(
+        "test", shuffle_files=False, preprocessing_fn=None, framework="tf"
+    )
+    dataset_size = 10000
+
+    with pytest.raises(ValueError):
+        datasets.filter_by_str_slice(ds, "[10000:]", dataset_size)
+
+    ds = datasets.mnist("test", shuffle_files=False, preprocessing_fn=None)
+    assert ds.size == dataset_size
+    ys = np.hstack([next(ds)[1] for i in range(10)])  # first 10 labels
+
+    for index, target in (
+        ("[:5]", ys[:5]),
+        ("[3:8]", ys[3:8]),
+        ("[0:5]", ys[0:5]),
+    ):
+        ds = datasets.mnist(
+            "test", shuffle_files=False, preprocessing_fn=None, index=index
+        )
+        assert ds.size == len(target)
+        ys_index = np.hstack([y for (x, y) in ds])
+        assert (target == ys_index).all()
+
+
 def test_parse_split_index_ordering():
     """
     Ensure that output order is deterministic for multiple splits


### PR DESCRIPTION
Currently, you can add a numeric index to loading a dataset, like this:
```
import logging
import coloredlogs
coloredlogs.install(logging.DEBUG)
import numpy as np
from armory.data import datasets
ds = datasets.mnist("test", shuffle_files=False, index=None)
print(np.hstack([next(ds)[1] for i in range(10)]))
# [2 0 4 8 7 6 0 6 3 1]
ds = datasets.mnist("test", shuffle_files=False, index=[1, 3, 5, 7, 9])
print(np.hstack([next(ds)[1] for i in range(5)]))
# [0 8 6 6 1]
```

I need to check to make sure that:
- [x] this works with config files
- [x] enable handling of simple slices
- [x] update documentation
- [x] update ArmoryDataGenerator size
- [x] Add tests

I'd be happy for any thoughts at this point.