### PR TITLE
Carla: export all relevant bboxes

### DIFF
--- a/armory/utils/export.py
+++ b/armory/utils/export.py
@@ -170,7 +170,7 @@ class SampleExporter:
 
                 bboxes_true = y[0]["boxes"]
                 labels_true = y[0]["labels"]
-                bboxes_pred_adv = y_pred_adv[0]["boxes"][y_pred_adv[0]["scores"] > 0.9]
+                bboxes_pred_adv = y_pred_adv[0]["boxes"][y_pred_adv[0]["scores"] > 0.5]
 
                 for true_box, label in zip(bboxes_true, labels_true):
                     if classes_to_skip is not None and label in classes_to_skip:


### PR DESCRIPTION
Only boxes with score greater than 0.9 were being drawn on exported samples, but the carla metrics count all predictions with score greater than 0.5.  This matches the export function to the metrics.