### PR TITLE
WIP: coco integration

### DIFF
--- a/armory/baseline_models/tf_graph/mscoco_frcnn.py
+++ b/armory/baseline_models/tf_graph/mscoco_frcnn.py
@@ -43,23 +43,6 @@ class TensorFlowFasterRCNNOneIndexed(TensorFlowFasterRCNN):
     def compute_loss(self, x, y):
         raise NotImplementedError
 
-    def loss_gradient(self, x, y, **kwargs):
-        y_zero_indexed = []
-        for y_dict in y:
-            y_dict_zero_indexed = y_dict.copy()
-            y_dict_zero_indexed["labels"] = y_dict_zero_indexed["labels"] - 1
-            y_zero_indexed.append(y_dict_zero_indexed)
-        return super().loss_gradient(x, y_zero_indexed, **kwargs)
-
-    def predict(self, x, **kwargs):
-        list_of_zero_indexed_pred_dicts = super().predict(x, **kwargs)
-        list_of_one_indexed_pred_dicts = []
-        for img_pred_dict in list_of_zero_indexed_pred_dicts:
-            zero_indexed_pred_labels = img_pred_dict["labels"]
-            img_pred_dict["labels"] = zero_indexed_pred_labels + 1
-            list_of_one_indexed_pred_dicts.append(img_pred_dict)
-        return list_of_one_indexed_pred_dicts
-
 
 def get_art_model(model_kwargs, wrapper_kwargs, weights_file=None):
     # APRICOT inputs should have shape (1, None, None, 3) while DAPRICOT inputs have shape

--- a/armory/baseline_models/tf_graph/mscoco_frcnn.py
+++ b/armory/baseline_models/tf_graph/mscoco_frcnn.py
@@ -9,46 +9,29 @@ from art.estimators.object_detection.tensorflow_faster_rcnn import TensorFlowFas
 import tensorflow as tf
 
 
-class TensorFlowFasterRCNNOneIndexed(TensorFlowFasterRCNN):
-    """
-    This is an MSCOCO pre-trained model. Note that the inherited TensorFlowFasterRCMM class
-    outputs 0-indexed classes, while this wrapper class outputs 1-indexed classes. A label map can be found at
-    https://github.com/tensorflow/models/blob/master/research/object_detection/data/mscoco_label_map.pbtxt
-
-    This model only performs inference and is not trainable. To train
-    or fine-tune this model, please follow instructions at
-    https://github.com/tensorflow/models/blob/master/research/object_detection/g3doc/tf1.md
-    """
-
-    def __init__(self, images):
-        super().__init__(
-            images,
-            model=None,
-            filename="faster_rcnn_resnet50_coco_2018_01_28",
-            url="http://download.tensorflow.org/models/object_detection/faster_rcnn_resnet50_coco_2018_01_28.tar.gz",
-            sess=None,
-            is_training=False,
-            clip_values=(0, 1),
-            channels_first=False,
-            preprocessing_defences=None,
-            postprocessing_defences=None,
-            attack_losses=(
-                "Loss/RPNLoss/localization_loss",
-                "Loss/RPNLoss/objectness_loss",
-                "Loss/BoxClassifierLoss/localization_loss",
-                "Loss/BoxClassifierLoss/classification_loss",
-            ),
-        )
-
-    def compute_loss(self, x, y):
-        raise NotImplementedError
-
-
 def get_art_model(model_kwargs, wrapper_kwargs, weights_file=None):
     # APRICOT inputs should have shape (1, None, None, 3) while DAPRICOT inputs have shape
     # (3, None, None, 3)
     images = tf.placeholder(
         tf.float32, shape=(model_kwargs.get("batch_size", 1), None, None, 3)
     )
-    model = TensorFlowFasterRCNNOneIndexed(images)
+    model = TensorFlowFasterRCNN(
+        images,
+        model=None,
+        filename="faster_rcnn_resnet50_coco_2018_01_28",
+        url="http://download.tensorflow.org/models/object_detection/faster_rcnn_resnet50_coco_2018_01_28.tar.gz",
+        sess=None,
+        is_training=False,
+        clip_values=(0, 1),
+        channels_first=False,
+        preprocessing_defences=None,
+        postprocessing_defences=None,
+        attack_losses=(
+            "Loss/RPNLoss/localization_loss",
+            "Loss/RPNLoss/objectness_loss",
+            "Loss/BoxClassifierLoss/localization_loss",
+            "Loss/BoxClassifierLoss/classification_loss",
+        ),
+    )
+
     return model

