### PR TITLE
preprocessing defense fixes

### DIFF
--- a/armory/art_experimental/defences/jpeg_compression_normalized.py
+++ b/armory/art_experimental/defences/jpeg_compression_normalized.py
@@ -12,7 +12,6 @@ class JpegCompressionNormalized(JpegCompression):
         self,
         clip_values,
         quality=50,
-        channel_index=3,
         apply_fit=True,
         apply_predict=False,
         means=None,
@@ -22,7 +21,6 @@ class JpegCompressionNormalized(JpegCompression):
         super().__init__(
             clip_values,
             quality=quality,
-            channel_index=channel_index,
             apply_fit=apply_fit,
             apply_predict=apply_predict,
         )

--- a/armory/utils/config_loading.py
+++ b/armory/utils/config_loading.py
@@ -205,6 +205,7 @@ def load_defense_internal(defense_config, classifier):
             classifier.preprocessing_defences = [defense]
         if art.__version__ >= "1.5":
             classifier._update_preprocessing_operations()
+            classifier.set_params()
     elif defense_type == "Postprocessor":
         _check_defense_api(defense, Postprocessor)
         if classifier.postprocessing_defences:

--- a/armory/utils/config_loading.py
+++ b/armory/utils/config_loading.py
@@ -13,7 +13,6 @@ try:
     import torch  # noqa: F401
 except ImportError:
     pass
-import art
 from art.attacks import Attack
 
 try:

--- a/armory/utils/config_loading.py
+++ b/armory/utils/config_loading.py
@@ -199,19 +199,21 @@ def load_defense_internal(defense_config, classifier):
     defense_type = defense_config["type"]
     if defense_type == "Preprocessor":
         _check_defense_api(defense, Preprocessor)
-        if classifier.preprocessing_defences:
-            classifier.preprocessing_defences.append(defense)
+        preprocessing_defences = classifier.get_params().get("preprocessing_defences")
+        if preprocessing_defences:
+            preprocessing_defences.append(defense)
         else:
-            classifier.preprocessing_defences = [defense]
-        if art.__version__ >= "1.5":
-            classifier._update_preprocessing_operations()
-            classifier.set_params()
+            preprocessing_defences = [defense]
+        classifier.set_params(preprocessing_defences=preprocessing_defences)
+
     elif defense_type == "Postprocessor":
         _check_defense_api(defense, Postprocessor)
-        if classifier.postprocessing_defences:
-            classifier.postprocessing_defences.append(defense)
+        postprocessing_defences = classifier.get_params().get("postprocessing_defences")
+        if postprocessing_defences:
+            postprocessing_defences.append(defense)
         else:
-            classifier.postprocessing_defences = [defense]
+            postprocessing_defences = [defense]
+        classifier.set_params(postprocessing_defences=postprocessing_defences)
     else:
         raise ValueError(
             f"Internal defenses must be of either type [Preprocessor, Postprocessor], found {defense_type}"

--- a/scenario_configs/apricot_frcnn_defended.json
+++ b/scenario_configs/apricot_frcnn_defended.json
@@ -23,7 +23,6 @@
         "kwargs": {
             "apply_fit": false,
             "apply_predict": true,
-            "channel_index": 3,
             "clip_values": [
                 0.0,
                 1.0

--- a/scenario_configs/xview_frcnn_defended.json
+++ b/scenario_configs/xview_frcnn_defended.json
@@ -33,7 +33,6 @@
         "kwargs": {
             "apply_fit": false,
             "apply_predict": true,
-            "channel_index": 3,
             "clip_values": [
                 0.0,
                 1.0


### PR DESCRIPTION
(1) Closes #1058. This issue arose because during the loading of ART preprocessing defenses, the ART estimator's `all_framework_preprocessing` attribute needs to be updated. This is accomplished by calling the estimator's `set_params()` method.

(2) Closes #1059. The defense in  `art_experimental/defences/jpeg_compression_normalized.py` was using a `channel_index` kwarg which has been deprecated in ART. This defense, as well as associated configs, have been updated. The channel index defaults to a channels_last format which is how Armory loads data.