### PR TITLE
Add non-preloaded dirty-label backdoor attack with bullethole trigger

### DIFF
--- a/scenario_configs/gtsrb_scenario_bullethole.json
+++ b/scenario_configs/gtsrb_scenario_bullethole.json
@@ -1,0 +1,75 @@
+{
+    "_description": "GTSRB poison image classification, contributed by MITRE Corporation",
+    "adhoc": {
+        "detection_kwargs": {
+            "nb_clusters": 2,
+            "nb_dims": 43,
+            "reduce": "PCA"
+        },
+        "experiment_id": 0,
+        "fraction_poisoned": 0.1,
+        "poison_dataset": true,
+        "source_class": 1,
+        "split_id": 0,
+        "target_class": 2,
+        "train_epochs": 50,
+        "use_poison_filtering_defense": true
+    },
+    "attack": {
+        "knowledge": "black",
+        "kwargs": {
+            "backdoor_packaged_with_armory": true,
+            "backdoor_path": "./armory/utils/triggers/bullet_holes.png",
+            "poison_module": "art.attacks.poisoning.perturbations",
+            "poison_type": "image",
+            "size": [
+                17,
+                15
+            ]
+        },
+        "module": "armory.art_experimental.attacks.poison_loader",
+        "name": "poison_loader_GTSRB"
+    },
+    "dataset": {
+        "batch_size": 512,
+        "framework": "numpy",
+        "module": "armory.data.datasets",
+        "name": "german_traffic_sign"
+    },
+    "defense": {
+        "kwargs": {
+            "cluster_analysis": "smaller",
+            "clustering_method": "KMeans",
+            "nb_clusters": 2,
+            "nb_dims": 43,
+            "reduce": "PCA"
+        },
+        "module": "art.defences.detector.poison.activation_defence",
+        "name": "ActivationDefence",
+        "type": "PoisonFilteringDefence"
+    },
+    "metric": null,
+    "model": {
+        "fit": true,
+        "fit_kwargs": {},
+        "model_kwargs": {},
+        "module": "armory.baseline_models.keras.micronnet_gtsrb",
+        "name": "get_art_model",
+        "weights_file": null,
+        "wrapper_kwargs": {}
+    },
+    "scenario": {
+        "kwargs": {},
+        "module": "armory.scenarios.poisoning_gtsrb_scenario",
+        "name": "GTSRB"
+    },
+    "sysconfig": {
+        "docker_image": "twosixarmory/tf1:0.13.3",
+        "external_github_repo": null,
+        "gpus": "all",
+        "output_dir": null,
+        "output_filename": null,
+        "set_pythonhashseed": true,
+        "use_gpu": false
+    }
+}

--- a/scenario_configs/gtsrb_scenario_bullethole.json
+++ b/scenario_configs/gtsrb_scenario_bullethole.json
@@ -64,7 +64,7 @@
         "name": "GTSRB"
     },
     "sysconfig": {
-        "docker_image": "twosixarmory/tf1:0.13.3",
+        "docker_image": "twosixarmory/tf1:0.14.0",
         "external_github_repo": null,
         "gpus": "all",
         "output_dir": null,


### PR DESCRIPTION
Add non-preloaded dirty-label backdoor attack with bullethole trigger - the preloaded dataset now will be deprecated.