### PR TITLE
Integrate ART 1.9.1 including Tensorboard feature

### DIFF
--- a/armory/__init__.py
+++ b/armory/__init__.py
@@ -8,7 +8,7 @@ logger.addHandler(logging.NullHandler())
 
 
 # Semantic Version
-__version__ = "0.14.2"
+__version__ = "0.14.3"
 
 # typedef for a widely used JSON-like configuration specification
 from typing import Dict, Any

--- a/armory/scenarios/scenario.py
+++ b/armory/scenarios/scenario.py
@@ -148,11 +148,6 @@ class Scenario:
         if attack_type == "preloaded" and self.skip_misclassified:
             raise ValueError("Cannot use skip_misclassified with preloaded dataset")
 
-        targeted = bool(attack_config.get("kwargs", {}).get("targeted"))
-        use_label = bool(attack_config.get("use_label"))
-        if targeted and use_label:
-            raise ValueError("Targeted attacks cannot have 'use_label'")
-
         if "summary_writer" in attack_config.get("kwargs", {}):
             summary_writer_kwarg = attack_config.get("kwargs").get("summary_writer")
             if isinstance(summary_writer_kwarg, str):

--- a/armory/scenarios/scenario.py
+++ b/armory/scenarios/scenario.py
@@ -153,14 +153,14 @@ class Scenario:
         if targeted and use_label:
             raise ValueError("Targeted attacks cannot have 'use_label'")
 
