### PR TITLE
split carla tests onto their own CI runner

### DIFF
--- a/.github/workflows/ci_test.yml
+++ b/.github/workflows/ci_test.yml
@@ -112,7 +112,6 @@ jobs:
           pip install -r requirements.txt
           version=$(python -m armory --version)
           bash docker/build.sh pytorch dev
-          docker run -w /armory_dev twosixarmory/pytorch:${version} pytest -s ./tests/test_docker
           docker run -w /armory_dev twosixarmory/pytorch:${version} pytest -k carla -s ./tests/test_pytorch
   armory-pytorch:
     name: Armory run tests PyTorch

--- a/.github/workflows/ci_test.yml
+++ b/.github/workflows/ci_test.yml
@@ -85,7 +85,7 @@ jobs:
           docker run -w /armory_dev twosixarmory/tf2:${version} python \
           /opt/conda/lib/python3.7/site-packages/object_detection/builders/model_builder_tf2_test.py
   pytest-pytorch:
-    name: PyTest PyTorch
+    name: PyTest PyTorch non-carla
     runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v2
@@ -98,7 +98,22 @@ jobs:
           version=$(python -m armory --version)
           bash docker/build.sh pytorch dev
           docker run -w /armory_dev twosixarmory/pytorch:${version} pytest -s ./tests/test_docker
-          docker run -w /armory_dev twosixarmory/pytorch:${version} pytest -s ./tests/test_pytorch
+          docker run -w /armory_dev twosixarmory/pytorch:${version} pytest -k "not carla" -s ./tests/test_pytorch
+  pytest-pytorch-carla:
+    name: PyTest PyTorch carla
+    runs-on: ubuntu-18.04
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v1
+        with:
+          python-version: '3.7'
+      - name: Run armory PyTorch docker tests
+        run: |
+          pip install -r requirements.txt
+          version=$(python -m armory --version)
+          bash docker/build.sh pytorch dev
+          docker run -w /armory_dev twosixarmory/pytorch:${version} pytest -s ./tests/test_docker
+          docker run -w /armory_dev twosixarmory/pytorch:${version} pytest -k carla -s ./tests/test_pytorch
   armory-pytorch:
     name: Armory run tests PyTorch
     runs-on: ubuntu-18.04

--- a/tests/test_pytorch/test_pytorch_models.py
+++ b/tests/test_pytorch/test_pytorch_models.py
@@ -160,7 +160,6 @@ def test_pytorch_gtsrb():
     assert (accuracy / test_dataset.batches_per_epoch) > 0.8
 
 
-@pytest.mark.skip(reason="checking if splitting carla clears bug #1241")
 @pytest.mark.usefixtures("ensure_armory_dirs")
 def test_pytorch_carla_video_tracking():
     runtime_paths = paths.runtime_paths()
@@ -196,7 +195,6 @@ def test_pytorch_carla_video_tracking():
         assert mean_iou > 0.45
 
 
-@pytest.mark.skip(reason="checking if splitting carla clears bug #1241")
 @pytest.mark.usefixtures("ensure_armory_dirs")
 def test_carla_od_rgb():
     detector_module = import_module(
@@ -279,7 +277,6 @@ def test_carla_od_rgb():
     assert [ap_per_class[i] > 0.35 for i in range(1, 4)]
 
 
-@pytest.mark.skip(reason="checking if splitting carla clears bug #1241")
 @pytest.mark.usefixtures("ensure_armory_dirs")
 def test_carla_od_depth():
     detector_module = import_module(
@@ -362,7 +359,6 @@ def test_carla_od_depth():
     assert [ap_per_class[i] > 0.35 for i in range(1, 4)]
 
 
-@pytest.mark.skip(reason="checking if splitting carla clears bug #1241")
 @pytest.mark.usefixtures("ensure_armory_dirs")
 def test_carla_od_multimodal():
     detector_module = import_module(
@@ -445,7 +441,6 @@ def test_carla_od_multimodal():
     assert [ap_per_class[i] > 0.35 for i in range(1, 4)]
 
 
-@pytest.mark.skip(reason="checking if splitting carla clears bug #1241")
 @pytest.mark.usefixtures("ensure_armory_dirs")
 def test_carla_od_multimodal_robust_fusion():
     detector_module = import_module(

--- a/tests/test_pytorch/test_pytorch_models.py
+++ b/tests/test_pytorch/test_pytorch_models.py
@@ -160,6 +160,7 @@ def test_pytorch_gtsrb():
     assert (accuracy / test_dataset.batches_per_epoch) > 0.8
 
 
+@pytest.mark.skip(reason="checking if splitting carla clears bug #1241")
 @pytest.mark.usefixtures("ensure_armory_dirs")
 def test_pytorch_carla_video_tracking():
     runtime_paths = paths.runtime_paths()
@@ -195,6 +196,7 @@ def test_pytorch_carla_video_tracking():
         assert mean_iou > 0.45
 
 
+@pytest.mark.skip(reason="checking if splitting carla clears bug #1241")
 @pytest.mark.usefixtures("ensure_armory_dirs")
 def test_carla_od_rgb():
     detector_module = import_module(
@@ -277,6 +279,7 @@ def test_carla_od_rgb():
     assert [ap_per_class[i] > 0.35 for i in range(1, 4)]
 
 
+@pytest.mark.skip(reason="checking if splitting carla clears bug #1241")
 @pytest.mark.usefixtures("ensure_armory_dirs")
 def test_carla_od_depth():
     detector_module = import_module(
@@ -359,6 +362,7 @@ def test_carla_od_depth():
     assert [ap_per_class[i] > 0.35 for i in range(1, 4)]
 
 
+@pytest.mark.skip(reason="checking if splitting carla clears bug #1241")
 @pytest.mark.usefixtures("ensure_armory_dirs")
 def test_carla_od_multimodal():
     detector_module = import_module(
@@ -441,6 +445,7 @@ def test_carla_od_multimodal():
     assert [ap_per_class[i] > 0.35 for i in range(1, 4)]
 
 
+@pytest.mark.skip(reason="checking if splitting carla clears bug #1241")
 @pytest.mark.usefixtures("ensure_armory_dirs")
 def test_carla_od_multimodal_robust_fusion():
     detector_module = import_module(


### PR DESCRIPTION
The `pytest-pytorch` block of CI was causing the CI build machine to run out of resources. 

This uses the pytest "test names matching pattern" `-k` option to run the carla CI tests separately allowing the test https://github.com/mwartell/armory/actions/runs/1654197244 to complete successfully.

This is merging to master because it fixes a CI problem that all subordinate branches will see.