### PR TITLE
refactor object detection metrics

### DIFF
--- a/armory/eval/plot.py
+++ b/armory/eval/plot.py
@@ -105,7 +105,7 @@ def get_xy(
         else:
             y.append(total - failed_benign - (epsilon >= e).sum())
 
-    x.append(max_value)
+    x.add_results(max_value)
     if ascending_attack:
         y.append(failed_attack)
     else:

--- a/armory/scenarios/poisoning_gtsrb_clbd.py
+++ b/armory/scenarios/poisoning_gtsrb_clbd.py
@@ -251,10 +251,10 @@ class GTSRB_CLBD(Scenario):
             # Ensure that input sample isn't overwritten by classifier
             x.flags.writeable = False
             y_pred = classifier.predict(x)
-            benign_validation_metric.append(y, y_pred)
+            benign_validation_metric.add_results(y, y_pred)
             y_pred_tgt_class = y_pred[y == src_class]
             if len(y_pred_tgt_class):
-                target_class_benign_metric.append(
+                target_class_benign_metric.add_results(
                     [src_class] * len(y_pred_tgt_class), y_pred_tgt_class
                 )
         logger.info(
@@ -293,11 +293,11 @@ class GTSRB_CLBD(Scenario):
                     poisoned_indices,
                 )
                 y_pred = classifier.predict(x_test)
-                poisoned_test_metric.append(y_test, y_pred)
+                poisoned_test_metric.add_results(y_test, y_pred)
 
                 y_pred_targeted = y_pred[y_test == src_class]
                 if len(y_pred_targeted):
-                    poisoned_targeted_test_metric.append(
+                    poisoned_targeted_test_metric.add_results(
                         [tgt_class] * len(y_pred_targeted), y_pred_targeted
                     )
             results["poisoned_test_accuracy"] = poisoned_test_metric.mean()

--- a/armory/scenarios/poisoning_gtsrb_scenario.py
+++ b/armory/scenarios/poisoning_gtsrb_scenario.py
@@ -303,10 +303,10 @@ class GTSRB(Scenario):
             # Ensure that input sample isn't overwritten by classifier
             x.flags.writeable = False
             y_pred = classifier.predict(x)
-            benign_validation_metric.append(y, y_pred)
+            benign_validation_metric.add_results(y, y_pred)
             y_pred_tgt_class = y_pred[y == src_class]
             if len(y_pred_tgt_class):
-                target_class_benign_metric.append(
+                target_class_benign_metric.add_results(
                     [src_class] * len(y_pred_tgt_class), y_pred_tgt_class
                 )
         logger.info(
@@ -337,8 +337,8 @@ class GTSRB(Scenario):
                 x_poison_test = np.array([xp for xp in x_poison_test], dtype=np.float32)
                 y_pred = classifier.predict(x_poison_test)
                 y_true = [src_class] * len(y_pred)
-                poisoned_targeted_test_metric.append(y_poison_test, y_pred)
-                poisoned_test_metric.append(y_true, y_pred)
+                poisoned_targeted_test_metric.add_results(y_poison_test, y_pred)
+                poisoned_test_metric.add_results(y_true, y_pred)
             test_data_clean = load_dataset(
                 config["dataset"],
                 epochs=1,
@@ -351,7 +351,7 @@ class GTSRB(Scenario):
             ):
                 x_clean_test = np.array([xp for xp in x_clean_test], dtype=np.float32)
                 y_pred = classifier.predict(x_clean_test)
-                poisoned_test_metric.append(y_clean_test, y_pred)
+                poisoned_test_metric.add_results(y_clean_test, y_pred)
 
         elif poison_dataset_flag:
             logger.info("Testing on poisoned test data")
@@ -375,12 +375,12 @@ class GTSRB(Scenario):
                     poisoned_indices,
                 )
                 y_pred = classifier.predict(x_test)
-                poisoned_test_metric.append(y_test, y_pred)
+                poisoned_test_metric.add_results(y_test, y_pred)
 
                 y_pred_targeted = y_pred[y_test == src_class]
                 if not len(y_pred_targeted):
                     continue
-                poisoned_targeted_test_metric.append(
+                poisoned_targeted_test_metric.add_results(
                     [tgt_class] * len(y_pred_targeted), y_pred_targeted
                 )
 

--- a/armory/utils/config_schema.json
+++ b/armory/utils/config_schema.json
@@ -239,9 +239,7 @@
                 "mean_image_circle_patch_diameter",
                 "max_image_circle_patch_diameter",
                 "word_error_rate",
-                "object_detection_AP_per_class",
-                "object_detection_class_recall",
-                "object_detection_class_precision"
+                "object_detection_AP_per_class"
             ]
         },
         "sysconfig": {

--- a/armory/utils/metrics.py
+++ b/armory/utils/metrics.py
@@ -370,7 +370,14 @@ def image_circle_patch_diameter(x, x_adv):
 def _check_object_detection_input(y_list, y_pred_list):
     """
     Helper function to check that the object detection labels and predictions are in
-    the expected format and contain the expected fields
+    the expected format and contain the expected fields.
+
+    y_list (list): of length equal to the number of input examples. Each element in the list
+        should be a dict with "labels" and "boxes" keys mapping to a numpy array of
+        shape (N,) and (N, 4) respectively where N = number of boxes.
+    y_pred_list (list): of length equal to the number of input examples. Each element in the
+        list should be a dict with "labels", "boxes", and "scores" keys mapping to a numpy
+        array of shape (N,), (N, 4), and (N,) respectively where N = number of boxes.
     """
     if not isinstance(y_pred_list, list):
         raise TypeError("Expected y_pred_list to be a list")
@@ -438,9 +445,15 @@ def object_detection_AP_per_class(y_list, y_pred_list, iou_threshold=0.5):
     """
     Mean average precision for object detection. This function returns a dictionary
     mapping each class to the average precision (AP) for the class. The mAP can be computed
-    by taking the mean of the AP's across all classes.
+    by taking the mean of the AP's across all classes. This metric is computed over all
+    evaluation samples, rather than on a per-sample basis.
 
-    This metric is computed over all evaluation samples, rather than on a per-sample basis.
+    y_list (list): of length equal to the number of input examples. Each element in the list
+        should be a dict with "labels" and "boxes" keys mapping to a numpy array of
+        shape (N,) and (N, 4) respectively where N = number of boxes.
+    y_pred_list (list): of length equal to the number of input examples. Each element in the
+        list should be a dict with "labels", "boxes", and "scores" keys mapping to a numpy
+        array of shape (N,), (N, 4), and (N,) respectively where N = number of boxes.
     """
     _check_object_detection_input(y_list, y_pred_list)
 
@@ -618,8 +631,15 @@ def apricot_patch_targeted_AP_per_class(y_list, y_pred_list, iou_threshold=0.1):
     The only classes with potentially nonzero AP's are the classes targeted by the patches
     (see above paragraph).
 
-    # From https://arxiv.org/abs/1912.08166: use a low IOU since "the patches will sometimes
-    # generate many small, overlapping predictions in the region of the attack"
+    From https://arxiv.org/abs/1912.08166: use a low IOU since "the patches will sometimes
+    generate many small, overlapping predictions in the region of the attack"
+
+    y_list (list): of length equal to the number of input examples. Each element in the list
+        should be a dict with "labels" and "boxes" keys mapping to a numpy array of
+        shape (N,) and (N, 4) respectively where N = number of boxes.
+    y_pred_list (list): of length equal to the number of input examples. Each element in the
+        list should be a dict with "labels", "boxes", and "scores" keys mapping to a numpy
+        array of shape (N,), (N, 4), and (N,) respectively where N = number of boxes.
     """
     _check_object_detection_input(y_list, y_pred_list)
 
@@ -796,11 +816,19 @@ def dapricot_patch_targeted_AP_per_class(y_list, y_pred_list, iou_threshold=0.1)
     (see above paragraph).
 
     Assumptions made for D-APRICOT dataset: each image has one ground truth box. This box corresponds
-    to the patch and is assigned a label of whatever the attack's target label is. There are no ground-truth
-    boxes of COCO objects.
+    to the patch and is assigned a label of whatever the attack's target label is. There are no
+    ground-truth boxes of COCO objects.
 
-    # From https://arxiv.org/abs/1912.08166: use a low IOU since "the patches will sometimes
-    # generate many small, overlapping predictions in the region of the attack"
+    From https://arxiv.org/abs/1912.08166: use a low IOU since "the patches will sometimes
+    generate many small, overlapping predictions in the region of the attack"
+
+    y_list (list): of length equal to the number of input examples. Each element in the list
+        should be a dict with "labels" and "boxes" keys mapping to a numpy array of
+        shape (N,) and (N, 4) respectively where N = number of boxes.
+    y_pred_list (list): of length equal to the number of input examples. Each element in the
+        list should be a dict with "labels", "boxes", and "scores" keys mapping to a numpy
+        array of shape (N,), (N, 4), and (N,) respectively where N = number of boxes.
+
     """
     _check_object_detection_input(y_list, y_pred_list)
 

--- a/armory/utils/metrics.py
+++ b/armory/utils/metrics.py
@@ -1120,8 +1120,16 @@ class MetricsLogger:
                 "To change this, set one or more 'task' or 'perturbation' metrics"
             )
         # the following metrics must be computed at once after all predictions have been obtained
-        self.non_elementwise_metrics = ["object_detection_AP_per_class", "apricot_patch_targeted_AP_per_class", "dapricot_patch_targeted_AP_per_class",]
-        self.mean_ap_metrics = ["object_detection_AP_per_class", "apricot_patch_targeted_AP_per_class", "dapricot_patch_targeted_AP_per_class",]
+        self.non_elementwise_metrics = [
+            "object_detection_AP_per_class",
+            "apricot_patch_targeted_AP_per_class",
+            "dapricot_patch_targeted_AP_per_class",
+        ]
+        self.mean_ap_metrics = [
+            "object_detection_AP_per_class",
+            "apricot_patch_targeted_AP_per_class",
+            "dapricot_patch_targeted_AP_per_class",
+        ]
 
     def _generate_counters(self, names):
         if names is None:
@@ -1224,7 +1232,9 @@ class MetricsLogger:
                     metric_result = metric.compute_non_elementwise_metric()
                     results[f"{prefix}_{metric.name}"] = metric_result
                     if metric.name in self.mean_ap_metrics:
-                        results[f"{prefix}_mean_{metric.name}"] = np.fromiter(metric_result.values(), dtype=float).mean()
+                        results[f"{prefix}_mean_{metric.name}"] = np.fromiter(
+                            metric_result.values(), dtype=float
+                        ).mean()
                     continue
 
                 if self.full:

--- a/armory/utils/metrics.py
+++ b/armory/utils/metrics.py
@@ -367,55 +367,6 @@ def image_circle_patch_diameter(x, x_adv):
     ]
 
 
-def object_detection_class_precision(y, y_pred, score_threshold=0.5):
-    _check_object_detection_input(y, y_pred)
-    num_tps, num_fps, num_fns = _object_detection_get_tp_fp_fn(
-        y, y_pred[0], score_threshold=score_threshold
-    )
-    if num_tps + num_fps > 0:
-        return [num_tps / (num_tps + num_fps)]
-    else:
-        return [0]
-
-
-def object_detection_class_recall(y, y_pred, score_threshold=0.5):
-    _check_object_detection_input(y, y_pred)
-    num_tps, num_fps, num_fns = _object_detection_get_tp_fp_fn(
-        y, y_pred[0], score_threshold=score_threshold
-    )
-    if num_tps + num_fns > 0:
-        return [num_tps / (num_tps + num_fns)]
-    else:
-        return [0]
-
-
-def _object_detection_get_tp_fp_fn(y, y_pred, score_threshold=0.5):
-    """
-    Helper function to compute the number of true positives, false positives, and false
-    negatives given a set of of object detection labels and predictions
-    """
-    ground_truth_set_of_classes = set(
-        y["labels"][np.where(y["labels"] != ADV_PATCH_MAGIC_NUMBER_LABEL_ID)]
-        .flatten()
-        .tolist()
-    )
-    predicted_set_of_classes = set(
-        y_pred["labels"][np.where(y_pred["scores"] > score_threshold)].tolist()
-    )
-
-    num_true_positives = len(
-        predicted_set_of_classes.intersection(ground_truth_set_of_classes)
-    )
-    num_false_positives = len(
-        [c for c in predicted_set_of_classes if c not in ground_truth_set_of_classes]
-    )
-    num_false_negatives = len(
-        [c for c in ground_truth_set_of_classes if c not in predicted_set_of_classes]
-    )
-
-    return num_true_positives, num_false_positives, num_false_negatives
-
-
 def _check_object_detection_input(y, y_pred):
     """
     Helper function to check that the object detection labels and predictions are in
@@ -1027,8 +978,6 @@ SUPPORTED_METRICS = {
     "mars_mean_patch": mars_mean_patch,
     "word_error_rate": word_error_rate,
     "object_detection_AP_per_class": object_detection_AP_per_class,
-    "object_detection_class_precision": object_detection_class_precision,
-    "object_detection_class_recall": object_detection_class_recall,
 }
 
 # Image-based metrics applied to video

--- a/tests/test_docker/test_metrics.py
+++ b/tests/test_docker/test_metrics.py
@@ -110,8 +110,8 @@ def test_snr_spectrogram():
 
 def test_metric_list():
     metric_list = metrics.MetricList("categorical_accuracy")
-    metric_list.append([1], [1])
-    metric_list.append([1, 2, 3], [1, 0, 2])
+    metric_list.add_results([1], [1])
+    metric_list.add_results([1, 2, 3], [1, 0, 2])
     assert metric_list.mean() == 0.5
     assert metric_list.values() == [1, 1, 0, 0]
 

--- a/tests/test_docker/test_metrics.py
+++ b/tests/test_docker/test_metrics.py
@@ -152,6 +152,6 @@ def test_mAP():
         "scores": np.array([0.8, 0.8]),
     }
 
-    ap_per_class = metrics.object_detection_AP_per_class([[labels]], [[preds]])
+    ap_per_class = metrics.object_detection_AP_per_class([labels], [preds])
     assert ap_per_class[9] == 0
     assert ap_per_class[2] >= 0.99

--- a/tests/test_pytorch/test_pytorch_models.py
+++ b/tests/test_pytorch/test_pytorch_models.py
@@ -113,8 +113,8 @@ def test_pytorch_xview_pretrained():
     list_of_ypreds = []
     for x, y in test_dataset:
         y_pred = detector.predict(x)
-        list_of_ys.append(y)
-        list_of_ypreds.append(y_pred)
+        list_of_ys.extend(y)
+        list_of_ypreds.extend(y_pred)
 
     average_precision_by_class = object_detection_AP_per_class(
         list_of_ys, list_of_ypreds

--- a/tests/test_tf1/test_tf1_models.py
+++ b/tests/test_tf1/test_tf1_models.py
@@ -60,8 +60,8 @@ def test_tf1_apricot():
     list_of_ypreds = []
     for x, y in dev_dataset:
         y_pred = detector.predict(x)
-        list_of_ys.append(y)
-        list_of_ypreds.append(y_pred)
+        list_of_ys.extend(y)
+        list_of_ypreds.extend(y_pred)
 
     average_precision_by_class = object_detection_AP_per_class(
         list_of_ys, list_of_ypreds
@@ -96,8 +96,8 @@ def test_tf1_apricot():
     list_of_ypreds = []
     for x, y in test_dataset:
         y_pred = detector.predict(x)
-        list_of_ys.append(y)
-        list_of_ypreds.append(y_pred)
+        list_of_ys.extend(y)
+        list_of_ypreds.extend(y_pred)
 
     average_precision_by_class = object_detection_AP_per_class(
         list_of_ys, list_of_ypreds


### PR DESCRIPTION
This PR applies to average precision (AP) metrics that must be computed at once over all samples. It also involves some changes to the core `MetricList` and `MetricsLogger` classes, mostly in how they relate to these AP metrics.

(1) Refactor/reduce conditional logic specific to individual metrics in a way that isn't clean or very readable, see [here](https://github.com/twosixlabs/armory/blob/v0.13.0/armory/utils/metrics.py#L1264-L1298) and [here](https://github.com/twosixlabs/armory/blob/v0.13.0/armory/utils/metrics.py#L1312-L1362).

(2) Simplify input format to average precision metrics to take in a list of labels and a list of predictions. Currently they take in a list of lists of dicts (one list for each batch), which makes the code less clear (see [here](https://github.com/twosixlabs/armory/blob/v0.13.0/armory/utils/metrics.py#L505-L508)).

(3) Function input format should be documented as well for easy stand-alone use external of an Armory scenario

(4) Remove metric functions that aren't useful and were placeholders before mAP was implemented. I'm referring to [these](https://github.com/twosixlabs/armory/blob/v0.13.0/armory/utils/metrics.py#L370-L416).

(5) Better exception handling for OD metric input format implemented [here](https://github.com/lcadalzo/armory/blob/969-refactor-od-metrics/armory/utils/metrics.py#L370-L399)

(6) Renamed some methods/variables to make code more readable. This resulted in some minor modifications to other files such as the poisoning scenario code.

(7) make iou_thresholds configurable as a kwarg