### PR TITLE
train_split kwarg shouldnt be passed along to ds function

### DIFF
--- a/armory/utils/config_loading.py
+++ b/armory/utils/config_loading.py
@@ -67,7 +67,7 @@ def load_dataset(dataset_config, *args, num_batches=None, check_run=False, **kwa
 
     # Add remaining dataset_config items to kwargs
     for remaining_kwarg in dataset_config:
-        if remaining_kwarg == "eval_split":
+        if remaining_kwarg in ["eval_split", "train_split"]:
             continue
         kwargs[remaining_kwarg] = dataset_config[remaining_kwarg]
 


### PR DESCRIPTION
Fixes dataset loading bug for configs with `"train_split"` field in dataset config.

 To test:

```
python -m armory run scenario_configs/librispeech_asr_kenansville_defended.json
```