### PR TITLE
Fix docker colons 1267

### DIFF
--- a/armory/docker/management.py
+++ b/armory/docker/management.py
@@ -29,7 +29,6 @@ class ArmoryInstance(object):
     ):
         self.docker_client = docker.from_env(version="auto")
 
-
         host_paths = paths.HostPaths()
         docker_paths = paths.DockerPaths()
 
@@ -47,10 +46,6 @@ class ArmoryInstance(object):
             "mounts": mounts,
             "shm_size": "16G",
         }
-
-        print(f"{container_args}")
-        input("Press Enter to continue...")
-
 
         if ports is not None:
             container_args["ports"] = ports

--- a/armory/docker/management.py
+++ b/armory/docker/management.py
@@ -32,12 +32,15 @@ class ArmoryInstance(object):
         host_paths = paths.HostPaths()
         docker_paths = paths.DockerPaths()
 
-        mounts = [docker.types.Mount(
-            source=getattr(host_paths, dir),
-            target=getattr(docker_paths, dir),
-            type="bind",
-            read_only=False,
-            ) for dir in 'cwd dataset_dir local_git_dir output_dir saved_model_dir tmp_dir'.split()]
+        mounts = [
+            docker.types.Mount(
+                source=getattr(host_paths, dir),
+                target=getattr(docker_paths, dir),
+                type="bind",
+                read_only=False,
+            )
+            for dir in "cwd dataset_dir local_git_dir output_dir saved_model_dir tmp_dir".split()
+        ]
 
         container_args = {
             "runtime": runtime,

--- a/armory/docker/management.py
+++ b/armory/docker/management.py
@@ -29,32 +29,28 @@ class ArmoryInstance(object):
     ):
         self.docker_client = docker.from_env(version="auto")
 
+
         host_paths = paths.HostPaths()
         docker_paths = paths.DockerPaths()
+
+        mounts = [docker.types.Mount(
+            source=getattr(host_paths, dir),
+            target=getattr(docker_paths, dir),
+            type="bind",
+            read_only=False,
+            ) for dir in 'cwd dataset_dir local_git_dir output_dir saved_model_dir tmp_dir'.split()]
 
         container_args = {
             "runtime": runtime,
             "remove": True,
             "detach": True,
-            "volumes": {
-                host_paths.cwd: {"bind": docker_paths.cwd, "mode": "rw"},
-                host_paths.dataset_dir: {
-                    "bind": docker_paths.dataset_dir,
-                    "mode": "rw",
-                },
-                host_paths.local_git_dir: {
-                    "bind": docker_paths.local_git_dir,
-                    "mode": "rw",
-                },
-                host_paths.output_dir: {"bind": docker_paths.output_dir, "mode": "rw"},
-                host_paths.saved_model_dir: {
-                    "bind": docker_paths.saved_model_dir,
-                    "mode": "rw",
-                },
-                host_paths.tmp_dir: {"bind": docker_paths.tmp_dir, "mode": "rw"},
-            },
+            "mounts": mounts,
             "shm_size": "16G",
         }
+
+        print(f"{container_args}")
+        input("Press Enter to continue...")
+
 
         if ports is not None:
             container_args["ports"] = ports


### PR DESCRIPTION
Fixes #1267 

Uses the `mount=` form of docker-py container creation instead of `volumes=` because the later cannot accept literal colons `:` in directory names.  Since armory mounts the expanded cwd, running armory in `/home/msw/foo:bar/` will fault.

The `mount=` form works properly if there is a colon. This is similar to the `docker --mount` and `--volumes` arguments.