### PR TITLE
unify sysconfig and command line directives

### DIFF
--- a/armory/__main__.py
+++ b/armory/__main__.py
@@ -21,6 +21,7 @@ from jsonschema import ValidationError
 
 import armory
 from armory import paths
+from armory import arguments
 from armory.configuration import load_global_config, save_config
 from armory.eval import Evaluator
 from armory.docker import images
@@ -130,17 +131,13 @@ def _port(parser):
 
 def _no_gpu(parser):
     parser.add_argument(
-        "--no-gpu",
-        action="store_true",
-        help="Whether to not use GPU(s)",
+        "--no-gpu", action="store_true", help="Whether to not use GPU(s)",
     )
 
 
 def _use_gpu(parser):
     parser.add_argument(
-        "--use-gpu",
-        action="store_true",
-        help="Whether to use GPU(s)",
+        "--use-gpu", action="store_true", help="Whether to use GPU(s)",
     )
 
 
@@ -191,9 +188,7 @@ def _no_docker(parser):
 
 def _root(parser):
     parser.add_argument(
-        "--root",
-        action="store_true",
-        help="Whether to run docker as root",
+        "--root", action="store_true", help="Whether to run docker as root",
     )
 
 
@@ -227,62 +222,6 @@ def _set_outputs(config, output_dir, output_filename):
         config["sysconfig"]["output_filename"] = output_filename
 
 
-def _merge_config_and_args(config, args):
-    """
-    Override members of config if specified as args. The config dict is mutated.
-    Members in config are percolated into args to act as if they were specified.
-    Members of args that are not in config are put there so that the output
-    accurately records what was run. The args namespace is mutated.
-    The precedence becomes defaults < config block < command args.
-    """
-
-    # TODO: this pierces the argparse.__dict__ member in order to fake a parsed
-    # command argument it can likely be made cleaner with more complexity
-
-    sysconfig = config["sysconfig"]
-    logger.debug("_merge_config_and_args sysconfig %s", sysconfig)
-    logger.debug("_merge_config_and_args args %s", args)
-
-    # TODO: this list will get out of sync as options are added; find a way
-    # to read them out of the argparse parser
-    names = (
-        "interactive jupyter port no_docker root output_dir "
-        "output_filename check num_eval_batches skip_benign skip_attack "
-        "skip_misclassified validate_config"
-    ).split()
-
-    # the truth table is complicated because they are actually tri-states:
-    # undef, defined but falsy, defined and truthy
-    #
-    # config    args    action
-    # u         u       nothing
-    # f         u       nothing
-    # d         u       args <- config
-    # u         f       nothing
-    # f         f       nothing
-    # d         f       args <- config
-    # u         d       config <- args
-    # f         d       config <- args
-    # d         d       config <- args
-
-    command = vars(args)  # a dict view of args namespace
-    for name in names:
-        if name in sysconfig:
-            logger.debug("sysconfig specifies %s %s", name, sysconfig[name])
-            if name not in command:
-                logger.debug("sysconfig faking arg %s %s", name, sysconfig[name])
-                args.__dict__[name] = sysconfig[name]
-        if name in command and command[name]:
-            logger.debug("command line overrides %s %s", name, command[name])
-            sysconfig[name] = command[name]
-        else:
-            # it is completely legal for name to be in neither
-            pass
-
-    logger.debug("sysconfig is now %s", sysconfig)
-    logger.debug("args is now %s", args)
-
-
 # Commands
 
 
