### PR TITLE
Dataset Indexing - Index and class filtering from command line

### DIFF
--- a/armory/data/datasets.py
+++ b/armory/data/datasets.py
@@ -278,24 +278,18 @@ def filter_by_index(dataset: "tf.data.Dataset", index: list, dataset_size: int):
     """
     logger.info(f"Filtering dataset to the following indices: {index}")
     dataset_size = int(dataset_size)
-    if len(index) == 0:
-        raise ValueError(
-            "The specified dataset 'index' param must have at least one value"
-        )
-    valid_indices = sorted([int(x) for x in set(index) if int(x) < dataset_size])
-    num_valid_indices = len(valid_indices)
-    if num_valid_indices == 0:
-        raise ValueError(
-            f"The specified dataset 'index' param values all exceed dataset size of {dataset_size}"
-        )
-    elif index[0] < 0:
+    sorted_index = sorted([int(x) for x in set(index)])
+    if len(sorted_index) == 0:
+        raise ValueError("The specified dataset 'index' param must be nonempty")
+    if sorted_index[0] < 0:
         raise ValueError("The specified dataset 'index' values must be nonnegative")
-    elif num_valid_indices != len(set(index)):
-        logger.warning(
-            f"All dataset 'index' values exceeding dataset size of {dataset_size} are being ignored"
+    if sorted_index[-1] >= dataset_size:
+        raise ValueError(
+            f"The specified dataset 'index' values exceed dataset size {dataset_size}"
         )
+    num_valid_indices = len(sorted_index)
 
-    index_tensor = tf.constant(index, dtype=tf.int64)
+    index_tensor = tf.constant(sorted_index, dtype=tf.int64)
 
     def enum_index(i, x):
         i = tf.expand_dims(i, 0)

--- a/docs/command_line.md
+++ b/docs/command_line.md
@@ -54,9 +54,11 @@ armory launch tf1 --gpus=1,4 --interactive
 armory exec pytorch --gpus=0 -- nvidia-smi
 ```
 
-## Check Runs and Number of Examples
+## Check Runs, Number of Example Batches, Indexing, and Class Filtering
 * `armory run <config> --check [...]`
 * `armory run <config> --num-eval-batches=X [...]`
+* `armory run <config> --index=a,b,c [...]`
+* `armory run <config> --classes=x,y,z [...]`
 Applies to `run` command.
 
 The `--check` flag will make every dataset return a single batch,
@@ -67,6 +69,17 @@ The `--num-eval-batches` argument will truncate the number of batches used in
 both benign and adversarial test sets.
 It is primarily designed for attack development iteration, where it is typically unhelpful
 to run more than 10-100 examples.
+
+The `--index` argument will only use samples from the comma-separated, non-negative list of numbers provided.
+Any duplicate numbers will be removed and the list will be sorted.
+If indices beyond the size of the dataset are provided, an error will result at runtime.
+Cannot be used with the `--num-eval-batches` argument.
+Currently, batch size must be set to 1.
+
+The `--classes` argument will only use samples from the comma-separated, non-negative list of numbers provided.
+Any duplicate numbers will be removed and the list will be sorted.
+If indices beyond the size of the dataset are provided, an error will result at runtime.
+Can be used with `--index` argument. In that case, indexing will be done after class filtering.
 
 NOTE: `--check` will take precedence over the `--num-eval-batches` argument.
 


### PR DESCRIPTION
It turns out that most of the functionality was already done:
https://github.com/twosixlabs/armory/blob/dev/armory/data/datasets.py#L273-L337

With tests:
https://github.com/twosixlabs/armory/blob/dev/tests/test_docker/test_dataset.py#L71-L142

I just added hooks for the command line, `--index` and `--classes`, and updated the docs.

Will close the previous PR as there was unnecessary code there.