--- a/armory/data/adversarial/apricot_metadata.py
+++ b/armory/data/adversarial/apricot_metadata.py
@@ -22,7 +22,7 @@ APRICOT_MODELS = [
 APRICOT_PATCHES = {
     0: {
         "adv_model": 0,
-        "adv_target": 53,
+        "adv_target": 52,
         "id": 0,
         "is_circle": True,
         "is_square": False,
@@ -30,7 +30,7 @@ APRICOT_PATCHES = {
     },
     1: {
         "adv_model": 0,
-        "adv_target": 27,
+        "adv_target": 26,
         "id": 1,
         "is_circle": True,
         "is_square": False,
@@ -38,7 +38,7 @@ APRICOT_PATCHES = {
     },
     2: {
         "adv_model": 0,
-        "adv_target": 44,
+        "adv_target": 43,
         "id": 2,
         "is_circle": True,
         "is_square": False,
@@ -46,7 +46,7 @@ APRICOT_PATCHES = {
     },
     3: {
         "adv_model": 0,
-        "adv_target": 17,
+        "adv_target": 16,
         "id": 3,
         "is_circle": True,
         "is_square": False,
@@ -54,7 +54,7 @@ APRICOT_PATCHES = {
     },
     4: {
         "adv_model": 0,
-        "adv_target": 85,
+        "adv_target": 84,
         "id": 4,
         "is_circle": True,
         "is_square": False,
@@ -62,7 +62,7 @@ APRICOT_PATCHES = {
     },
     5: {
         "adv_model": 0,
-        "adv_target": 73,
+        "adv_target": 72,
         "id": 5,
         "is_circle": True,
         "is_square": False,
@@ -70,7 +70,7 @@ APRICOT_PATCHES = {
     },
     6: {
         "adv_model": 0,
-        "adv_target": 78,
+        "adv_target": 77,
         "id": 6,
         "is_circle": True,
         "is_square": False,
@@ -78,7 +78,7 @@ APRICOT_PATCHES = {
     },
     7: {
         "adv_model": 0,
-        "adv_target": 1,
+        "adv_target": 0,
         "id": 7,
         "is_circle": True,
         "is_square": False,
@@ -86,7 +86,7 @@ APRICOT_PATCHES = {
     },
     8: {
         "adv_model": 0,
-        "adv_target": 64,
+        "adv_target": 63,
         "id": 8,
         "is_circle": True,
         "is_square": False,
@@ -94,7 +94,7 @@ APRICOT_PATCHES = {
     },
     9: {
         "adv_model": 0,
-        "adv_target": 33,
+        "adv_target": 32,
         "id": 9,
         "is_circle": True,
         "is_square": False,
@@ -102,7 +102,7 @@ APRICOT_PATCHES = {
     },
     10: {
         "adv_model": 0,
-        "adv_target": 53,
+        "adv_target": 52,
         "id": 10,
         "is_circle": False,
         "is_square": True,
@@ -110,7 +110,7 @@ APRICOT_PATCHES = {
     },
     11: {
         "adv_model": 0,
-        "adv_target": 27,
+        "adv_target": 26,
         "id": 11,
         "is_circle": False,
         "is_square": True,
@@ -118,7 +118,7 @@ APRICOT_PATCHES = {
     },
     12: {
         "adv_model": 0,
-        "adv_target": 44,
+        "adv_target": 43,
         "id": 12,
         "is_circle": False,
         "is_square": True,
@@ -126,7 +126,7 @@ APRICOT_PATCHES = {
     },
     13: {
         "adv_model": 0,
-        "adv_target": 17,
+        "adv_target": 16,
         "id": 13,
         "is_circle": False,
         "is_square": True,
@@ -134,7 +134,7 @@ APRICOT_PATCHES = {
     },
     14: {
         "adv_model": 0,
-        "adv_target": 85,
+        "adv_target": 84,
         "id": 14,
         "is_circle": False,
         "is_square": True,
@@ -142,7 +142,7 @@ APRICOT_PATCHES = {
     },
     15: {
         "adv_model": 0,
-        "adv_target": 73,
+        "adv_target": 72,
         "id": 15,
         "is_circle": False,
         "is_square": True,
@@ -150,7 +150,7 @@ APRICOT_PATCHES = {
     },
     16: {
         "adv_model": 0,
-        "adv_target": 78,
+        "adv_target": 77,
         "id": 16,
         "is_circle": False,
         "is_square": True,
@@ -158,7 +158,7 @@ APRICOT_PATCHES = {
     },
     17: {
         "adv_model": 0,
-        "adv_target": 1,
+        "adv_target": 0,
         "id": 17,
         "is_circle": False,
         "is_square": True,
@@ -166,7 +166,7 @@ APRICOT_PATCHES = {
     },
     18: {
         "adv_model": 0,
-        "adv_target": 64,
+        "adv_target": 63,
         "id": 18,
         "is_circle": False,
         "is_square": True,
@@ -174,7 +174,7 @@ APRICOT_PATCHES = {
     },
     19: {
         "adv_model": 0,
-        "adv_target": 33,
+        "adv_target": 32,
         "id": 19,
         "is_circle": False,
         "is_square": True,
@@ -182,7 +182,7 @@ APRICOT_PATCHES = {
     },
     20: {
         "adv_model": 1,
-        "adv_target": 53,
+        "adv_target": 52,
         "id": 20,
         "is_circle": True,
         "is_square": False,
@@ -190,7 +190,7 @@ APRICOT_PATCHES = {
     },
     21: {
         "adv_model": 1,
-        "adv_target": 27,
+        "adv_target": 26,
         "id": 21,
         "is_circle": True,
         "is_square": False,
@@ -198,7 +198,7 @@ APRICOT_PATCHES = {
     },
     22: {
         "adv_model": 1,
-        "adv_target": 44,
+        "adv_target": 43,
         "id": 22,
         "is_circle": True,
         "is_square": False,
@@ -206,7 +206,7 @@ APRICOT_PATCHES = {
     },
     23: {
         "adv_model": 1,
-        "adv_target": 17,
+        "adv_target": 16,
         "id": 23,
         "is_circle": True,
         "is_square": False,
@@ -214,7 +214,7 @@ APRICOT_PATCHES = {
     },
     24: {
         "adv_model": 1,
-        "adv_target": 85,
+        "adv_target": 84,
         "id": 24,
         "is_circle": True,
         "is_square": False,
@@ -222,7 +222,7 @@ APRICOT_PATCHES = {
     },
     25: {
         "adv_model": 1,
-        "adv_target": 73,
+        "adv_target": 72,
         "id": 25,
         "is_circle": True,
         "is_square": False,
@@ -230,7 +230,7 @@ APRICOT_PATCHES = {
     },
     26: {
         "adv_model": 1,
-        "adv_target": 78,
+        "adv_target": 77,
         "id": 26,
         "is_circle": True,
         "is_square": False,
@@ -238,7 +238,7 @@ APRICOT_PATCHES = {
     },
     27: {
         "adv_model": 1,
-        "adv_target": 1,
+        "adv_target": 0,
         "id": 27,
         "is_circle": True,
         "is_square": False,
@@ -246,7 +246,7 @@ APRICOT_PATCHES = {
     },
     28: {
         "adv_model": 1,
-        "adv_target": 64,
+        "adv_target": 63,
         "id": 28,
         "is_circle": True,
         "is_square": False,
@@ -254,7 +254,7 @@ APRICOT_PATCHES = {
     },
     29: {
         "adv_model": 1,
-        "adv_target": 33,
+        "adv_target": 32,
         "id": 29,
         "is_circle": True,
         "is_square": False,
@@ -262,7 +262,7 @@ APRICOT_PATCHES = {
     },
     30: {
         "adv_model": 1,
-        "adv_target": 53,
+        "adv_target": 52,
         "id": 30,
         "is_circle": False,
         "is_square": True,
@@ -270,7 +270,7 @@ APRICOT_PATCHES = {
     },
     31: {
         "adv_model": 1,
-        "adv_target": 27,
+        "adv_target": 26,
         "id": 31,
         "is_circle": False,
         "is_square": True,
@@ -278,7 +278,7 @@ APRICOT_PATCHES = {
     },
     32: {
         "adv_model": 1,
-        "adv_target": 44,
+        "adv_target": 43,
         "id": 32,
         "is_circle": False,
         "is_square": True,
@@ -286,7 +286,7 @@ APRICOT_PATCHES = {
     },
     33: {
         "adv_model": 1,
-        "adv_target": 17,
+        "adv_target": 16,
         "id": 33,
         "is_circle": False,
         "is_square": True,
@@ -294,7 +294,7 @@ APRICOT_PATCHES = {
     },
     34: {
         "adv_model": 1,
-        "adv_target": 85,
+        "adv_target": 84,
         "id": 34,
         "is_circle": False,
         "is_square": True,
@@ -302,7 +302,7 @@ APRICOT_PATCHES = {
     },
     35: {
         "adv_model": 1,
-        "adv_target": 73,
+        "adv_target": 72,
         "id": 35,
         "is_circle": False,
         "is_square": True,
@@ -310,7 +310,7 @@ APRICOT_PATCHES = {
     },
     36: {
         "adv_model": 1,
-        "adv_target": 78,
+        "adv_target": 77,
         "id": 36,
         "is_circle": False,
         "is_square": True,
@@ -318,7 +318,7 @@ APRICOT_PATCHES = {
     },
     37: {
         "adv_model": 1,
-        "adv_target": 1,
+        "adv_target": 0,
         "id": 37,
         "is_circle": False,
         "is_square": True,
@@ -326,7 +326,7 @@ APRICOT_PATCHES = {
     },
     38: {
         "adv_model": 1,
-        "adv_target": 64,
+        "adv_target": 63,
         "id": 38,
         "is_circle": False,
         "is_square": True,
@@ -334,7 +334,7 @@ APRICOT_PATCHES = {
     },
     39: {
         "adv_model": 1,
-        "adv_target": 33,
+        "adv_target": 32,
         "id": 39,
         "is_circle": False,
         "is_square": True,
@@ -342,7 +342,7 @@ APRICOT_PATCHES = {
     },
     40: {
         "adv_model": 2,
-        "adv_target": 53,
+        "adv_target": 52,
         "id": 40,
         "is_circle": True,
         "is_square": False,
@@ -350,7 +350,7 @@ APRICOT_PATCHES = {
     },
     41: {
         "adv_model": 2,
-        "adv_target": 27,
+        "adv_target": 26,
         "id": 41,
         "is_circle": True,
         "is_square": False,
@@ -358,7 +358,7 @@ APRICOT_PATCHES = {
     },
     42: {
         "adv_model": 2,
-        "adv_target": 44,
+        "adv_target": 43,
         "id": 42,
         "is_circle": True,
         "is_square": False,
@@ -366,7 +366,7 @@ APRICOT_PATCHES = {
     },
     43: {
         "adv_model": 2,
-        "adv_target": 17,
+        "adv_target": 16,
         "id": 43,
         "is_circle": True,
         "is_square": False,
@@ -374,7 +374,7 @@ APRICOT_PATCHES = {
     },
     44: {
         "adv_model": 2,
-        "adv_target": 85,
+        "adv_target": 84,
         "id": 44,
         "is_circle": True,
         "is_square": False,
@@ -382,7 +382,7 @@ APRICOT_PATCHES = {
     },
     45: {
         "adv_model": 2,
-        "adv_target": 73,
+        "adv_target": 72,
         "id": 45,
         "is_circle": True,
         "is_square": False,
@@ -390,7 +390,7 @@ APRICOT_PATCHES = {
     },
     46: {
         "adv_model": 2,
-        "adv_target": 78,
+        "adv_target": 77,
         "id": 46,
         "is_circle": True,
         "is_square": False,
@@ -398,7 +398,7 @@ APRICOT_PATCHES = {
     },
     47: {
         "adv_model": 2,
-        "adv_target": 1,
+        "adv_target": 0,
         "id": 47,
         "is_circle": True,
         "is_square": False,
@@ -406,7 +406,7 @@ APRICOT_PATCHES = {
     },
     48: {
         "adv_model": 2,
-        "adv_target": 64,
+        "adv_target": 63,
         "id": 48,
         "is_circle": True,
         "is_square": False,
@@ -414,7 +414,7 @@ APRICOT_PATCHES = {
     },
     49: {
         "adv_model": 2,
-        "adv_target": 33,
+        "adv_target": 32,
         "id": 49,
         "is_circle": True,
         "is_square": False,
@@ -422,7 +422,7 @@ APRICOT_PATCHES = {
     },
     50: {
         "adv_model": 2,
-        "adv_target": 53,
+        "adv_target": 52,
         "id": 50,
         "is_circle": False,
         "is_square": True,
@@ -430,7 +430,7 @@ APRICOT_PATCHES = {
     },
     51: {
         "adv_model": 2,
-        "adv_target": 27,
+        "adv_target": 26,
         "id": 51,
         "is_circle": False,
         "is_square": True,
@@ -438,7 +438,7 @@ APRICOT_PATCHES = {
     },
     52: {
         "adv_model": 2,
-        "adv_target": 44,
+        "adv_target": 43,
         "id": 52,
         "is_circle": False,
         "is_square": True,
@@ -446,7 +446,7 @@ APRICOT_PATCHES = {
     },
     53: {
         "adv_model": 2,
-        "adv_target": 17,
+        "adv_target": 16,
         "id": 53,
         "is_circle": False,
         "is_square": True,
@@ -454,7 +454,7 @@ APRICOT_PATCHES = {
     },
     54: {
         "adv_model": 2,
-        "adv_target": 85,
+        "adv_target": 84,
         "id": 54,
         "is_circle": False,
         "is_square": True,
@@ -462,7 +462,7 @@ APRICOT_PATCHES = {
     },
     55: {
         "adv_model": 2,
-        "adv_target": 73,
+        "adv_target": 72,
         "id": 55,
         "is_circle": False,
         "is_square": True,
@@ -470,7 +470,7 @@ APRICOT_PATCHES = {
     },
     56: {
         "adv_model": 2,
-        "adv_target": 78,
+        "adv_target": 77,
         "id": 56,
         "is_circle": False,
         "is_square": True,
@@ -478,7 +478,7 @@ APRICOT_PATCHES = {
     },
     57: {
         "adv_model": 2,
-        "adv_target": 1,
+        "adv_target": 0,
         "id": 57,
         "is_circle": False,
         "is_square": True,
@@ -486,7 +486,7 @@ APRICOT_PATCHES = {
     },
     58: {
         "adv_model": 2,
-        "adv_target": 64,
+        "adv_target": 63,
         "id": 58,
         "is_circle": False,
         "is_square": True,
@@ -494,7 +494,7 @@ APRICOT_PATCHES = {
     },
     59: {
         "adv_model": 2,
-        "adv_target": 33,
+        "adv_target": 32,
         "id": 59,
         "is_circle": False,
         "is_square": True,

--- a/armory/data/adversarial_datasets.py
+++ b/armory/data/adversarial_datasets.py
@@ -321,11 +321,13 @@ def gtsrb_poison(
 
 def apricot_label_preprocessing(x, y):
     """
-    Convert labels to list of dicts. If batch_size > 1, this will already be the case,
-    and y will simply be returned without modification.
+    Convert labels to list of dicts. If batch_size > 1, this will already be the case.
+    Decrement labels of non-patch objects by 1 to be 0-indexed
     """
     if isinstance(y, dict):
         y = [y]
+    for y_dict in y:
+        y_dict["labels"] -= y_dict["labels"] != ADV_PATCH_MAGIC_NUMBER_LABEL_ID
     return y
 
 

--- a/armory/data/cached_s3_checksums/coco.txt
+++ b/armory/data/cached_s3_checksums/coco.txt
@@ -1,0 +1,1 @@
+armory-public-data coco/coco_2017_1.1.0.tar.gz 26637028273 8ded05e62039b40b1610104268eb8a712519903fea56a5b3b2a68acae87fb30c

--- a/armory/data/datasets.py
+++ b/armory/data/datasets.py
@@ -1391,22 +1391,96 @@ def coco_label_preprocessing(x, y):
     If batch_size is 1, this function converts the single y dictionary to a list of length 1.
     This function converts COCO labels from a 0-79 range to the standard 0-89 with 10 unused indices
     (see https://github.com/tensorflow/models/blob/master/research/object_detection/data/mscoco_label_map.pbtxt).
+    The label map used matches the link above, with the note that labels start from 0 rather than 1.
     """
     # This will be true only when batch_size is 1
     if isinstance(y, dict):
         y = [y]
-
-    # 80 COCO classes range from ID 0 through 89 with 10 unused values
-    NUM_COCO_CLASSES = 80
-    unused_indices = [11, 25, 28, 29, 44, 65, 67, 68, 70, 82]
-    coco_labels = list(range(NUM_COCO_CLASSES + len(unused_indices)))
-    for idx in unused_indices:
-        coco_labels.remove(idx)
-    label_map = {i: coco_labels[i] for i in range(NUM_COCO_CLASSES)}
-
+    idx_map = {
+        0: 0,
+        1: 1,
+        2: 2,
+        3: 3,
+        4: 4,
+        5: 5,
+        6: 6,
+        7: 7,
+        8: 8,
+        9: 9,
+        10: 10,
+        11: 12,
+        12: 13,
+        13: 14,
+        14: 15,
+        15: 16,
+        16: 17,
+        17: 18,
+        18: 19,
+        19: 20,
+        20: 21,
+        21: 22,
+        22: 23,
+        23: 24,
+        24: 26,
+        25: 27,
+        26: 30,
+        27: 31,
+        28: 32,
+        29: 33,
+        30: 34,
+        31: 35,
+        32: 36,
+        33: 37,
+        34: 38,
+        35: 39,
+        36: 40,
+        37: 41,
+        38: 42,
+        39: 43,
+        40: 45,
+        41: 46,
+        42: 47,
+        43: 48,
+        44: 49,
+        45: 50,
+        46: 51,
+        47: 52,
+        48: 53,
+        49: 54,
+        50: 55,
+        51: 56,
+        52: 57,
+        53: 58,
+        54: 59,
+        55: 60,
+        56: 61,
+        57: 62,
+        58: 63,
+        59: 64,
+        60: 66,
+        61: 69,
+        62: 71,
+        63: 72,
+        64: 73,
+        65: 74,
+        66: 75,
+        67: 76,
+        68: 77,
+        69: 78,
+        70: 79,
+        71: 80,
+        72: 81,
+        73: 83,
+        74: 84,
+        75: 85,
+        76: 86,
+        77: 87,
+        78: 88,
+        79: 89,
+    }
     for label_dict in y:
         label_dict["boxes"] = label_dict.pop("bbox").reshape(-1, 4)
-        label_dict["labels"] = np.vectorize(label_map.__getitem__)(
+        label_dict["labels"] = np.vectorize(idx_map.__getitem__)(
             label_dict.pop("label").reshape(-1,)
         )
     return y

--- a/armory/data/datasets.py
+++ b/armory/data/datasets.py
@@ -1419,9 +1419,7 @@ def coco2017(
     """
     preprocessing_fn = preprocessing_chain(preprocessing_fn, fit_preprocessing_fn)
     if "class_ids" in kwargs:
-        raise ValueError(
-            "Filtering by class is not supported for the coco2017 dataset"
-        )
+        raise ValueError("Filtering by class is not supported for the coco2017 dataset")
     return _generator_from_tfds(
         "coco/2017:1.1.0",
         split=split,

--- a/armory/data/datasets.py
+++ b/armory/data/datasets.py
@@ -676,6 +676,7 @@ resisc45_context = ImageContext(x_shape=(256, 256, 3))
 resisc10_context = ImageContext(x_shape=(64, 64, 3))
 imagenette_context = ImageContext(x_shape=(None, None, 3))
 xview_context = ImageContext(x_shape=(None, None, 3))
+coco_context = ImageContext(x_shape=(None, None, 3))
 ucf101_context = VideoContext(x_shape=(None, None, None, 3), frame_rate=25)
 
 
@@ -709,6 +710,10 @@ def imagenette_canonical_preprocessing(batch):
 
 def xview_canonical_preprocessing(batch):
     return canonical_variable_image_preprocess(xview_context, batch)
+
+
+def coco_canonical_preprocessing(batch):
+    return canonical_variable_image_preprocess(coco_context, batch)
 
 
 def ucf101_canonical_preprocessing(batch):
@@ -1377,6 +1382,62 @@ def xview(
         framework=framework,
         shuffle_files=shuffle_files,
         context=xview_context,
+        **kwargs,
+    )
+
+
+def coco_label_preprocessing(x, y):
+    """
+    If batch_size is 1, this function converts the single y dictionary to a list of length 1.
+    """
+    # This will be true only when batch_size is 1
+    if isinstance(y, dict):
+        y = [y]
+    for label_dict in y:
+        label_dict["boxes"] = label_dict.pop("bbox").reshape(-1, 4)
+        label_dict["labels"] = label_dict.pop("label").reshape(-1,)
+    return y
+
+
+def coco2017(
+    split: str = "train",
+    epochs: int = 1,
+    batch_size: int = 1,
+    dataset_dir: str = None,
+    preprocessing_fn: Callable = coco_canonical_preprocessing,
+    label_preprocessing_fn: Callable = coco_label_preprocessing,
+    fit_preprocessing_fn: Callable = None,
+    cache_dataset: bool = True,
+    framework: str = "numpy",
+    shuffle_files: bool = True,
+    **kwargs,
+) -> ArmoryDataGenerator:
+    """
+    split - one of ("train", "validation", "test")
+
+    Note: images from the "test" split are not annotated.
+    """
+    preprocessing_fn = preprocessing_chain(preprocessing_fn, fit_preprocessing_fn)
+    if "class_ids" in kwargs:
+        raise ValueError(
+            "Filtering by class is not supported for the coco2017 dataset"
+        )
+    return _generator_from_tfds(
+        "coco/2017:1.1.0",
+        split=split,
+        batch_size=batch_size,
+        epochs=epochs,
+        dataset_dir=dataset_dir,
+        preprocessing_fn=preprocessing_fn,
+        label_preprocessing_fn=label_preprocessing_fn,
+        as_supervised=False,
+        supervised_xy_keys=("image", "objects"),
+        variable_length=bool(batch_size > 1),
+        variable_y=bool(batch_size > 1),
+        cache_dataset=cache_dataset,
+        framework=framework,
+        shuffle_files=shuffle_files,
+        context=coco_context,
         **kwargs,
     )
 

--- a/docs/datasets.md
+++ b/docs/datasets.md
@@ -25,6 +25,7 @@ These tfrecord files will be pulled from S3 if not available on your
 | [Coco2017](https://arxiv.org/abs/1405.0312) | Common Objects in Context | (N, variable_height, variable_width, 3) | float32 | n/a | dict | train, validation, test | 
 | [xView](https://arxiv.org/pdf/1802.07856) | Objects in Context in Overhead Imagery | (N, variable_height, variable_width, 3) | float32 | n/a | dict | train, test | 
 
+NOTE: the Coco2017 dataset's class labels are 0-indexed (start from 0).
 <br>
 
 ### Audio Datasets

--- a/docs/datasets.md
+++ b/docs/datasets.md
@@ -22,6 +22,7 @@ These tfrecord files will be pulled from S3 if not available on your
 | [imagenette](https://github.com/fastai/imagenette) | Smaller subset of 10 classes from Imagenet | (N, variable_height, variable_width, 3) | uint8  | (N,) | int64 | train, validation |
 | [mnist](http://yann.lecun.com/exdb/mnist/) | MNIST hand written digit image dataset | (N, 28, 28, 1) | float32 | (N,) | int64 | train, test | 
 | [resisc45](https://arxiv.org/abs/1703.00121) | REmote Sensing Image Scene Classification | (N, 256, 256, 3) | float32 | (N,) | int64 | train, validation, test | 
+| [Coco2017](https://arxiv.org/abs/1405.0312) | Common Objects in Context | (N, variable_height, variable_width, 3) | float32 | n/a | dict | train, validation, test | 
 | [xView](https://arxiv.org/pdf/1802.07856) | Objects in Context in Overhead Imagery | (N, variable_height, variable_width, 3) | float32 | n/a | dict | train, test | 
 
 <br>

--- a/tests/test_docker/test_dataset.py
+++ b/tests/test_docker/test_dataset.py
@@ -482,24 +482,6 @@ def test_dapricot():
                 assert patch_metadata_key in y_patch_metadata[k]
 
 
-def test_coco2017():
-    split_size = 5000
-    split = "validation"
-    dataset = datasets.coco2017(split=split,)
-    assert dataset.size == split_size
-
-    for i in range(8):
-        x, y = dataset.get_batch()
-        assert x.shape[0] == 1
-        assert x.shape[-1] == 3
-        assert isinstance(y, list)
-        assert len(y) == 1
-        y_dict = y[0]
-        assert isinstance(y_dict, dict)
-        for obj_key in ["labels", "boxes", "area"]:
-            assert obj_key in y_dict
-
-
 def test_ucf101_adversarial_112x112():
     if not os.path.isdir(
         os.path.join(

--- a/tests/test_docker/test_dataset.py
+++ b/tests/test_docker/test_dataset.py
@@ -482,6 +482,24 @@ def test_dapricot():
                 assert patch_metadata_key in y_patch_metadata[k]
 
 
+def test_coco2017():
+    split_size = 5000
+    split = "validation"
+    dataset = datasets.coco2017(split=split,)
+    assert dataset.size == split_size
+
+    for i in range(8):
+        x, y = dataset.get_batch()
+        assert x.shape[0] == 1
+        assert x.shape[-1] == 3
+        assert isinstance(y, list)
+        assert len(y) == 1
+        y_dict = y[0]
+        assert isinstance(y_dict, dict)
+        for obj_key in ["labels", "boxes", "area"]:
+            assert obj_key in y_dict
+
+
 def test_ucf101_adversarial_112x112():
     if not os.path.isdir(
         os.path.join(

--- a/tests/test_tf1/test_tf1_models.py
+++ b/tests/test_tf1/test_tf1_models.py
@@ -120,29 +120,3 @@ def test_tf1_apricot():
     }
     for class_id, expected_AP in expected_patch_targeted_AP_by_class.items():
         assert np.abs(patch_targeted_AP_by_class[class_id] - expected_AP) < 0.03
-
-
-@pytest.mark.usefixtures("ensure_armory_dirs")
-def test_tf1_coco():
-    detector_module = import_module("armory.baseline_models.tf_graph.mscoco_frcnn")
-    detector_fn = getattr(detector_module, "get_art_model")
-    detector = detector_fn(model_kwargs={}, wrapper_kwargs={})
-
-    NUM_TEST_SAMPLES = 10
-    dataset = datasets.coco2017(split="validation", shuffle_files=False)
-
-    list_of_ys = []
-    list_of_ypreds = []
-    for _ in range(NUM_TEST_SAMPLES):
-        x, y = dataset.get_batch()
-        y_pred = detector.predict(x)
-        list_of_ys.extend(y)
-        list_of_ypreds.extend(y_pred)
-
-    average_precision_by_class = object_detection_AP_per_class(
-        list_of_ys, list_of_ypreds
-    )
-    mAP = np.fromiter(average_precision_by_class.values(), dtype=float).mean()
-    for class_id in [0, 2, 5, 9, 10]:
-        assert average_precision_by_class[class_id] > 0.6
-    assert mAP > 0.1


### PR DESCRIPTION
Closes #1069.

Beyond integrating the COCO dataset, this PR also ensures that (1) the COCO dataset, (2) the APRICOT dataset, and (3) the COCO baseline model (which is used for APRICOT too) are all 0-indexed, meaning object labels start at 0 rather than 1. 

The tfds COCO dataset comes 0-indexed out-of-the-box, as does the [baseline model](https://github.com/lcadalzo/armory/blob/1069-coco-integration/armory/baseline_models/tf_graph/mscoco_frcnn.py#L22). The APRICOT dataset came 1-indexed, though, and so previously (i.e. currently in Armory 0.13.1), the baseline model was [modified](https://github.com/twosixlabs/armory/blob/v0.13.1/armory/baseline_models/tf_graph/mscoco_frcnn.py#L54-L61) to output 1-indexed classes to avoid a label mismatch. 

This PR undoes this modification and makes everything 0-indexed. For the APRICOT dataset, this means adding a label_preprocessing function to decrement labels by 1 so that they're 0-indexed and thus align with the baseline model (and COCO dataset).

Note: this baseline model is also used in the D-APRICOT scenario, although the D-APRICOT dataset doesn't contain labels for COCO objects so no update to the D-APRICOT dataset is needed