### PR TITLE
sweep attacks

### DIFF
--- a/armory/art_experimental/attacks/sweep.py
+++ b/armory/art_experimental/attacks/sweep.py
@@ -125,11 +125,14 @@ class SweepAttack(EvasionAttack):
                 )
 
         if x_best is None:
-            logger.info("Attack failed. Returning original x.")
+            logger.info(
+                "Sweep attack concluded. Returning original x since attack failed at all sweep points."
+            )
             return x
         if x_best is not None:
             logger.info(
-                f"Returning best attack with kwargs {best_attack_kwargs} and generate_kwargs {best_generate_kwargs}"
+                f"Sweep attack concluded. Returning the weakest-strength successful attack with "
+                f"kwargs {best_attack_kwargs} and generate_kwargs {best_generate_kwargs}"
             )
             return x_best
 

--- a/armory/art_experimental/attacks/sweep.py
+++ b/armory/art_experimental/attacks/sweep.py
@@ -1,0 +1,209 @@
+import logging
+from importlib import import_module
+
+import numpy as np
+from art.attacks import EvasionAttack
+
+
+logger = logging.getLogger(__name__)
+
+
+class SweepAttack(EvasionAttack):
+    def __init__(self, estimator, attack_fn, sweep_params, **kwargs):
+        if not isinstance(sweep_params, dict):
+            raise ValueError(
+                "If attack_config['type'] == 'sweep', then "
+                "attack_config['sweep_params'] must be specified with "
+                "'kwargs' and/or 'generate_kwargs' field(s)."
+            )
+        for key in sweep_params:
+            if key not in ["kwargs", "generate_kwargs", "metric"]:
+                raise ValueError(
+                    f"Received an unexpected field '{key}' in attack_config['sweep_params']. "
+                    f"The list of allowable fields is as follows: "
+                    f"['kwargs', 'generate_kwargs', 'metric']."
+                )
+        if (
+            "kwargs" not in sweep_params.keys()
+            and "generate_kwargs" not in sweep_params.keys()
+        ):
+            raise ValueError(
+                "attack_config['sweep_params'] must contain at least one "
+                "of the following fields: ['kwargs', 'generate_kwargs']."
+            )
+
+        self.sweep_kwargs = sweep_params.get("kwargs", {})
+        self.sweep_generate_kwargs = sweep_params.get("generate_kwargs", {})
+        if len(self.sweep_kwargs) + len(self.sweep_generate_kwargs) == 0:
+            raise ValueError(
+                "Received no kwargs to sweep over. At least one of "
+                "attack_config['sweep_params']['kwargs'] and "
+                "attack_config['sweep_params']['generate_kwargs'] should be non-empty."
+            )
+
+        if len(kwargs.keys() & self.sweep_kwargs.keys()) > 0:
+            logger.warning(
+                f"The following kwargs were set in both attack_config['kwargs'] and "
+                f"attack_config['sweep_params']['kwargs']: "
+                f"{list(kwargs.keys() & self.sweep_kwargs.keys())}. Values specified "
+                f"in attack_config['kwargs'] will be ignored."
+            )
+
+        self._check_kwargs(self.sweep_kwargs)
+        self._check_kwargs(self.sweep_generate_kwargs)
+        self._load_metric_fn(sweep_params.get("metric", {}))
+
+        self.targeted = kwargs.get("targeted", False)
+        self.attacks = []
+        self._estimator = estimator
+
+        if len(self.sweep_kwargs) > 0:
+            self.num_search_points = len(list(self.sweep_kwargs.values())[0])
+        else:
+            self.num_search_points = len(list(self.sweep_generate_kwargs.values())[0])
+
+        for i in range(self.num_search_points):
+            subattack_i_kwargs = kwargs.copy()
+            for sweep_attack_kwarg in self.sweep_kwargs:
+                subattack_i_kwargs[sweep_attack_kwarg] = self.sweep_kwargs[
+                    sweep_attack_kwarg
+                ][i]
+            subattack_i = attack_fn(estimator, **subattack_i_kwargs)
+            self.attacks.append(subattack_i)
+
+    def generate(self, x, y=None, **kwargs):
+        if x.shape[0] != 1:
+            raise ValueError("Dataset batch_size should be set to 1")
+        if y is None:
+            raise ValueError(
+                "This attack requires given labels. Ensure that attack['use_label'] is set to True."
+            )
+
+        if len(kwargs.keys() & self.sweep_generate_kwargs.keys()) > 0:
+            logger.warning(
+                f"The following kwargs were set in both attack_config['generate_kwargs'] and "
+                f"attack_config['sweep_params']['generate_kwargs']: "
+                f"{list(kwargs.keys() & self.sweep_generate_kwargs.keys())}. Values specified "
+                f"in attack_config['generate_kwargs'] will be ignored."
+            )
+
+        y_pred = self._estimator.predict(x)
+        if not self._is_robust(y, y_pred):
+            logger.info("Estimator is not robust to original x. Returning original x.")
+            return x
+
+        i_min = 0
+        i_max = self.num_search_points
+        x_best = None
+        while i_min < i_max:
+            i_mid = (i_min + i_max) // 2
+            attack_kwargs = {k: v[i_mid] for k, v in self.sweep_kwargs.items()}
+            generate_kwargs = {
+                k: v[i_mid] for k, v in self.sweep_generate_kwargs.items()
+            }
+            kwargs.update(generate_kwargs)
+            x_adv = self.attacks[i_mid].generate(x, y, **kwargs)
+            y_pred = self._estimator.predict(x_adv)
+            if not self._is_robust(y, y_pred):
+                # attack success
+                logger.info(
+                    f"Success with kwargs {attack_kwargs} and generate_kwargs {generate_kwargs}"
+                )
+                x_best = x_adv
+                best_attack_kwargs = attack_kwargs
+                best_generate_kwargs = generate_kwargs
+                i_max = i_mid
+            else:
+                # attack failure
+                i_min = i_mid + 1
+                logger.info(
+                    f"Failure with kwargs {attack_kwargs} and generate_kwargs {generate_kwargs}"
+                )
+
+        if x_best is None:
+            logger.info("Attack failed. Returning original x.")
+            return x
+        if x_best is not None:
+            logger.info(
+                f"Returning best attack with kwargs {best_attack_kwargs} and generate_kwargs {best_generate_kwargs}"
+            )
+            return x_best
+
+    def _is_robust(self, y, y_pred):
+        if y.dtype == np.object:
+            metric_result = self.metric_fn([y[0]], y_pred)
+            if isinstance(metric_result, dict):
+                metric_result = np.fromiter(metric_result.values(), dtype=float).mean()
+            else:
+                metric_result = metric_result[0]
+        else:
+            metric_result = self.metric_fn(y, y_pred)[0]
+
+        if self.targeted:
+            return metric_result < self.metric_threshold
+        else:
+            return metric_result > self.metric_threshold
+
+    def _check_kwargs(self, kwargs):
+        if not isinstance(kwargs, dict):
+            raise ValueError(
+                f"Expected dict for 'sweep_params' kwargs, received type {type(kwargs)}"
+            )
+        num_search_points = None
+        for kwarg, values in kwargs.items():
+            if not isinstance(values, (tuple, list)):
+                raise ValueError(
+                    f"The values passed for kwarg '{kwarg}' should be a list or "
+                    f"tuple, not {type(values)}"
+                )
+            if len(values) <= 1:
+                raise ValueError(
+                    f"Expected multiple values to sweep over for kwarg "
+                    f"'{kwarg}', received {len(values)}: {values}."
+                )
+            if num_search_points is None:
+                num_search_points = len(values)
+                num_search_points_reference_kwarg = kwarg
+            else:
+                if len(values) != num_search_points:
+                    raise ValueError(
+                        f"All kwargs lists in attack_config['sweep_params'] "
+                        f"should have the same number of values. Found {len(values)} values "
+                        f"for '{kwarg}' but {num_search_points} for "
+                        f"'{num_search_points_reference_kwarg}'."
+                    )
+
+            if sorted(values) != values:
+                logger.warning(
+                    f"The values of kwarg '{kwarg}' are not sorted in ascending order. "
+                    f"SweepAttack's search procedure assumes that attack strength is "
+                    f"monotonically increasing."
+                )
+
+    def _load_metric_fn(self, metric_dict):
+        metric_module_name = metric_dict.get("module")
+        if metric_module_name is None:
+            # by default use categorical accuracy to measure attack success
+            from armory.utils.metrics import categorical_accuracy
+
+            self.metric_fn = categorical_accuracy
+            self.metric_threshold = (
+                0.5  # for binary metric, any x s.t. 0 < x < 1 suffices
+            )
+        else:
+            metric_module = import_module(metric_module_name)
+            metric_name = metric_dict.get("name")
+            if metric_name is None:
+                raise ValueError(
+                    "If attack_config['sweep_params']['metric']['module'] is "
+                    "specified, then attack_config['sweep_params']['metric']['name'] must "
+                    "be specified as well."
+                )
+            self.metric_fn = getattr(metric_module, metric_name)
+            self.metric_threshold = metric_dict.get("threshold")
+            if self.metric_threshold is None:
+                raise ValueError(
+                    "If attack_config['sweep_params']['metric']['module'] is specified, then "
+                    "attack_config['sweep_params']['metric']['threshold'] must be "
+                    "specified as well."
+                )