@@ -304,9 +243,7 @@ def run(command_args, prog, description):
     _no_docker(parser)
     _root(parser)
     parser.add_argument(
-        "--output-dir",
-        type=str,
-        help="Override of default output directory prefix",
+        "--output-dir", type=str, help="Override of default output directory prefix",
     )
     parser.add_argument(
         "--output-filename",
@@ -373,7 +310,9 @@ def run(command_args, prog, description):
         sys.exit(1)
     _set_gpus(config, args.use_gpu, args.no_gpu, args.gpus)
     _set_outputs(config, args.output_dir, args.output_filename)
-    _merge_config_and_args(config, args)
+    logging.debug("unifying sysconfig %s and args %s", config["sysconfig"], args)
+    (config, args) = arguments.merge_config_and_args(config, args)
+    logging.debug("unified sysconfig %s and args %s", config["sysconfig"], args)
 
     rig = Evaluator(config, no_docker=args.no_docker, root=args.root)
     exit_code = rig.run(
@@ -677,7 +616,7 @@ def launch(command_args, prog, description):
 
     config = {"sysconfig": {"docker_image": args.docker_image}}
     _set_gpus(config, args.use_gpu, args.no_gpu, args.gpus)
-    _merge_config_and_args(config, args)
+    (config, args) = arguments.merge_config_and_args(config, args)
 
     rig = Evaluator(config, root=args.root)
     exit_code = rig.run(
@@ -721,7 +660,7 @@ def exec(command_args, prog, description):
     config = {"sysconfig": {"docker_image": args.docker_image}}
     # Config
     _set_gpus(config, args.use_gpu, args.no_gpu, args.gpus)
-    _merge_config_and_args(config, args)
+    (config, args) = arguments.merge_config_and_args(config, args)
 
     rig = Evaluator(config, root=args.root)
     exit_code = rig.run(command=command)
@@ -775,11 +714,7 @@ def main():
 
     parser = argparse.ArgumentParser(prog="armory", usage=usage())
     parser.add_argument(
-        "command",
-        metavar="<command>",
-        type=str,
-        help="armory command",
-        action=Command,
+        "command", metavar="<command>", type=str, help="armory command", action=Command,
     )
     args = parser.parse_args(sys.argv[1:2])
 

--- a/armory/arguments.py
+++ b/armory/arguments.py
@@ -1,0 +1,62 @@
+"""
+Handling of command line arguments and other configuration.
+"""
+
+import argparse
+
+
+def merge_config_and_args(config, args):
+    """
+    Override members of config if specified as args. The config dict is mutated.
+    Members in config are percolated into args to act as if they were specified.
+    Members of args that are not in config are put there so that the output
+    accurately records what was run. Returns a modified config and a newly
+    created args.
+    The precedence becomes defaults < config block < command args.
+    """
+
+    sysconfig = config["sysconfig"]
+
+    # TODO: this list will get out of sync as options are added; find a way
+    # to read them out of the argparse parser
+    names = (
+        "interactive jupyter port no_docker root output_dir "
+        "output_filename check num_eval_batches skip_benign skip_attack "
+        "skip_misclassified validate_config"
+    ).split()
+
+    # the truth table is complicated because they are actually tri-states:
+    # undef, defined but falsy, defined and truthy
+    #
+    # config    args    action
+    # u         u       nothing
+    # f         u       nothing
+    # d         u       args <- config
+    # u         f       nothing
+    # f         f       nothing
+    # d         f       args <- config
+    # u         d       config <- args
+    # f         d       config <- args
+    # d         d       config <- args
+
+    # find truthy config specifications
+    new_spec = {}
+    for name in sysconfig:
+        if sysconfig[name]:
+            new_spec[name] = sysconfig[name]
+
+    # find truthy args specifications, overwriting config if present
+    specified = vars(args)
+    for name in specified:
+        if specified[name]:
+            new_spec[name] = specified[name]
+
+    # sysconfig gets updated with prioritized union
+    sysconfig.update(new_spec)
+
+    # new_args now gets the original namespace and all truthy members of the prioritized
+    # union
+    specified.update(new_spec)
+    new_args = argparse.Namespace(**specified)
+
+    return config, new_args

--- a/armory/arguments.py
+++ b/armory/arguments.py
@@ -17,14 +17,6 @@ def merge_config_and_args(config, args):
 
     sysconfig = config["sysconfig"]
 
-    # TODO: this list will get out of sync as options are added; find a way
-    # to read them out of the argparse parser
-    names = (
-        "interactive jupyter port no_docker root output_dir "
-        "output_filename check num_eval_batches skip_benign skip_attack "
-        "skip_misclassified validate_config"
-    ).split()
-
     # the truth table is complicated because they are actually tri-states:
     # undef, defined but falsy, defined and truthy
     #

--- a/armory/arguments.py
+++ b/armory/arguments.py
@@ -15,20 +15,6 @@ def merge_config_and_args(config, args):
     The precedence becomes defaults < config block < command args.
     """
 
-    # the truth table is complicated because they are actually tri-states:
-    # undef, defined but falsy, defined and truthy
-    #
-    # config    args    action
-    # u         u       nothing
-    # f         u       nothing
-    # t         u       args <- config
-    # u         f       nothing
-    # f         f       nothing
-    # t         f       args <- config
-    # u         t       config <- args
-    # f         t       config <- args
-    # t         t       config <- args
-
     # find truthy sysconfig specifications
     sysconf = config["sysconfig"]
     new_spec = {name: sysconf[name] for name in sysconf if sysconf[name]}

--- a/docs/command_line.md
+++ b/docs/command_line.md
@@ -106,3 +106,13 @@ benign sample rather than running an attack. Note: the following criteria must b
 ```
 armory run scenario_configs/mnist_baseline.json --skip-misclassified
 ```
+
+## command line arguments and sysconfig
+
+For convenience, command line control arguments can be specified in the "sysconfig"
+block of an evaluation configuration. Adding control to the configuration is
+described in [Configuration Files][conf]. Command line arguments will override
+sysconfig specifications.
+
+
+  [conf]: configuration_files.md#sysconfig-and-command-line-arguments

--- a/docs/configuration_files.md
+++ b/docs/configuration_files.md
@@ -148,3 +148,32 @@ field of the configuration file under the subfield "defense_model," with the num
 epochs of training under the subfield "defense_model_train_epochs." A concrete example
 of a configuration with this field is available in the armory-example
 [repo](https://github.com/twosixlabs/armory-example/tree/master/example_scenario_configs).
+
+### sysconfig and command line arguments
+
+Parameters specified in the "sysconfig" block will be treated as if they were passed
+as arguments to `armory` for example a configuration block like
+```json
+{
+  "sysconfig": {
+    "num_eval_batches": 5,
+    "skip_benign": true
+  }
+}
+```
+will cause armory to act as if you had run it as
+```
+armory run scenario.json --num-eval-batches 5 --skip-benign
+```
+However, arguments actually specified on the command line will take precedence,
+so if you execute, using the same configuration file
+```
+armory run scenario.json --num-eval-batches 100
+```
+Then the command line will override the sysconfig and 100 batches (not 5) will
+be run. In this example, `--skip-benign` will also be true because it is
+in the sysconfig block.
+
+No matter whether these attributes are specified on the command line, in sysconfig,
+or both, the output file will record the attributes as executed, so you have a
+record of how the evaluation ultimately ran.

--- a/docs/configuration_files.md
+++ b/docs/configuration_files.md
@@ -177,3 +177,7 @@ in the sysconfig block.
 No matter whether these attributes are specified on the command line, in sysconfig,
 or both, the output file will record the attributes as executed, so you have a
 record of how the evaluation ultimately ran.
+
+The [full specification of command line arguments][cmdline] is available.
+
+  [cmdline]: command_line.md

--- a/tests/test_host/test_config_merge.py
+++ b/tests/test_host/test_config_merge.py
@@ -1,0 +1,42 @@
+import argparse
+import sys
+
+import pytest
+
+from armory import __version__
+from armory import arguments
+
+
+def test_config_args_merge():
+    config = dict(
+        sysconfig={
+            "output_dir": None,
+            "output_filename": "file.out",
+            "num_eval_batches": 2,
+            "skip_misclassified": True,
+        }
+    )
+    args = argparse.Namespace(
+        num_eval_batches=5,
+        skip_misclassified=False,
+        output_dir="output-dir",
+        check=True,
+        skip_attack=False,
+    )
+
+    (config, args) = arguments.merge_config_and_args(config, args)
+
+    sysconfig = config["sysconfig"]
+    assert sysconfig["output_dir"] == "output-dir"
+    assert sysconfig["output_filename"] == "file.out"
+    assert sysconfig["num_eval_batches"] == 5
+    assert sysconfig["skip_misclassified"] == True
+    assert sysconfig["check"] == True
+    assert "skip_attack" not in sysconfig
+
+    assert args.output_dir == "output-dir"
+    assert args.output_filename == "file.out"
+    assert args.num_eval_batches == 5
+    assert args.skip_misclassified == True
+    assert args.check == True
+    assert "skip_attack" not in args

--- a/tests/test_host/test_config_merge.py
+++ b/tests/test_host/test_config_merge.py
@@ -1,9 +1,5 @@
 import argparse
-import sys
 
-import pytest
-
-from armory import __version__
 from armory import arguments
 
 
@@ -30,13 +26,13 @@ def test_config_args_merge():
     assert sysconfig["output_dir"] == "output-dir"
     assert sysconfig["output_filename"] == "file.out"
     assert sysconfig["num_eval_batches"] == 5
-    assert sysconfig["skip_misclassified"] == True
-    assert sysconfig["check"] == True
+    assert sysconfig["skip_misclassified"]
+    assert sysconfig["check"]
     assert "skip_attack" not in sysconfig
 
     assert args.output_dir == "output-dir"
     assert args.output_filename == "file.out"
     assert args.num_eval_batches == 5
-    assert args.skip_misclassified == True
-    assert args.check == True
-    assert args.skip_attack == False
+    assert args.skip_misclassified
+    assert args.check
+    assert args.skip_attack is False

--- a/tests/test_host/test_config_merge.py
+++ b/tests/test_host/test_config_merge.py
@@ -39,4 +39,4 @@ def test_config_args_merge():
     assert args.num_eval_batches == 5
     assert args.skip_misclassified == True
     assert args.check == True
-    assert "skip_attack" not in args
+    assert args.skip_attack == False


### PR DESCRIPTION
Fixes #976 

Cross-pollinate sysconfig and command-line overrides from config into arguments and arguments back into config so that output records actual run-time parameters.

WIP because it needs formal tests across the 9 enumerated cases.