### PR TITLE
first check if y is numpy array before checking dtype

### DIFF
--- a/armory/art_experimental/attacks/sweep.py
+++ b/armory/art_experimental/attacks/sweep.py
@@ -144,10 +144,9 @@ class SweepAttack(EvasionAttack):
             return metric_result > self.metric_threshold
 
     def _get_metric_result(self, y, y_pred):
-        if isinstance(y, np.ndarray):
-            if y.dtype == np.object:
-                # convert np object array to list of dicts
-                metric_result = self.metric_fn([y[0]], y_pred)
+        if isinstance(y, np.ndarray) and y.dtype == np.object:
+            # convert np object array to list of dicts
+            metric_result = self.metric_fn([y[0]], y_pred)
         else:
             metric_result = self.metric_fn(y, y_pred)
         if isinstance(metric_result, list):


### PR DESCRIPTION
Current bug in `art_experimental/attacks/sweep.py` assumes `y` is a np array when checking `y.dtype`, but `y` can be a list

To test:
```
python -m armory run scenario_configs/xview_frcnn_sweep_patch_size.json --check
```