### PR TITLE
WIP Docker tf1 fix to allow tensorflow.keras to load h5 weights

### DIFF
--- a/docker/tf1/Dockerfile
+++ b/docker/tf1/Dockerfile
@@ -56,6 +56,10 @@ RUN /opt/conda/bin/pip install --no-cache-dir numpy==1.19.2
 
 WORKDIR /workspace
 
+RUN python -c 'import h5py; print(f"Initial h5py version: {h5py.__version__}")'
+RUN /opt/conda/bin/pip install "h5py<3.0.0"
+RUN python -c 'import h5py; print(f"New h5py version: {h5py.__version__}")'
+
 ########## TF 1 Dev #################
 
 FROM armory-tf1-base AS armory-tf1-dev

--- a/docker/tf1/Dockerfile
+++ b/docker/tf1/Dockerfile
@@ -53,12 +53,9 @@ RUN /opt/conda/bin/pip install --no-cache-dir adversarial-robustness-toolbox==1.
 
 # Note: this is necessary until the following TF issue is resolved: https://github.com/tensorflow/models/issues/9706
 RUN /opt/conda/bin/pip install --no-cache-dir numpy==1.19.2
+RUN /opt/conda/bin/pip install "h5py<3.0.0"
 
 WORKDIR /workspace
-
-RUN python -c 'import h5py; print(f"Initial h5py version: {h5py.__version__}")'
-RUN /opt/conda/bin/pip install "h5py<3.0.0"
-RUN python -c 'import h5py; print(f"New h5py version: {h5py.__version__}")'
 
 ########## TF 1 Dev #################
 


### PR DESCRIPTION
The tf1 container has a dated version of Tensorflow (1.15.0), which still has the following [bug](https://github.com/h5py/h5py/issues/1732) when h5py is >=3.0.0. The conda version of tensorflow still does not support>1.15.0. As a workaround can pin the h5py version to be <3.0.0.