### PR TITLE
fix carla video attack

### DIFF
--- a/armory/art_experimental/attacks/carla_adversarial_texture.py
+++ b/armory/art_experimental/attacks/carla_adversarial_texture.py
@@ -55,8 +55,8 @@ class AdversarialPhysicalTexture(AdversarialTexturePyTorch):
         patch_width = np.max(gs_coords[:, 0]) - np.min(gs_coords[:, 0])
         patch_height = np.max(gs_coords[:, 1]) - np.min(gs_coords[:, 1])
 
-        self.x_min = np.min(gs_coords[:, 0])
-        self.y_min = np.min(gs_coords[:, 1])
+        self.x_min = np.min(gs_coords[:, 1])
+        self.y_min = np.min(gs_coords[:, 0])
         self.patch_height = patch_height
         self.patch_width = patch_width
 


### PR DESCRIPTION
Fixed a bug in CARLA video patch attack that resulted in either a slightly misalignment between patch and green screen or a patch that's only partially perturbed.