### PR TITLE
WIP: OD label format comply with ART >= 1.6.2

### DIFF
--- a/armory/data/adversarial_datasets.py
+++ b/armory/data/adversarial_datasets.py
@@ -322,10 +322,13 @@ def gtsrb_poison(
 def apricot_label_preprocessing(x, y):
     """
     Convert labels to list of dicts. If batch_size > 1, this will already be the case,
-    and y will simply be returned without modification.
+    and y will simply be returned without modification. Converts labels from shape
+    (1, num_boxes) to shape (num_boxes,).
     """
     if isinstance(y, dict):
         y = [y]
+    for label_dict in y:
+        label_dict["labels"] = label_dict["labels"].reshape((-1,))
     return y
 
 

--- a/armory/data/datasets.py
+++ b/armory/data/datasets.py
@@ -1333,6 +1333,7 @@ def xview_label_preprocessing(x, y):
         height, width = x[i].shape[:2]
         converted_boxes *= [width, height, width, height]
         label_dict["boxes"] = converted_boxes
+        label_dict["labels"] = label_dict["labels"].reshape((-1,))
         y_preprocessed.append(label_dict)
     return y_preprocessed
 


### PR DESCRIPTION
Closes #1083. This will enable setting `"use_label": true` for xView when using ART >= 1.6.2.