--- a/armory/art_experimental/attacks/sweep.py
+++ b/armory/art_experimental/attacks/sweep.py
@@ -89,7 +89,11 @@ class SweepAttack(EvasionAttack):
 
         y_pred = self._estimator.predict(x)
         if not self._is_robust(y, y_pred):
-            logger.info("Estimator is not robust to original x. Returning original x.")
+            logger.info(
+                f"Estimator is not robust to original x as measured with metric "
+                f"function {self.metric_fn.__name__} and threshold "
+                f"{self.metric_threshold}. Returning original x."
+            )
             return x
 
         i_min = 0
@@ -186,6 +190,11 @@ class SweepAttack(EvasionAttack):
             # by default use categorical accuracy to measure attack success
             from armory.utils.metrics import categorical_accuracy
 
+            logger.info(
+                "Using default categorical accuracy to measure attack success "
+                "since attack_config['sweep_params']['metric']['module'] is "
+                "unspecified."
+            )
             self.metric_fn = categorical_accuracy
             self.metric_threshold = (
                 0.5  # for binary metric, any x s.t. 0 < x < 1 suffices

--- a/armory/utils/config_loading.py
+++ b/armory/utils/config_loading.py
@@ -128,6 +128,7 @@ def load_model(model_config):
 
 
 def load_attack(attack_config, classifier):
+    SUPPORTED_TYPES = ["preloaded", "patch", "sweep", None]
     if attack_config.get("type") == "patch":
         original_kwargs = attack_config.pop("kwargs")
         kwargs = original_kwargs.copy()
@@ -137,6 +138,13 @@ def load_attack(attack_config, classifier):
         if targeted:
             logger.warning("Patch attack generation may ignore 'targeted' set to True")
         attack_config["kwargs"] = kwargs
+    else:
+        if attack_config.get("type") not in SUPPORTED_TYPES:
+            logger.warning(
+                f"attack_config['type'] of {attack_config.get('type')} was not "
+                f"recognized and isn't being used. Supported attack types "
+                f"are as follows: {SUPPORTED_TYPES}."
+            )
 
     attack_module = import_module(attack_config["module"])
     attack_fn = getattr(attack_module, attack_config["name"])

--- a/armory/utils/config_loading.py
+++ b/armory/utils/config_loading.py
@@ -27,6 +27,7 @@ from art.defences.preprocessor import Preprocessor
 from art.defences.trainer import Trainer
 
 from armory.art_experimental.attacks import patch
+from armory.art_experimental.attacks.sweep import SweepAttack
 from armory.data.datasets import ArmoryDataGenerator, EvalGenerator
 from armory.data.utils import maybe_download_weights_from_s3
 from armory.utils import labels
@@ -140,6 +141,15 @@ def load_attack(attack_config, classifier):
     attack_module = import_module(attack_config["module"])
     attack_fn = getattr(attack_module, attack_config["name"])
     attack = attack_fn(classifier, **attack_config["kwargs"])
+
+    if attack_config.get("type") == "sweep":
+        attack = SweepAttack(
+            classifier,
+            attack_fn,
+            attack_config.get("sweep_params"),
+            **attack_config.get("kwargs"),
+        )
+
     if not isinstance(attack, Attack):
         logger.warning(
             f"attack {attack} is not an instance of {Attack}."

--- a/armory/utils/config_schema.json
+++ b/armory/utils/config_schema.json
@@ -240,7 +240,8 @@
                 "mean_image_circle_patch_diameter",
                 "max_image_circle_patch_diameter",
                 "word_error_rate",
-                "object_detection_AP_per_class"
+                "object_detection_AP_per_class",
+                "object_detection_mAP"
             ]
         },
         "sysconfig": {

--- a/armory/utils/metrics.py
+++ b/armory/utils/metrics.py
@@ -613,6 +613,25 @@ def object_detection_AP_per_class(y_list, y_pred_list, iou_threshold=0.5):
     return average_precisions_by_class
 
 
+def object_detection_mAP(y_list, y_pred_list, iou_threshold=0.5):
+    """
+    Mean average precision for object detection. This function returns a scalar value.
+
+    y_list (list): of length equal to the number of input examples. Each element in the list
+        should be a dict with "labels" and "boxes" keys mapping to a numpy array of
+        shape (N,) and (N, 4) respectively where N = number of boxes.
+    y_pred_list (list): of length equal to the number of input examples. Each element in the
+        list should be a dict with "labels", "boxes", and "scores" keys mapping to a numpy
+        array of shape (N,), (N, 4), and (N,) respectively where N = number of boxes.
+
+    """
+    _check_object_detection_input(y_list, y_pred_list)
+    ap_per_class = object_detection_AP_per_class(
+        y_list, y_pred_list, iou_threshold=iou_threshold
+    )
+    return np.fromiter(ap_per_class.values(), dtype=float).mean()
+
+
 def apricot_patch_targeted_AP_per_class(y_list, y_pred_list, iou_threshold=0.1):
     """
     Average precision indicating how successfully the APRICOT patch causes the detector
@@ -1047,6 +1066,7 @@ SUPPORTED_METRICS = {
     "mars_mean_patch": mars_mean_patch,
     "word_error_rate": word_error_rate,
     "object_detection_AP_per_class": object_detection_AP_per_class,
+    "object_detection_mAP": object_detection_mAP,
 }
 
 # Image-based metrics applied to video

--- a/docs/configuration_files.md
+++ b/docs/configuration_files.md
@@ -132,8 +132,9 @@ All configuration files are verified against the jsonschema definition at run ti
 ```
 
 ### attack config "type" field
-The supported values for the`"type"` field in attack configs are as follows: 
-<`preloaded`|`patch`|`sweep`>. 
+The supported values for the `"type"` field in attack configs are as follows: 
+<`preloaded`|`patch`|`sweep`>. If none of the cases below apply, the field 
+does not need to be included.
 
 1. `"preloaded"`: This value is specified when using an adversarial dataset (e.g. APRICOT) where no 
 perturbations should be applied to the inputs.

--- a/docs/configuration_files.md
+++ b/docs/configuration_files.md
@@ -19,6 +19,7 @@ All configuration files are verified against the jsonschema definition at run ti
     use_label: [Bool] Default: False. Whether attack should use the true label when 
           attacking the model. Without this, it is not possible to drive the accuracy 
           down to 0% when the model has misclassifications.
+    type: [Optional String]: in <`preloaded`|`patch`|`sweep`>.
   }
 `dataset`: [Object]
   {
@@ -129,6 +130,20 @@ All configuration files are verified against the jsonschema definition at run ti
     }
 }
 ```
+
+### attack config "type" field
+The supported values for the`"type"` field in attack configs are as follows: 
+<`preloaded`|`patch`|`sweep`>. 
+
+1. `"preloaded"`: This value is specified when using an adversarial dataset (e.g. APRICOT) where no 
+perturbations should be applied to the inputs.
+
+2. `"patch"`: Some ART attacks such as `"AdversarialPatch"`  or `"RobustDPatch"` have a `generate()` method
+which returns a patch rather than the input with patch. When using such an attack in an Armory scenario,
+setting `attack_config["type"]` to `"patch"` will enable an Armory wrapper class with an updated 
+`generate()` which applies the patch to the input.
+
+2. `"sweep"`: To enable "sweep" attacks, see the instructions in [sweep_attacks.md](sweep_attacks.md).
 
 ### Use with Custom Docker Image
 

--- a/docs/sweep_attacks.md
+++ b/docs/sweep_attacks.md
@@ -1,0 +1,77 @@
+# Sweep Attacks
+
+Armory supports running adversarial attacks which "sweep" over a range of values for specified 
+attack parameters (e.g. `"eps"`). This helps automate the process of determining at what 
+attack parameter values (i.e. perturbation budget) a defense is no longer robust.
+
+To enable such an attack, set `attack_config["type"]` to `"sweep"`. 
+```aidl
+"attack": {
+    "module": "art.attacks.evasion",
+    "name": "ProjectedGradientDescent",
+    ...
+    "type": "sweep"
+}
+```
+
+Next, specify which parameter(s) to perform the search over. This is done using the 
+`attack_config["sweep_params"]["kwargs"]` field for kwargs passed to attack instantiation and the
+`attack_config["sweep_params"]["generate_kwargs"]` field for kwargs passed to the attack's 
+`generate()` method. In the example below we sweep over the `"eps"` and `"eps_step"` 
+parameters:
+
+```aidl
+"attack": {
+    "module": "art.attacks.evasion",
+    "name": "ProjectedGradientDescent",
+    "type": "sweep",
+    "sweep_params": {
+        "kwargs": {
+            "eps": [0.01, 0.02, 0.03, 0.04, 0.05, 0.06, 0.07, 0.08],
+            "eps_step": [0.005, 0.01, 0.015, 0.02, 0.025, 0.03, 0.035, 0.04]
+        }
+    }
+}
+```
+
+Similarly, in the following example, we sweep over kwargs passed to the attack's `generate()` method 
+using the `"generate_kwargs"` field inside `attack_config["sweep_params"]`:
+```aidl
+"attack": {
+    "module": "armory.art_experimental.attacks.pgd_patch",
+    "name": "PGDPatch",
+    "type": "sweep",
+    "sweep_params": {
+        "generate_kwargs": {
+            "patch_height": [10, 20, 30, 40, 50],
+            "patch_width": [10, 20, 30, 40, 50]
+        }
+    }
+}
+```
+
+Each range of sweep parameters must be specified with a list of length `N`, where `N > 1` is 
+the number of desired search points. All parameters specified inside of 
+`attack_config["sweep_params"]` must correspond to lists of length `N`, and the `ith` element of
+a given kwarg list will be used in conjunction with the `ith` element of all other kwarg 
+lists (i.e. in the first example, when `"eps"` is `0.01`, `"eps_step"` is `0.005` and so on). The
+search algorithm assumes that parameters lists are in ascending order of attack strength.
+
+Attack parameters to be held constant should be specified in `attack_config["kwargs"]` and
+`attack_config["generate_kwargs"]` as per usual. If the same kwarg (or generate_kwarg) appears in `attack_config["kwargs"]`
+and `attack_config["sweep_params"]["kwargs"]`, the former will be ignored. 
+
+
+### Determining Attack Success
+In order to identify at what point an attack is successful, it is necessary to define how
+attack success is measured. By default `armory.utils.metrics.categorical_accuracy` is used to 
+determine whether the predicted label matches the ground-truth. For non-classification 
+scenarios such as object detection or speech recognition, this metric doesn't apply. 
+
+Users can specify the task-relevant metric used to measure robustness via the 
+`attack_config["sweep_params"]["metric"]` field. Inside this field, specify a `"module"` and
+`"name"` which point to the desired metric function. This can be any function `f` which takes
+positional arguments `y` and `y_pred` as such: `f(y, y_pred)` and returns a scalar. A 
+`"threshold"` must also be specified indicating at what metric value that attack is 
+considered successful. For non-targeted attacks, if the value is *below* the threshold we 
+consider the attack successful, while the opposite is true for targeted attacks.

--- a/docs/sweep_attacks.md
+++ b/docs/sweep_attacks.md
@@ -75,3 +75,13 @@ positional arguments `y` and `y_pred` as such: `f(y, y_pred)` and returns a scal
 `"threshold"` must also be specified indicating at what metric value that attack is 
 considered successful. For non-targeted attacks, if the value is *below* the threshold we 
 consider the attack successful, while the opposite is true for targeted attacks.
+
+### Additional Configuration Settings
+Sweep attacks require access to either ground-truth or target labels `y`. If the attack 
+is untargeted, set `attack_config["use_label"]` to `true`.
+
+
+To ensure that metrics are saved on a per-example basis, set 
+`metric_config["record_metric_per_sample"]` to `true`.
+
+

--- a/docs/sweep_attacks.md
+++ b/docs/sweep_attacks.md
@@ -2,7 +2,9 @@
 
 Armory supports running adversarial attacks which "sweep" over a range of values for specified 
 attack parameters (e.g. `"eps"`). This helps automate the process of determining at what 
-attack parameter values (i.e. perturbation budget) a defense is no longer robust.
+attack parameter values (i.e. perturbation budget) a defense is no longer robust. The attack
+returns the weakest-strength adversarial example that is successful, or the original input 
+if the attack fails at all values.
 
 To enable such an attack, set `attack_config["type"]` to `"sweep"`. 
 ```aidl
@@ -83,5 +85,3 @@ is untargeted, set `attack_config["use_label"]` to `true`.
 
 To ensure that metrics are saved on a per-example basis, set 
 `metric_config["record_metric_per_sample"]` to `true`.
-
-

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -4,6 +4,7 @@ nav:
   - Home: index.md
   - Getting Started: getting_started.md
   - Configuration Files: configuration_files.md
+  - Sweep Attacks: sweep_attacks.md
   - Baseline Models: baseline_models.md
   - Datasets: datasets.md
   - Adversarial Datasets: adversarial_datasets.md

--- a/scenario_configs/gtsrb_scenario_clbd.json
+++ b/scenario_configs/gtsrb_scenario_clbd.json
@@ -32,7 +32,6 @@
         },
         "module": "armory.art_experimental.attacks.poison_loader_clbd",
         "name": "poison_loader_clbd",
-        "type": "clbd",
         "use_adversarial_trainer": false
     },
     "dataset": {

--- a/scenario_configs/gtsrb_scenario_clbd_bullethole.json
+++ b/scenario_configs/gtsrb_scenario_clbd_bullethole.json
@@ -38,7 +38,6 @@
         },
         "module": "armory.art_experimental.attacks.poison_loader_clbd",
         "name": "poison_loader_clbd",
-        "type": "clbd",
         "use_adversarial_trainer": false
     },
     "dataset": {

--- a/scenario_configs/gtsrb_scenario_clbd_defended.json
+++ b/scenario_configs/gtsrb_scenario_clbd_defended.json
@@ -32,7 +32,6 @@
         },
         "module": "armory.art_experimental.attacks.poison_loader_clbd",
         "name": "poison_loader_clbd",
-        "type": "clbd",
         "use_adversarial_trainer": false
     },
     "dataset": {

--- a/scenario_configs/resisc45_baseline_densenet121_sweep_eps.json
+++ b/scenario_configs/resisc45_baseline_densenet121_sweep_eps.json
@@ -68,7 +68,7 @@
         "name": "ImageClassificationTask"
     },
     "sysconfig": {
-        "docker_image": "twosixarmory/tf1:0.13.1",
+        "docker_image": "twosixarmory/tf1:0.14.0",
         "external_github_repo": null,
         "gpus": "all",
         "output_dir": null,

--- a/scenario_configs/resisc45_baseline_densenet121_sweep_eps.json
+++ b/scenario_configs/resisc45_baseline_densenet121_sweep_eps.json
@@ -48,7 +48,7 @@
     "metric": {
         "means": true,
         "perturbation": "linf",
-        "record_metric_per_sample": false,
+        "record_metric_per_sample": true,
         "task": [
             "categorical_accuracy"
         ]

--- a/scenario_configs/resisc45_baseline_densenet121_sweep_eps.json
+++ b/scenario_configs/resisc45_baseline_densenet121_sweep_eps.json
@@ -1,0 +1,78 @@
+{
+    "_description": "Resisc45 image classification, contributed by MITRE Corporation",
+    "adhoc": null,
+    "attack": {
+        "knowledge": "white",
+        "kwargs": {
+            "batch_size": 1,
+            "minimal": false,
+            "num_random_init": 0,
+            "targeted": false
+        },
+        "module": "art.attacks.evasion",
+        "name": "FastGradientMethod",
+        "sweep_params": {
+            "kwargs": {
+                "eps": [
+                    0.01,
+                    0.02,
+                    0.03,
+                    0.04,
+                    0.05,
+                    0.06,
+                    0.07,
+                    0.08
+                ],
+                "eps_step": [
+                    0.005,
+                    0.01,
+                    0.015,
+                    0.02,
+                    0.025,
+                    0.03,
+                    0.035,
+                    0.04
+                ]
+            }
+        },
+        "type": "sweep",
+        "use_label": true
+    },
+    "dataset": {
+        "batch_size": 1,
+        "framework": "numpy",
+        "module": "armory.data.datasets",
+        "name": "resisc45"
+    },
+    "defense": null,
+    "metric": {
+        "means": true,
+        "perturbation": "linf",
+        "record_metric_per_sample": false,
+        "task": [
+            "categorical_accuracy"
+        ]
+    },
+    "model": {
+        "fit": false,
+        "fit_kwargs": {},
+        "model_kwargs": {},
+        "module": "armory.baseline_models.keras.densenet121_resisc45",
+        "name": "get_art_model",
+        "weights_file": "densenet121_resisc45_v1.h5",
+        "wrapper_kwargs": {}
+    },
+    "scenario": {
+        "kwargs": {},
+        "module": "armory.scenarios.image_classification",
+        "name": "ImageClassificationTask"
+    },
+    "sysconfig": {
+        "docker_image": "twosixarmory/tf1:0.13.1",
+        "external_github_repo": null,
+        "gpus": "all",
+        "output_dir": null,
+        "output_filename": null,
+        "use_gpu": false
+    }
+}

--- a/scenario_configs/xview_frcnn_sweep_patch_size.json
+++ b/scenario_configs/xview_frcnn_sweep_patch_size.json
@@ -95,7 +95,7 @@
         "name": "ObjectDetectionTask"
     },
     "sysconfig": {
-        "docker_image": "twosixarmory/pytorch:0.13.1",
+        "docker_image": "twosixarmory/pytorch:0.14.0",
         "external_github_repo": null,
         "gpus": "all",
         "output_dir": null,

--- a/scenario_configs/xview_frcnn_sweep_patch_size.json
+++ b/scenario_configs/xview_frcnn_sweep_patch_size.json
@@ -1,0 +1,105 @@
+{
+    "_description": "XView object detection, contributed by MITRE Corporation",
+    "adhoc": null,
+    "attack": {
+        "generate_kwargs": {
+            "xmin": 0,
+            "ymin": 0
+        },
+        "knowledge": "white",
+        "kwargs": {
+            "batch_size": 1,
+            "eps": 1.0,
+            "eps_step": 0.01,
+            "max_iter": 1,
+            "num_random_init": 0,
+            "random_eps": false,
+            "targeted": true,
+            "verbose": true
+        },
+        "module": "armory.art_experimental.attacks.pgd_patch",
+        "name": "PGDPatch",
+        "sweep_params": {
+            "generate_kwargs": {
+                "patch_height": [
+                    10,
+                    20,
+                    30,
+                    40,
+                    50,
+                    60,
+                    70,
+                    80,
+                    90,
+                    100,
+                    110
+                ],
+                "patch_width": [
+                    10,
+                    20,
+                    30,
+                    40,
+                    50,
+                    60,
+                    70,
+                    80,
+                    90,
+                    100,
+                    110
+                ]
+            },
+            "kwargs": {},
+            "metric": {
+                "module": "armory.utils.metrics",
+                "name": "object_detection_AP_per_class",
+                "threshold": 0.3
+            }
+        },
+        "targeted_labels": {
+            "kwargs": {
+                "value": 2
+            },
+            "module": "armory.utils.labels",
+            "name": "ObjectDetectionFixedLabelTargeter"
+        },
+        "type": "sweep",
+        "use_label": false
+    },
+    "dataset": {
+        "batch_size": 1,
+        "framework": "numpy",
+        "module": "armory.data.datasets",
+        "name": "xview"
+    },
+    "defense": null,
+    "metric": {
+        "means": true,
+        "perturbation": "l0",
+        "record_metric_per_sample": false,
+        "task": [
+            "object_detection_AP_per_class"
+        ]
+    },
+    "model": {
+        "fit": false,
+        "fit_kwargs": {},
+        "model_kwargs": {},
+        "module": "armory.baseline_models.pytorch.xview_frcnn",
+        "name": "get_art_model",
+        "weights_file": "xview_model_state_dict_epoch_99_loss_0p67",
+        "wrapper_kwargs": {}
+    },
+    "scenario": {
+        "kwargs": {},
+        "module": "armory.scenarios.object_detection",
+        "name": "ObjectDetectionTask"
+    },
+    "sysconfig": {
+        "docker_image": "twosixarmory/pytorch:0.13.1",
+        "external_github_repo": null,
+        "gpus": "all",
+        "output_dir": null,
+        "output_filename": null,
+        "use_gpu": false
+    }
+}

--- a/scenario_configs/xview_frcnn_sweep_patch_size.json
+++ b/scenario_configs/xview_frcnn_sweep_patch_size.json
@@ -75,7 +75,7 @@
     "metric": {
         "means": true,
         "perturbation": "l0",
-        "record_metric_per_sample": false,
+        "record_metric_per_sample": true,
         "task": [
             "object_detection_AP_per_class"
         ]

--- a/scenario_configs/xview_frcnn_sweep_patch_size.json
+++ b/scenario_configs/xview_frcnn_sweep_patch_size.json
@@ -11,7 +11,7 @@
             "batch_size": 1,
             "eps": 1.0,
             "eps_step": 0.01,
-            "max_iter": 1,
+            "max_iter": 100,
             "num_random_init": 0,
             "random_eps": false,
             "targeted": true,
@@ -51,8 +51,8 @@
             "kwargs": {},
             "metric": {
                 "module": "armory.utils.metrics",
-                "name": "object_detection_AP_per_class",
-                "threshold": 0.3
+                "name": "object_detection_mAP",
+                "threshold": 0.1
             }
         },
         "targeted_labels": {


### PR DESCRIPTION
Closes #1066.

Two other items that this PR includes:

1. Documenting the supported values for attack config `"type"` field and throwing a warning if an unexpected value is received
2. Adding `object_detection_mAP()` metric function. This simply calls the `object_detection_AP_per_class()` function and then returns the mean across each class. SweepAttacks enforce that metrics used to measure attack success return scalars, hence the reason this was included in this PR