### PR TITLE
disable filter by class for carla datasets

### DIFF
--- a/armory/data/adversarial_datasets.py
+++ b/armory/data/adversarial_datasets.py
@@ -599,6 +599,10 @@ def carla_obj_det_dev(
     Dev set for CARLA object detection dataset, containing RGB and depth channels. The dev
     set also contains green screens for adversarial patch insertion.
     """
+    if "class_ids" in kwargs:
+        raise ValueError(
+            "Filtering by class is not supported for the carla_obj_det_dev dataset"
+        )
     if batch_size != 1:
         raise ValueError("carla_obj_det_dev batch size must be set to 1")
 
@@ -671,6 +675,10 @@ def carla_video_tracking_dev(
     Dev set for CARLA video tracking dataset, The dev set also contains green screens
     for adversarial patch insertion.
     """
+    if "class_ids" in kwargs:
+        raise ValueError(
+            "Filtering by class is not supported for the carla_video_tracking_dev dataset"
+        )
     if batch_size != 1:
         raise ValueError("carla_obj_det_dev batch size must be set to 1")
 

--- a/armory/data/datasets.py
+++ b/armory/data/datasets.py
@@ -865,6 +865,10 @@ def carla_obj_det_train(
     """
     Training set for CARLA object detection dataset, containing RGB and depth channels.
     """
+    if "class_ids" in kwargs:
+        raise ValueError(
+            "Filtering by class is not supported for the carla_obj_det_train dataset"
+        )
     modality = kwargs.pop("modality", "rgb")
     if modality not in ["rgb", "depth", "both"]:
         raise ValueError(


### PR DESCRIPTION
Filtering by class is only supported for classification datasets. Prior to the additions in this PR, the user instead sees an ambiguous TF error when trying to filter CARLA datasets by class