### PR TITLE
point ci build to develop branch instead of dev

### DIFF
--- a/.github/workflows/ci_test.yml
+++ b/.github/workflows/ci_test.yml
@@ -5,12 +5,12 @@ on:
   push:
     branches:
       - master
-      - dev
+      - develop
 
   pull_request:
     branches:
       - master
-      - dev
+      - develop
 
   workflow_dispatch:
 


### PR DESCRIPTION
Uses `develop` instead of `dev` in CI build.