-        if "tensor_board" in attack_config.get("kwargs", {}):
-            tensor_board_kwarg = attack_config.get("kwargs").get("tensor_board")
-            if isinstance(tensor_board_kwarg, str):
+        if "summary_writer" in attack_config.get("kwargs", {}):
+            summary_writer_kwarg = attack_config.get("kwargs").get("summary_writer")
+            if isinstance(summary_writer_kwarg, str):
                 logger.warning(
-                    f"Overriding 'tensor_board' attack kwarg {tensor_board_kwarg} with {self.scenario_output_dir}."
+                    f"Overriding 'summary_writer' attack kwarg {summary_writer_kwarg} with {self.scenario_output_dir}."
                 )
             attack_config["kwargs"][
-                "tensor_board"
+                "summary_writer"
             ] = f"{self.scenario_output_dir}/tfevents_{self.time_stamp}"
         if attack_type == "preloaded":
             preloaded_split = attack_config.get("kwargs", {}).get(

--- a/armory/scenarios/scenario.py
+++ b/armory/scenarios/scenario.py
@@ -66,6 +66,7 @@ class Scenario:
         if skip_attack:
             logger.info("Skipping attack generation...")
         self.mongo_host = mongo_host
+        self.time_stamp = time.time()
         if self.mongo_host is not None:  # fail fast if pymongo is not installed
             from armory.scenarios import mongo  # noqa: F401
 
@@ -147,6 +148,20 @@ class Scenario:
         if attack_type == "preloaded" and self.skip_misclassified:
             raise ValueError("Cannot use skip_misclassified with preloaded dataset")
 
+        targeted = bool(attack_config.get("kwargs", {}).get("targeted"))
+        use_label = bool(attack_config.get("use_label"))
+        if targeted and use_label:
+            raise ValueError("Targeted attacks cannot have 'use_label'")
+
+        if "tensor_board" in attack_config.get("kwargs", {}):
+            tensor_board_kwarg = attack_config.get("kwargs").get("tensor_board")
+            if isinstance(tensor_board_kwarg, str):
+                logger.warning(
+                    f"Overriding 'tensor_board' attack kwarg {tensor_board_kwarg} with {self.scenario_output_dir}."
+                )
+            attack_config["kwargs"][
+                "tensor_board"
+            ] = f"{self.scenario_output_dir}/tfevents_{self.time_stamp}"
         if attack_type == "preloaded":
             preloaded_split = attack_config.get("kwargs", {}).get(
                 "split", "adversarial"
@@ -365,12 +380,11 @@ class Scenario:
         if adv_examples is not None:
             raise NotImplementedError("saving adversarial examples")
 
-        timestamp = int(time.time())
         output = {
             "armory_version": armory.__version__,
             "config": config,
             "results": results,
-            "timestamp": timestamp,
+            "timestamp": int(self.time_stamp),
         }
         return output
 

--- a/docker/pytorch-deepspeech/Dockerfile
+++ b/docker/pytorch-deepspeech/Dockerfile
@@ -30,7 +30,9 @@ RUN /opt/conda/bin/pip install --no-cache-dir \
     dill==0.3.1.1 \
     pytest==6.2.2 \
     pandas==1.2.4 \
-    ffmpeg-python==0.2.0
+    ffmpeg-python==0.2.0 \
+    matplotlib==3.5.1 \
+    tensorboardX==2.4.1
 
 
 RUN /opt/conda/bin/conda install -c conda-forge ffmpeg==4.2.3 && \
@@ -63,7 +65,7 @@ RUN /opt/conda/bin/pip install hydra-core==1.0.6 \
     soundfile \
     sox \
     warpctc-pytorch==0.2.1+torch16.cuda102 \
-    git+https://github.com/Trusted-AI/adversarial-robustness-toolbox.git@development_object_tracking_attack --no-cache-dir
+    adversarial-robustness-toolbox==1.9.0 --no-cache-dir
 
 
 ########## PyTorch 1 Deep Speech Dev #################

--- a/docker/pytorch-deepspeech/Dockerfile
+++ b/docker/pytorch-deepspeech/Dockerfile
@@ -64,7 +64,7 @@ RUN /opt/conda/bin/pip install hydra-core==1.0.6 \
     soundfile \
     sox \
     warpctc-pytorch==0.2.1+torch16.cuda102 \
-    adversarial-robustness-toolbox==1.9.0 --no-cache-dir
+    adversarial-robustness-toolbox==1.9.1 --no-cache-dir
 
 
 ########## PyTorch 1 Deep Speech Dev #################

--- a/docker/pytorch-deepspeech/Dockerfile
+++ b/docker/pytorch-deepspeech/Dockerfile
@@ -31,7 +31,6 @@ RUN /opt/conda/bin/pip install --no-cache-dir \
     pytest==6.2.2 \
     pandas==1.2.4 \
     ffmpeg-python==0.2.0 \
-    matplotlib==3.5.1 \
     tensorboardX==2.4.1
 
 

--- a/docker/pytorch/Dockerfile
+++ b/docker/pytorch/Dockerfile
@@ -51,7 +51,7 @@ RUN /opt/conda/bin/conda install pytorch==1.7 \
     /opt/conda/bin/conda clean --all
 RUN /opt/conda/bin/pip install --no-cache-dir \
     tensorflow-gpu==2.4.1 \
-    adversarial-robustness-toolbox==1.9.0
+    adversarial-robustness-toolbox==1.9.1
 
 ########## PyTorch 1 Dev #################
 

--- a/docker/pytorch/Dockerfile
+++ b/docker/pytorch/Dockerfile
@@ -33,7 +33,6 @@ RUN /opt/conda/bin/pip install --no-cache-dir \
     pandas==1.2.4 \
     ffmpeg-python==0.2.0 \
     numba==0.53.1 \
-    matplotlib==3.5.1 \
     tensorboardX==2.4.1
 
 RUN /opt/conda/bin/conda install -c conda-forge ffmpeg==4.2.3 && \

--- a/docker/pytorch/Dockerfile
+++ b/docker/pytorch/Dockerfile
@@ -32,7 +32,9 @@ RUN /opt/conda/bin/pip install --no-cache-dir \
     opencv-python==4.5.1.48 \
     pandas==1.2.4 \
     ffmpeg-python==0.2.0 \
-    numba==0.53.1
+    numba==0.53.1 \
+    matplotlib==3.5.1 \
+    tensorboardX==2.4.1
 
 RUN /opt/conda/bin/conda install -c conda-forge ffmpeg==4.2.3 && \
     /opt/conda/bin/conda clean --all
@@ -50,7 +52,7 @@ RUN /opt/conda/bin/conda install pytorch==1.7 \
     /opt/conda/bin/conda clean --all
 RUN /opt/conda/bin/pip install --no-cache-dir \
     tensorflow-gpu==2.4.1 \
-    git+https://github.com/Trusted-AI/adversarial-robustness-toolbox.git@development_object_tracking_attack
+    adversarial-robustness-toolbox==1.9.0
 
 ########## PyTorch 1 Dev #################
 

--- a/docker/tf1/Dockerfile
+++ b/docker/tf1/Dockerfile
@@ -28,10 +28,7 @@ RUN /opt/conda/bin/conda install \
     jupyterlab==3.1.7 \
     boto3==1.18.21 \
     dill=0.3.4 \
-    pytest==6.2.4 \
-    matplotlib==3.5.1 \
-    tensorboardX==2.4.1
-
+    pytest==6.2.4
 
 RUN /opt/conda/bin/conda install -c conda-forge ffmpeg==4.2.3
 
@@ -41,7 +38,11 @@ RUN /opt/conda/bin/pip install --no-cache-dir \
     pydub==0.24.1 \
     apache-beam==2.22.0 \
     opencv-python==4.5.1.48 \
-    ffmpeg-python==0.2.0
+    ffmpeg-python==0.2.0 \
+    matplotlib==3.5.1 \
+    tensorboardX==2.4.1
+
+
 
 # the numpy install was moved above in order to group conda installs together before pip installs
 # as recommended by https://www.anaconda.com/blog/using-pip-in-a-conda-environment

--- a/docker/tf1/Dockerfile
+++ b/docker/tf1/Dockerfile
@@ -39,7 +39,6 @@ RUN /opt/conda/bin/pip install --no-cache-dir \
     apache-beam==2.22.0 \
     opencv-python==4.5.1.48 \
     ffmpeg-python==0.2.0 \
-    matplotlib==3.5.1 \
     tensorboardX==2.4.1
 
 

--- a/docker/tf1/Dockerfile
+++ b/docker/tf1/Dockerfile
@@ -28,7 +28,9 @@ RUN /opt/conda/bin/conda install \
     jupyterlab==3.1.7 \
     boto3==1.18.21 \
     dill=0.3.4 \
-    pytest==6.2.4
+    pytest==6.2.4 \
+    matplotlib==3.5.1 \
+    tensorboardX==2.4.1
 
 
 RUN /opt/conda/bin/conda install -c conda-forge ffmpeg==4.2.3
@@ -62,7 +64,7 @@ WORKDIR /tmp/models/research
 RUN protoc object_detection/protos/*.proto --python_out=.
 RUN cp object_detection/packages/tf1/setup.py .
 RUN /opt/conda/bin/pip install .
-RUN /opt/conda/bin/pip install --no-cache-dir git+https://github.com/Trusted-AI/adversarial-robustness-toolbox.git@development_object_tracking_attack
+RUN /opt/conda/bin/pip install --no-cache-dir adversarial-robustness-toolbox==1.9.0
 
 
 WORKDIR /workspace

--- a/docker/tf1/Dockerfile
+++ b/docker/tf1/Dockerfile
@@ -64,7 +64,7 @@ WORKDIR /tmp/models/research
 RUN protoc object_detection/protos/*.proto --python_out=.
 RUN cp object_detection/packages/tf1/setup.py .
 RUN /opt/conda/bin/pip install .
-RUN /opt/conda/bin/pip install --no-cache-dir adversarial-robustness-toolbox==1.9.0
+RUN /opt/conda/bin/pip install --no-cache-dir adversarial-robustness-toolbox==1.9.1
 
 
 WORKDIR /workspace

--- a/docker/tf2/Dockerfile
+++ b/docker/tf2/Dockerfile
@@ -31,7 +31,9 @@ RUN /opt/conda/bin/pip install --no-cache-dir \
     pytest==6.2.2 \
     opencv-python==4.5.1.48 \
     pandas==1.2.4 \
-    ffmpeg-python==0.2.0
+    ffmpeg-python==0.2.0 \
+    matplotlib==3.5.1 \
+    tensorboardX==2.4.1
 
 
 RUN /opt/conda/bin/conda install -c conda-forge ffmpeg==4.2.3 && \
@@ -53,7 +55,7 @@ WORKDIR /tmp/models/research
 RUN protoc object_detection/protos/*.proto --python_out=.
 RUN cp object_detection/packages/tf2/setup.py .
 RUN /opt/conda/bin/pip install .
-RUN /opt/conda/bin/pip install --no-cache-dir git+https://github.com/Trusted-AI/adversarial-robustness-toolbox.git@development_object_tracking_attack
+RUN /opt/conda/bin/pip install --no-cache-dir adversarial-robustness-toolbox==1.9.0
 
 WORKDIR /workspace
 

--- a/docker/tf2/Dockerfile
+++ b/docker/tf2/Dockerfile
@@ -54,7 +54,7 @@ WORKDIR /tmp/models/research
 RUN protoc object_detection/protos/*.proto --python_out=.
 RUN cp object_detection/packages/tf2/setup.py .
 RUN /opt/conda/bin/pip install .
-RUN /opt/conda/bin/pip install --no-cache-dir adversarial-robustness-toolbox==1.9.0
+RUN /opt/conda/bin/pip install --no-cache-dir adversarial-robustness-toolbox==1.9.1
 
 WORKDIR /workspace
 

--- a/docker/tf2/Dockerfile
+++ b/docker/tf2/Dockerfile
@@ -32,7 +32,6 @@ RUN /opt/conda/bin/pip install --no-cache-dir \
     opencv-python==4.5.1.48 \
     pandas==1.2.4 \
     ffmpeg-python==0.2.0 \
-    matplotlib==3.5.1 \
     tensorboardX==2.4.1
 
 

--- a/scenario_configs/apricot_frcnn.json
+++ b/scenario_configs/apricot_frcnn.json
@@ -44,7 +44,7 @@
         "name": "ObjectDetectionTask"
     },
     "sysconfig": {
-        "docker_image": "twosixarmory/tf1:0.14.2",
+        "docker_image": "twosixarmory/tf1:0.14.3",
         "external_github_repo": null,
         "gpus": "all",
         "output_dir": null,

--- a/scenario_configs/apricot_frcnn_defended.json
+++ b/scenario_configs/apricot_frcnn_defended.json
@@ -57,7 +57,7 @@
         "name": "ObjectDetectionTask"
     },
     "sysconfig": {
-        "docker_image": "twosixarmory/tf1:0.14.2",
+        "docker_image": "twosixarmory/tf1:0.14.3",
         "external_github_repo": null,
         "gpus": "all",
         "output_dir": null,

--- a/scenario_configs/carla_obj_det_dpatch_undefended.json
+++ b/scenario_configs/carla_obj_det_dpatch_undefended.json
@@ -51,7 +51,7 @@
         "name": "CarlaObjectDetectionTask"
     },
     "sysconfig": {
-        "docker_image": "twosixarmory/pytorch:0.14.2",
+        "docker_image": "twosixarmory/pytorch:0.14.3",
         "external_github_repo": "colour-science/colour",
         "gpus": "all",
         "output_dir": null,

--- a/scenario_configs/carla_obj_det_multimodal_dpatch_defended.json
+++ b/scenario_configs/carla_obj_det_multimodal_dpatch_defended.json
@@ -49,7 +49,7 @@
         "name": "CarlaObjectDetectionTask"
     },
     "sysconfig": {
-        "docker_image": "twosixarmory/pytorch:0.14.2",
+        "docker_image": "twosixarmory/pytorch:0.14.3",
         "external_github_repo": "colour-science/colour",
         "gpus": "all",
         "output_dir": null,

--- a/scenario_configs/carla_obj_det_multimodal_dpatch_undefended.json
+++ b/scenario_configs/carla_obj_det_multimodal_dpatch_undefended.json
@@ -49,7 +49,7 @@
         "name": "CarlaObjectDetectionTask"
     },
     "sysconfig": {
-        "docker_image": "twosixarmory/pytorch:0.14.2",
+        "docker_image": "twosixarmory/pytorch:0.14.3",
         "external_github_repo": "colour-science/colour",
         "gpus": "all",
         "output_dir": null,

--- a/scenario_configs/carla_video_tracking_goturn_advtextures_undefended.json
+++ b/scenario_configs/carla_video_tracking_goturn_advtextures_undefended.json
@@ -44,7 +44,7 @@
         "name": "CarlaVideoTracking"
     },
     "sysconfig": {
-        "docker_image": "twosixarmory/pytorch:0.14.2",
+        "docker_image": "twosixarmory/pytorch:0.14.3",
         "external_github_repo": "amoudgl/pygoturn",
         "gpus": "all",
         "output_dir": null,

--- a/scenario_configs/cifar10_baseline.json
+++ b/scenario_configs/cifar10_baseline.json
@@ -49,7 +49,7 @@
         "name": "ImageClassificationTask"
     },
     "sysconfig": {
-        "docker_image": "twosixarmory/pytorch:0.14.2",
+        "docker_image": "twosixarmory/pytorch:0.14.3",
         "external_github_repo": null,
         "gpus": "all",
         "output_dir": null,

--- a/scenario_configs/cifar10_defended_example.json
+++ b/scenario_configs/cifar10_defended_example.json
@@ -57,7 +57,7 @@
         "name": "ImageClassificationTask"
     },
     "sysconfig": {
-        "docker_image": "twosixarmory/pytorch:0.14.2",
+        "docker_image": "twosixarmory/pytorch:0.14.3",
         "external_github_repo": null,
         "gpus": "all",
         "output_dir": null,

--- a/scenario_configs/dapricot_frcnn_masked_pgd.json
+++ b/scenario_configs/dapricot_frcnn_masked_pgd.json
@@ -53,7 +53,7 @@
         "name": "ObjectDetectionTask"
     },
     "sysconfig": {
-        "docker_image": "twosixarmory/tf1:0.14.2",
+        "docker_image": "twosixarmory/tf1:0.14.3",
         "external_github_repo": "colour-science/colour",
         "gpus": "all",
         "output_dir": null,

--- a/scenario_configs/gtsrb_scenario_baseline.json
+++ b/scenario_configs/gtsrb_scenario_baseline.json
@@ -58,7 +58,7 @@
         "name": "GTSRB"
     },
     "sysconfig": {
-        "docker_image": "twosixarmory/tf1:0.14.2",
+        "docker_image": "twosixarmory/tf1:0.14.3",
         "external_github_repo": null,
         "gpus": "all",
         "output_dir": null,

--- a/scenario_configs/gtsrb_scenario_baseline_pytorch.json
+++ b/scenario_configs/gtsrb_scenario_baseline_pytorch.json
@@ -58,7 +58,7 @@
         "name": "GTSRB"
     },
     "sysconfig": {
-        "docker_image": "twosixarmory/pytorch:0.14.2",
+        "docker_image": "twosixarmory/pytorch:0.14.3",
         "external_github_repo": null,
         "gpus": "all",
         "output_dir": null,

--- a/scenario_configs/gtsrb_scenario_clbd.json
+++ b/scenario_configs/gtsrb_scenario_clbd.json
@@ -58,7 +58,7 @@
         "name": "GTSRB_CLBD"
     },
     "sysconfig": {
-        "docker_image": "twosixarmory/tf1:0.14.2",
+        "docker_image": "twosixarmory/tf1:0.14.3",
         "external_github_repo": null,
         "gpus": "all",
         "output_dir": null,

--- a/scenario_configs/gtsrb_scenario_clbd_bullethole.json
+++ b/scenario_configs/gtsrb_scenario_clbd_bullethole.json
@@ -64,7 +64,7 @@
         "name": "GTSRB_CLBD"
     },
     "sysconfig": {
-        "docker_image": "twosixarmory/tf1:0.14.2",
+        "docker_image": "twosixarmory/tf1:0.14.3",
         "external_github_repo": null,
         "gpus": "all",
         "output_dir": null,

--- a/scenario_configs/gtsrb_scenario_clbd_defended.json
+++ b/scenario_configs/gtsrb_scenario_clbd_defended.json
@@ -69,7 +69,7 @@
         "name": "GTSRB_CLBD"
     },
     "sysconfig": {
-        "docker_image": "twosixarmory/tf1:0.14.2",
+        "docker_image": "twosixarmory/tf1:0.14.3",
         "external_github_repo": null,
         "gpus": "all",
         "output_dir": null,

--- a/scenario_configs/gtsrb_scenario_poison.json
+++ b/scenario_configs/gtsrb_scenario_poison.json
@@ -48,7 +48,7 @@
         "name": "GTSRB"
     },
     "sysconfig": {
-        "docker_image": "twosixarmory/tf1:0.14.2",
+        "docker_image": "twosixarmory/tf1:0.14.3",
         "external_github_repo": null,
         "gpus": "all",
         "use_gpu": false

--- a/scenario_configs/librispeech_asr_imperceptible_defended.json
+++ b/scenario_configs/librispeech_asr_imperceptible_defended.json
@@ -81,7 +81,7 @@
         "name": "AutomaticSpeechRecognition"
     },
     "sysconfig": {
-        "docker_image": "twosixarmory/pytorch-deepspeech:0.14.2",
+        "docker_image": "twosixarmory/pytorch-deepspeech:0.14.3",
         "external_github_repo": "hkakitani/deepspeech.pytorch",
         "gpus": "all",
         "local_repo_path": null,

--- a/scenario_configs/librispeech_asr_imperceptible_undefended.json
+++ b/scenario_configs/librispeech_asr_imperceptible_undefended.json
@@ -70,7 +70,7 @@
         "name": "AutomaticSpeechRecognition"
     },
     "sysconfig": {
-        "docker_image": "twosixarmory/pytorch-deepspeech:0.14.2",
+        "docker_image": "twosixarmory/pytorch-deepspeech:0.14.3",
         "external_github_repo": "hkakitani/deepspeech.pytorch",
         "gpus": "all",
         "local_repo_path": null,

--- a/scenario_configs/librispeech_asr_kenansville_defended.json
+++ b/scenario_configs/librispeech_asr_kenansville_defended.json
@@ -64,7 +64,7 @@
         "name": "AutomaticSpeechRecognition"
     },
     "sysconfig": {
-        "docker_image": "twosixarmory/pytorch-deepspeech:0.14.2",
+        "docker_image": "twosixarmory/pytorch-deepspeech:0.14.3",
         "external_github_repo": "hkakitani/deepspeech.pytorch",
         "gpus": "all",
         "local_repo_path": null,

--- a/scenario_configs/librispeech_asr_kenansville_undefended.json
+++ b/scenario_configs/librispeech_asr_kenansville_undefended.json
@@ -53,7 +53,7 @@
         "name": "AutomaticSpeechRecognition"
     },
     "sysconfig": {
-        "docker_image": "twosixarmory/pytorch-deepspeech:0.14.2",
+        "docker_image": "twosixarmory/pytorch-deepspeech:0.14.3",
         "external_github_repo": "hkakitani/deepspeech.pytorch",
         "gpus": "all",
         "local_repo_path": null,

--- a/scenario_configs/librispeech_asr_pgd_defended.json
+++ b/scenario_configs/librispeech_asr_pgd_defended.json
@@ -75,7 +75,7 @@
         "name": "AutomaticSpeechRecognition"
     },
     "sysconfig": {
-        "docker_image": "twosixarmory/pytorch-deepspeech:0.14.2",
+        "docker_image": "twosixarmory/pytorch-deepspeech:0.14.3",
         "external_github_repo": "hkakitani/deepspeech.pytorch",
         "gpus": "all",
         "local_repo_path": null,

--- a/scenario_configs/librispeech_asr_pgd_multipath_channel_defended.json
+++ b/scenario_configs/librispeech_asr_pgd_multipath_channel_defended.json
@@ -80,7 +80,7 @@
         "name": "AutomaticSpeechRecognition"
     },
     "sysconfig": {
-        "docker_image": "twosixarmory/pytorch-deepspeech:0.14.2",
+        "docker_image": "twosixarmory/pytorch-deepspeech:0.14.3",
         "external_github_repo": "hkakitani/deepspeech.pytorch",
         "gpus": "all",
         "local_repo_path": null,

--- a/scenario_configs/librispeech_asr_pgd_multipath_channel_undefended.json
+++ b/scenario_configs/librispeech_asr_pgd_multipath_channel_undefended.json
@@ -69,7 +69,7 @@
         "name": "AutomaticSpeechRecognition"
     },
     "sysconfig": {
-        "docker_image": "twosixarmory/pytorch-deepspeech:0.14.2",
+        "docker_image": "twosixarmory/pytorch-deepspeech:0.14.3",
         "external_github_repo": "hkakitani/deepspeech.pytorch",
         "gpus": "all",
         "local_repo_path": null,

--- a/scenario_configs/librispeech_asr_pgd_undefended.json
+++ b/scenario_configs/librispeech_asr_pgd_undefended.json
@@ -64,7 +64,7 @@
         "name": "AutomaticSpeechRecognition"
     },
     "sysconfig": {
-        "docker_image": "twosixarmory/pytorch-deepspeech:0.14.2",
+        "docker_image": "twosixarmory/pytorch-deepspeech:0.14.3",
         "external_github_repo": "hkakitani/deepspeech.pytorch",
         "gpus": "all",
         "local_repo_path": null,

--- a/scenario_configs/librispeech_asr_snr_undefended.json
+++ b/scenario_configs/librispeech_asr_snr_undefended.json
@@ -69,7 +69,7 @@
         "name": "AutomaticSpeechRecognition"
     },
     "sysconfig": {
-        "docker_image": "twosixarmory/pytorch-deepspeech:0.14.2",
+        "docker_image": "twosixarmory/pytorch-deepspeech:0.14.3",
         "external_github_repo": "hkakitani/deepspeech.pytorch",
         "gpus": "all",
         "local_repo_path": null,

--- a/scenario_configs/librispeech_baseline_sincnet.json
+++ b/scenario_configs/librispeech_baseline_sincnet.json
@@ -55,7 +55,7 @@
         "name": "AudioClassificationTask"
     },
     "sysconfig": {
-        "docker_image": "twosixarmory/pytorch:0.14.2",
+        "docker_image": "twosixarmory/pytorch:0.14.3",
         "external_github_repo": "hkakitani/SincNet",
         "gpus": "all",
         "output_dir": null,

--- a/scenario_configs/librispeech_baseline_sincnet_snr_pgd.json
+++ b/scenario_configs/librispeech_baseline_sincnet_snr_pgd.json
@@ -59,7 +59,7 @@
         "name": "AudioClassificationTask"
     },
     "sysconfig": {
-        "docker_image": "twosixarmory/pytorch:0.14.2",
+        "docker_image": "twosixarmory/pytorch:0.14.3",
         "external_github_repo": "hkakitani/SincNet",
         "gpus": "all",
         "output_dir": null,

--- a/scenario_configs/librispeech_baseline_sincnet_targeted.json
+++ b/scenario_configs/librispeech_baseline_sincnet_targeted.json
@@ -62,7 +62,7 @@
         "name": "AudioClassificationTask"
     },
     "sysconfig": {
-        "docker_image": "twosixarmory/pytorch:0.14.2",
+        "docker_image": "twosixarmory/pytorch:0.14.3",
         "external_github_repo": "hkakitani/SincNet",
         "gpus": "all",
         "output_dir": null,

--- a/scenario_configs/mnist_baseline.json
+++ b/scenario_configs/mnist_baseline.json
@@ -47,7 +47,7 @@
         "name": "ImageClassificationTask"
     },
     "sysconfig": {
-        "docker_image": "twosixarmory/tf1:0.14.2",
+        "docker_image": "twosixarmory/tf1:0.14.3",
         "external_github_repo": null,
         "gpus": "all",
         "output_dir": null,

--- a/scenario_configs/resisc10_poison_dlbd.json
+++ b/scenario_configs/resisc10_poison_dlbd.json
@@ -114,7 +114,7 @@
         "name": "RESISC10"
     },
     "sysconfig": {
-        "docker_image": "twosixarmory/pytorch:0.14.2",
+        "docker_image": "twosixarmory/pytorch:0.14.3",
         "external_github_repo": null,
         "gpus": "all",
         "output_dir": null,

--- a/scenario_configs/resisc45_baseline_densenet121.json
+++ b/scenario_configs/resisc45_baseline_densenet121.json
@@ -45,7 +45,7 @@
         "name": "ImageClassificationTask"
     },
     "sysconfig": {
-        "docker_image": "twosixarmory/tf1:0.14.2",
+        "docker_image": "twosixarmory/tf1:0.14.3",
         "external_github_repo": null,
         "gpus": "all",
         "output_dir": null,

--- a/scenario_configs/resisc45_baseline_densenet121_cascade.json
+++ b/scenario_configs/resisc45_baseline_densenet121_cascade.json
@@ -70,7 +70,7 @@
         "name": "ImageClassificationTask"
     },
     "sysconfig": {
-        "docker_image": "twosixarmory/tf1:0.14.2",
+        "docker_image": "twosixarmory/tf1:0.14.3",
         "external_github_repo": null,
         "gpus": "all",
         "output_dir": null,

--- a/scenario_configs/resisc45_baseline_densenet121_finetune.json
+++ b/scenario_configs/resisc45_baseline_densenet121_finetune.json
@@ -45,7 +45,7 @@
         "name": "ImageClassificationTask"
     },
     "sysconfig": {
-        "docker_image": "twosixarmory/tf1:0.14.2",
+        "docker_image": "twosixarmory/tf1:0.14.3",
         "external_github_repo": null,
         "gpus": "all",
         "output_dir": null,

--- a/scenario_configs/resisc45_baseline_densenet121_patch.json
+++ b/scenario_configs/resisc45_baseline_densenet121_patch.json
@@ -58,7 +58,7 @@
         "name": "ImageClassificationTask"
     },
     "sysconfig": {
-        "docker_image": "twosixarmory/tf1:0.14.2",
+        "docker_image": "twosixarmory/tf1:0.14.3",
         "external_github_repo": null,
         "gpus": "all",
         "output_dir": null,

--- a/scenario_configs/resisc45_baseline_densenet121_sweep_eps.json
+++ b/scenario_configs/resisc45_baseline_densenet121_sweep_eps.json
@@ -68,7 +68,7 @@
         "name": "ImageClassificationTask"
     },
     "sysconfig": {
-        "docker_image": "twosixarmory/tf1:0.14.2",
+        "docker_image": "twosixarmory/tf1:0.14.3",
         "external_github_repo": null,
         "gpus": "all",
         "output_dir": null,

--- a/scenario_configs/resisc45_baseline_densenet121_targeted.json
+++ b/scenario_configs/resisc45_baseline_densenet121_targeted.json
@@ -52,7 +52,7 @@
         "name": "ImageClassificationTask"
     },
     "sysconfig": {
-        "docker_image": "twosixarmory/tf1:0.14.2",
+        "docker_image": "twosixarmory/tf1:0.14.3",
         "external_github_repo": null,
         "gpus": "all",
         "output_dir": null,

--- a/scenario_configs/so2sat_eo_masked_pgd_defended.json
+++ b/scenario_configs/so2sat_eo_masked_pgd_defended.json
@@ -136,7 +136,7 @@
         "name": "So2SatClassification"
     },
     "sysconfig": {
-        "docker_image": "twosixarmory/tf1:0.14.2",
+        "docker_image": "twosixarmory/tf1:0.14.3",
         "external_github_repo": null,
         "gpus": "all",
         "output_dir": null,

--- a/scenario_configs/so2sat_eo_masked_pgd_undefended.json
+++ b/scenario_configs/so2sat_eo_masked_pgd_undefended.json
@@ -90,7 +90,7 @@
         "name": "So2SatClassification"
     },
     "sysconfig": {
-        "docker_image": "twosixarmory/tf1:0.14.2",
+        "docker_image": "twosixarmory/tf1:0.14.3",
         "external_github_repo": null,
         "gpus": "all",
         "output_dir": null,

--- a/scenario_configs/so2sat_sar_masked_pgd_defended.json
+++ b/scenario_configs/so2sat_sar_masked_pgd_defended.json
@@ -136,7 +136,7 @@
         "name": "So2SatClassification"
     },
     "sysconfig": {
-        "docker_image": "twosixarmory/tf1:0.14.2",
+        "docker_image": "twosixarmory/tf1:0.14.3",
         "external_github_repo": null,
         "gpus": "all",
         "output_dir": null,

--- a/scenario_configs/so2sat_sar_masked_pgd_undefended.json
+++ b/scenario_configs/so2sat_sar_masked_pgd_undefended.json
@@ -90,7 +90,7 @@
         "name": "So2SatClassification"
     },
     "sysconfig": {
-        "docker_image": "twosixarmory/tf1:0.14.2",
+        "docker_image": "twosixarmory/tf1:0.14.3",
         "external_github_repo": null,
         "gpus": "all",
         "output_dir": null,

--- a/scenario_configs/ucf101_baseline_finetune.json
+++ b/scenario_configs/ucf101_baseline_finetune.json
@@ -52,7 +52,7 @@
         "name": "Ucf101"
     },
     "sysconfig": {
-        "docker_image": "twosixarmory/pytorch:0.14.2",
+        "docker_image": "twosixarmory/pytorch:0.14.3",
         "external_github_repo": "yusong-tan/MARS",
         "gpus": "all",
         "output_dir": null,

--- a/scenario_configs/ucf101_baseline_pretrained_targeted.json
+++ b/scenario_configs/ucf101_baseline_pretrained_targeted.json
@@ -58,7 +58,7 @@
         "name": "Ucf101"
     },
     "sysconfig": {
-        "docker_image": "twosixarmory/pytorch:0.14.2",
+        "docker_image": "twosixarmory/pytorch:0.14.3",
         "external_github_repo": "yusong-tan/MARS",
         "gpus": "all",
         "output_dir": null,

--- a/scenario_configs/ucf101_pretrained_flicker_defended.json
+++ b/scenario_configs/ucf101_pretrained_flicker_defended.json
@@ -67,7 +67,7 @@
         "name": "Ucf101"
     },
     "sysconfig": {
-        "docker_image": "twosixarmory/pytorch:0.14.2",
+        "docker_image": "twosixarmory/pytorch:0.14.3",
         "external_github_repo": "yusong-tan/MARS",
         "gpus": "all",
         "output_dir": null,

--- a/scenario_configs/ucf101_pretrained_flicker_undefended.json
+++ b/scenario_configs/ucf101_pretrained_flicker_undefended.json
@@ -55,7 +55,7 @@
         "name": "Ucf101"
     },
     "sysconfig": {
-        "docker_image": "twosixarmory/pytorch:0.14.2",
+        "docker_image": "twosixarmory/pytorch:0.14.3",
         "external_github_repo": "yusong-tan/MARS",
         "gpus": "all",
         "output_dir": null,

--- a/scenario_configs/ucf101_pretrained_frame_saliency_defended.json
+++ b/scenario_configs/ucf101_pretrained_frame_saliency_defended.json
@@ -76,7 +76,7 @@
         "name": "Ucf101"
     },
     "sysconfig": {
-        "docker_image": "twosixarmory/pytorch:0.14.2",
+        "docker_image": "twosixarmory/pytorch:0.14.3",
         "external_github_repo": "yusong-tan/MARS",
         "gpus": "all",
         "output_dir": null,

--- a/scenario_configs/ucf101_pretrained_frame_saliency_undefended.json
+++ b/scenario_configs/ucf101_pretrained_frame_saliency_undefended.json
@@ -64,7 +64,7 @@
         "name": "Ucf101"
     },
     "sysconfig": {
-        "docker_image": "twosixarmory/pytorch:0.14.2",
+        "docker_image": "twosixarmory/pytorch:0.14.3",
         "external_github_repo": "yusong-tan/MARS",
         "gpus": "all",
         "output_dir": null,

--- a/scenario_configs/ucf101_pretrained_masked_pgd_defended.json
+++ b/scenario_configs/ucf101_pretrained_masked_pgd_defended.json
@@ -73,7 +73,7 @@
         "name": "Ucf101"
     },
     "sysconfig": {
-        "docker_image": "twosixarmory/pytorch:0.14.2",
+        "docker_image": "twosixarmory/pytorch:0.14.3",
         "external_github_repo": "yusong-tan/MARS",
         "gpus": "all",
         "output_dir": null,

--- a/scenario_configs/ucf101_pretrained_masked_pgd_undefended.json
+++ b/scenario_configs/ucf101_pretrained_masked_pgd_undefended.json
@@ -61,7 +61,7 @@
         "name": "Ucf101"
     },
     "sysconfig": {
-        "docker_image": "twosixarmory/pytorch:0.14.2",
+        "docker_image": "twosixarmory/pytorch:0.14.3",
         "external_github_repo": "yusong-tan/MARS",
         "gpus": "all",
         "output_dir": null,

--- a/scenario_configs/xview_frcnn_masked_pgd_defended.json
+++ b/scenario_configs/xview_frcnn_masked_pgd_defended.json
@@ -64,7 +64,7 @@
         "name": "ObjectDetectionTask"
     },
     "sysconfig": {
-        "docker_image": "twosixarmory/pytorch:0.14.2",
+        "docker_image": "twosixarmory/pytorch:0.14.3",
         "external_github_repo": null,
         "gpus": "all",
         "output_dir": null,

--- a/scenario_configs/xview_frcnn_masked_pgd_undefended.json
+++ b/scenario_configs/xview_frcnn_masked_pgd_undefended.json
@@ -51,7 +51,7 @@
         "name": "ObjectDetectionTask"
     },
     "sysconfig": {
-        "docker_image": "twosixarmory/pytorch:0.14.2",
+        "docker_image": "twosixarmory/pytorch:0.14.3",
         "external_github_repo": null,
         "gpus": "all",
         "output_dir": null,

--- a/scenario_configs/xview_frcnn_robust_dpatch_defended.json
+++ b/scenario_configs/xview_frcnn_robust_dpatch_defended.json
@@ -66,7 +66,7 @@
         "name": "ObjectDetectionTask"
     },
     "sysconfig": {
-        "docker_image": "twosixarmory/pytorch:0.14.2",
+        "docker_image": "twosixarmory/pytorch:0.14.3",
         "external_github_repo": null,
         "gpus": "all",
         "output_dir": null,

--- a/scenario_configs/xview_frcnn_robust_dpatch_undefended.json
+++ b/scenario_configs/xview_frcnn_robust_dpatch_undefended.json
@@ -53,7 +53,7 @@
         "name": "ObjectDetectionTask"
     },
     "sysconfig": {
-        "docker_image": "twosixarmory/pytorch:0.14.2",
+        "docker_image": "twosixarmory/pytorch:0.14.3",
         "external_github_repo": null,
         "gpus": "all",
         "output_dir": null,

--- a/scenario_configs/xview_frcnn_sweep_patch_size.json
+++ b/scenario_configs/xview_frcnn_sweep_patch_size.json
@@ -95,7 +95,7 @@
         "name": "ObjectDetectionTask"
     },
     "sysconfig": {
-        "docker_image": "twosixarmory/pytorch:0.14.2",
+        "docker_image": "twosixarmory/pytorch:0.14.3",
         "external_github_repo": null,
         "gpus": "all",
         "output_dir": null,

--- a/scenario_configs/xview_frcnn_targeted.json
+++ b/scenario_configs/xview_frcnn_targeted.json
@@ -60,7 +60,7 @@
         "name": "ObjectDetectionTask"
     },
     "sysconfig": {
-        "docker_image": "twosixarmory/pytorch:0.14.2",
+        "docker_image": "twosixarmory/pytorch:0.14.3",
         "external_github_repo": null,
         "gpus": "all",
         "output_dir": null,

--- a/tests/scenarios/broken/invalid_dataset_framework.json
+++ b/tests/scenarios/broken/invalid_dataset_framework.json
@@ -46,7 +46,7 @@
         "name": "ImageClassificationTask"
     },
     "sysconfig": {
-        "docker_image": "twosixarmory/tf1:0.14.2",
+        "docker_image": "twosixarmory/tf1:0.14.3",
         "external_github_repo": null,
         "gpus": "all",
         "output_dir": null,

--- a/tests/scenarios/broken/invalid_module.json
+++ b/tests/scenarios/broken/invalid_module.json
@@ -39,7 +39,7 @@
         "name": "fgm_attack"
     },
     "sysconfig": {
-        "docker_image": "twosixarmory/tf1:0.14.2",
+        "docker_image": "twosixarmory/tf1:0.14.3",
         "external_github_repo": null,
         "gpus": "",
         "output_dir": null,

--- a/tests/scenarios/broken/missing_scenario.json
+++ b/tests/scenarios/broken/missing_scenario.json
@@ -40,7 +40,7 @@
         "wrapper_kwargs": {}
     },
     "sysconfig": {
-        "docker_image": "twosixarmory/tf1:0.14.2",
+        "docker_image": "twosixarmory/tf1:0.14.3",
         "external_github_repo": null,
         "gpus": "all",
         "output_dir": null,

--- a/tests/scenarios/pytorch/image_classification.json
+++ b/tests/scenarios/pytorch/image_classification.json
@@ -46,7 +46,7 @@
         "name": "ImageClassificationTask"
     },
     "sysconfig": {
-        "docker_image": "twosixarmory/pytorch:0.14.2",
+        "docker_image": "twosixarmory/pytorch:0.14.3",
         "external_github_repo": null,
         "gpus": "all",
         "output_dir": null,

--- a/tests/scenarios/pytorch/image_classification_pretrained.json
+++ b/tests/scenarios/pytorch/image_classification_pretrained.json
@@ -44,7 +44,7 @@
         "name": "ImageClassificationTask"
     },
     "sysconfig": {
-        "docker_image": "twosixarmory/pytorch:0.14.2",
+        "docker_image": "twosixarmory/pytorch:0.14.3",
         "external_github_repo": null,
         "gpus": "all",
         "output_dir": null,

--- a/tests/scenarios/tf1/image_classification.json
+++ b/tests/scenarios/tf1/image_classification.json
@@ -46,7 +46,7 @@
         "name": "ImageClassificationTask"
     },
     "sysconfig": {
-        "docker_image": "twosixarmory/tf1:0.14.2",
+        "docker_image": "twosixarmory/tf1:0.14.3",
         "external_github_repo": null,
         "gpus": "all",
         "output_dir": null,

--- a/tests/scenarios/tf1/image_classification_pretrained.json
+++ b/tests/scenarios/tf1/image_classification_pretrained.json
@@ -44,7 +44,7 @@
         "name": "ImageClassificationTask"
     },
     "sysconfig": {
-        "docker_image": "twosixarmory/tf1:0.14.2",
+        "docker_image": "twosixarmory/tf1:0.14.3",
         "external_github_repo": null,
         "gpus": "all",
         "output_dir": null,

--- a/tests/scenarios/tf1/image_classification_tfgraph.json
+++ b/tests/scenarios/tf1/image_classification_tfgraph.json
@@ -46,7 +46,7 @@
         "name": "ImageClassificationTask"
     },
     "sysconfig": {
-        "docker_image": "twosixarmory/tf1:0.14.2",
+        "docker_image": "twosixarmory/tf1:0.14.3",
         "external_github_repo": null,
         "gpus": "all",
         "output_dir": null,


### PR DESCRIPTION
This PR does 3 things:

1. bumps Armory version to 0.14.3
2. updates Dockerfiles to A) pin to ART 1.9.1 and B) include packages needed for Tensorboard integration
3. Adds some code to generic scenario class that directs all TF event files (used by Tensorboard, outputted by ART) to the Armory output dir. This overrides ART's approach which is the following, assuming the `summary_writer` kwarg is provided: if the value for the `summary_writer` kwarg is `true`, it outputs to the current working directory; if the value is a string, it outputs to that user-specified directory. To reiterate, with this PR, Armory will force all TF event files to the Armory output dir e.g. `~/.armory/outputs/2022-01-06T224911.011884`. It does provide a warning if the user provides a string for `summary_writer`.

To test the Tensorboard integration, add `"summary_writer": true` as an attack kwarg. Note that this is only supported for certain attacks, e.g. PGD. Then, after running the scenario, run the following command: `tensorboard --logdir <ARMORY SCENARIO OUTPUT DIR>`. Note that you'll need to install tensorboard first. After running the command, follow the instructions logged to view the plots