### PR TITLE
bump develop version to 0.14.6

### DIFF
--- a/armory/__init__.py
+++ b/armory/__init__.py
@@ -8,7 +8,7 @@ logger.addHandler(logging.NullHandler())
 
 
 # Semantic Version
-__version__ = "0.14.4"
+__version__ = "0.14.6"
 
 # typedef for a widely used JSON-like configuration specification
 from typing import Dict, Any

--- a/scenario_configs/apricot_frcnn.json
+++ b/scenario_configs/apricot_frcnn.json
@@ -44,7 +44,7 @@
         "name": "ObjectDetectionTask"
     },
     "sysconfig": {
-        "docker_image": "twosixarmory/tf2:0.14.4",
+        "docker_image": "twosixarmory/tf2:0.14.6",
         "external_github_repo": null,
         "gpus": "all",
         "output_dir": null,

--- a/scenario_configs/apricot_frcnn_defended.json
+++ b/scenario_configs/apricot_frcnn_defended.json
@@ -57,7 +57,7 @@
         "name": "ObjectDetectionTask"
     },
     "sysconfig": {
-        "docker_image": "twosixarmory/tf2:0.14.4",
+        "docker_image": "twosixarmory/tf2:0.14.6",
         "external_github_repo": null,
         "gpus": "all",
         "output_dir": null,

--- a/scenario_configs/carla_obj_det_dpatch_defended.json
+++ b/scenario_configs/carla_obj_det_dpatch_defended.json
@@ -64,7 +64,7 @@
         "name": "CarlaObjectDetectionTask"
     },
     "sysconfig": {
-        "docker_image": "twosixarmory/pytorch:0.14.4",
+        "docker_image": "twosixarmory/pytorch:0.14.6",
         "external_github_repo": "colour-science/colour@v0.3.16",
         "gpus": "all",
         "output_dir": null,

--- a/scenario_configs/carla_obj_det_dpatch_undefended.json
+++ b/scenario_configs/carla_obj_det_dpatch_undefended.json
@@ -51,7 +51,7 @@
         "name": "CarlaObjectDetectionTask"
     },
     "sysconfig": {
-        "docker_image": "twosixarmory/pytorch:0.14.4",
+        "docker_image": "twosixarmory/pytorch:0.14.6",
         "external_github_repo": "colour-science/colour@v0.3.16",
         "gpus": "all",
         "output_dir": null,

--- a/scenario_configs/carla_obj_det_multimodal_dpatch_defended.json
+++ b/scenario_configs/carla_obj_det_multimodal_dpatch_defended.json
@@ -49,7 +49,7 @@
         "name": "CarlaObjectDetectionTask"
     },
     "sysconfig": {
-        "docker_image": "twosixarmory/pytorch:0.14.4",
+        "docker_image": "twosixarmory/pytorch:0.14.6",
         "external_github_repo": "colour-science/colour@v0.3.16",
         "gpus": "all",
         "output_dir": null,

--- a/scenario_configs/carla_obj_det_multimodal_dpatch_undefended.json
+++ b/scenario_configs/carla_obj_det_multimodal_dpatch_undefended.json
@@ -49,7 +49,7 @@
         "name": "CarlaObjectDetectionTask"
     },
     "sysconfig": {
-        "docker_image": "twosixarmory/pytorch:0.14.4",
+        "docker_image": "twosixarmory/pytorch:0.14.6",
         "external_github_repo": "colour-science/colour@v0.3.16",
         "gpus": "all",
         "output_dir": null,

--- a/scenario_configs/carla_video_tracking_goturn_advtextures_defended.json
+++ b/scenario_configs/carla_video_tracking_goturn_advtextures_defended.json
@@ -56,7 +56,7 @@
         "name": "CarlaVideoTracking"
     },
     "sysconfig": {
-        "docker_image": "twosixarmory/pytorch:0.14.4",
+        "docker_image": "twosixarmory/pytorch:0.14.6",
         "external_github_repo": "amoudgl/pygoturn",
         "gpus": "all",
         "output_dir": null,

--- a/scenario_configs/carla_video_tracking_goturn_advtextures_undefended.json
+++ b/scenario_configs/carla_video_tracking_goturn_advtextures_undefended.json
@@ -44,7 +44,7 @@
         "name": "CarlaVideoTracking"
     },
     "sysconfig": {
-        "docker_image": "twosixarmory/pytorch:0.14.4",
+        "docker_image": "twosixarmory/pytorch:0.14.6",
         "external_github_repo": "amoudgl/pygoturn",
         "gpus": "all",
         "output_dir": null,

--- a/scenario_configs/cifar10_baseline.json
+++ b/scenario_configs/cifar10_baseline.json
@@ -49,7 +49,7 @@
         "name": "ImageClassificationTask"
     },
     "sysconfig": {
-        "docker_image": "twosixarmory/pytorch:0.14.4",
+        "docker_image": "twosixarmory/pytorch:0.14.6",
         "external_github_repo": null,
         "gpus": "all",
         "output_dir": null,

--- a/scenario_configs/cifar10_defended_example.json
+++ b/scenario_configs/cifar10_defended_example.json
@@ -57,7 +57,7 @@
         "name": "ImageClassificationTask"
     },
     "sysconfig": {
-        "docker_image": "twosixarmory/pytorch:0.14.4",
+        "docker_image": "twosixarmory/pytorch:0.14.6",
         "external_github_repo": null,
         "gpus": "all",
         "output_dir": null,

--- a/scenario_configs/dapricot_frcnn_masked_pgd.json
+++ b/scenario_configs/dapricot_frcnn_masked_pgd.json
@@ -53,7 +53,7 @@
         "name": "ObjectDetectionTask"
     },
     "sysconfig": {
-        "docker_image": "twosixarmory/tf2:0.14.4",
+        "docker_image": "twosixarmory/tf2:0.14.6",
         "external_github_repo": "colour-science/colour@v0.3.16",
         "gpus": "all",
         "output_dir": null,

--- a/scenario_configs/gtsrb_scenario_baseline.json
+++ b/scenario_configs/gtsrb_scenario_baseline.json
@@ -58,7 +58,7 @@
         "name": "GTSRB"
     },
     "sysconfig": {
-        "docker_image": "twosixarmory/pytorch:0.14.4",
+        "docker_image": "twosixarmory/pytorch:0.14.6",
         "external_github_repo": null,
         "gpus": "all",
         "output_dir": null,

--- a/scenario_configs/gtsrb_scenario_baseline_pytorch.json
+++ b/scenario_configs/gtsrb_scenario_baseline_pytorch.json
@@ -58,7 +58,7 @@
         "name": "GTSRB"
     },
     "sysconfig": {
-        "docker_image": "twosixarmory/pytorch:0.14.4",
+        "docker_image": "twosixarmory/pytorch:0.14.6",
         "external_github_repo": null,
         "gpus": "all",
         "output_dir": null,

--- a/scenario_configs/gtsrb_scenario_clbd.json
+++ b/scenario_configs/gtsrb_scenario_clbd.json
@@ -58,7 +58,7 @@
         "name": "GTSRB_CLBD"
     },
     "sysconfig": {
-        "docker_image": "twosixarmory/pytorch:0.14.4",
+        "docker_image": "twosixarmory/pytorch:0.14.6",
         "external_github_repo": null,
         "gpus": "all",
         "output_dir": null,

--- a/scenario_configs/gtsrb_scenario_clbd_bullethole.json
+++ b/scenario_configs/gtsrb_scenario_clbd_bullethole.json
@@ -64,7 +64,7 @@
         "name": "GTSRB_CLBD"
     },
     "sysconfig": {
-        "docker_image": "twosixarmory/pytorch:0.14.4",
+        "docker_image": "twosixarmory/pytorch:0.14.6",
         "external_github_repo": null,
         "gpus": "all",
         "output_dir": null,

--- a/scenario_configs/gtsrb_scenario_clbd_defended.json
+++ b/scenario_configs/gtsrb_scenario_clbd_defended.json
@@ -69,7 +69,7 @@
         "name": "GTSRB_CLBD"
     },
     "sysconfig": {
-        "docker_image": "twosixarmory/pytorch:0.14.4",
+        "docker_image": "twosixarmory/pytorch:0.14.6",
         "external_github_repo": null,
         "gpus": "all",
         "output_dir": null,

--- a/scenario_configs/gtsrb_scenario_poison.json
+++ b/scenario_configs/gtsrb_scenario_poison.json
@@ -48,7 +48,7 @@
         "name": "GTSRB"
     },
     "sysconfig": {
-        "docker_image": "twosixarmory/pytorch:0.14.4",
+        "docker_image": "twosixarmory/pytorch:0.14.6",
         "external_github_repo": null,
         "gpus": "all",
         "use_gpu": false

--- a/scenario_configs/librispeech_asr_imperceptible_defended.json
+++ b/scenario_configs/librispeech_asr_imperceptible_defended.json
@@ -81,7 +81,7 @@
         "name": "AutomaticSpeechRecognition"
     },
     "sysconfig": {
-        "docker_image": "twosixarmory/pytorch-deepspeech:0.14.4",
+        "docker_image": "twosixarmory/pytorch-deepspeech:0.14.6",
         "external_github_repo": "SeanNaren/deepspeech.pytorch@V3.0",
         "gpus": "all",
         "local_repo_path": null,

--- a/scenario_configs/librispeech_asr_imperceptible_undefended.json
+++ b/scenario_configs/librispeech_asr_imperceptible_undefended.json
@@ -70,7 +70,7 @@
         "name": "AutomaticSpeechRecognition"
     },
     "sysconfig": {
-        "docker_image": "twosixarmory/pytorch-deepspeech:0.14.4",
+        "docker_image": "twosixarmory/pytorch-deepspeech:0.14.6",
         "external_github_repo": "SeanNaren/deepspeech.pytorch@V3.0",
         "gpus": "all",
         "local_repo_path": null,

--- a/scenario_configs/librispeech_asr_kenansville_defended.json
+++ b/scenario_configs/librispeech_asr_kenansville_defended.json
@@ -64,7 +64,7 @@
         "name": "AutomaticSpeechRecognition"
     },
     "sysconfig": {
-        "docker_image": "twosixarmory/pytorch-deepspeech:0.14.4",
+        "docker_image": "twosixarmory/pytorch-deepspeech:0.14.6",
         "external_github_repo": "SeanNaren/deepspeech.pytorch@V3.0",
         "gpus": "all",
         "local_repo_path": null,

--- a/scenario_configs/librispeech_asr_kenansville_undefended.json
+++ b/scenario_configs/librispeech_asr_kenansville_undefended.json
@@ -53,7 +53,7 @@
         "name": "AutomaticSpeechRecognition"
     },
     "sysconfig": {
-        "docker_image": "twosixarmory/pytorch-deepspeech:0.14.4",
+        "docker_image": "twosixarmory/pytorch-deepspeech:0.14.6",
         "external_github_repo": "SeanNaren/deepspeech.pytorch@V3.0",
         "gpus": "all",
         "local_repo_path": null,

--- a/scenario_configs/librispeech_asr_pgd_defended.json
+++ b/scenario_configs/librispeech_asr_pgd_defended.json
@@ -75,7 +75,7 @@
         "name": "AutomaticSpeechRecognition"
     },
     "sysconfig": {
-        "docker_image": "twosixarmory/pytorch-deepspeech:0.14.4",
+        "docker_image": "twosixarmory/pytorch-deepspeech:0.14.6",
         "external_github_repo": "SeanNaren/deepspeech.pytorch@V3.0",
         "gpus": "all",
         "local_repo_path": null,

--- a/scenario_configs/librispeech_asr_pgd_multipath_channel_defended.json
+++ b/scenario_configs/librispeech_asr_pgd_multipath_channel_defended.json
@@ -80,7 +80,7 @@
         "name": "AutomaticSpeechRecognition"
     },
     "sysconfig": {
-        "docker_image": "twosixarmory/pytorch-deepspeech:0.14.4",
+        "docker_image": "twosixarmory/pytorch-deepspeech:0.14.6",
         "external_github_repo": "SeanNaren/deepspeech.pytorch@V3.0",
         "gpus": "all",
         "local_repo_path": null,

--- a/scenario_configs/librispeech_asr_pgd_multipath_channel_undefended.json
+++ b/scenario_configs/librispeech_asr_pgd_multipath_channel_undefended.json
@@ -69,7 +69,7 @@
         "name": "AutomaticSpeechRecognition"
     },
     "sysconfig": {
-        "docker_image": "twosixarmory/pytorch-deepspeech:0.14.4",
+        "docker_image": "twosixarmory/pytorch-deepspeech:0.14.6",
         "external_github_repo": "SeanNaren/deepspeech.pytorch@V3.0",
         "gpus": "all",
         "local_repo_path": null,

--- a/scenario_configs/librispeech_asr_pgd_undefended.json
+++ b/scenario_configs/librispeech_asr_pgd_undefended.json
@@ -64,7 +64,7 @@
         "name": "AutomaticSpeechRecognition"
     },
     "sysconfig": {
-        "docker_image": "twosixarmory/pytorch-deepspeech:0.14.4",
+        "docker_image": "twosixarmory/pytorch-deepspeech:0.14.6",
         "external_github_repo": "SeanNaren/deepspeech.pytorch@V3.0",
         "gpus": "all",
         "local_repo_path": null,

--- a/scenario_configs/librispeech_asr_snr_undefended.json
+++ b/scenario_configs/librispeech_asr_snr_undefended.json
@@ -69,7 +69,7 @@
         "name": "AutomaticSpeechRecognition"
     },
     "sysconfig": {
-        "docker_image": "twosixarmory/pytorch-deepspeech:0.14.4",
+        "docker_image": "twosixarmory/pytorch-deepspeech:0.14.6",
         "external_github_repo": "SeanNaren/deepspeech.pytorch@V3.0",
         "gpus": "all",
         "local_repo_path": null,

--- a/scenario_configs/librispeech_baseline_sincnet.json
+++ b/scenario_configs/librispeech_baseline_sincnet.json
@@ -55,7 +55,7 @@
         "name": "AudioClassificationTask"
     },
     "sysconfig": {
-        "docker_image": "twosixarmory/pytorch:0.14.4",
+        "docker_image": "twosixarmory/pytorch:0.14.6",
         "external_github_repo": "hkakitani/SincNet",
         "gpus": "all",
         "output_dir": null,

--- a/scenario_configs/librispeech_baseline_sincnet_snr_pgd.json
+++ b/scenario_configs/librispeech_baseline_sincnet_snr_pgd.json
@@ -59,7 +59,7 @@
         "name": "AudioClassificationTask"
     },
     "sysconfig": {
-        "docker_image": "twosixarmory/pytorch:0.14.4",
+        "docker_image": "twosixarmory/pytorch:0.14.6",
         "external_github_repo": "hkakitani/SincNet",
         "gpus": "all",
         "output_dir": null,

--- a/scenario_configs/librispeech_baseline_sincnet_targeted.json
+++ b/scenario_configs/librispeech_baseline_sincnet_targeted.json
@@ -62,7 +62,7 @@
         "name": "AudioClassificationTask"
     },
     "sysconfig": {
-        "docker_image": "twosixarmory/pytorch:0.14.4",
+        "docker_image": "twosixarmory/pytorch:0.14.6",
         "external_github_repo": "hkakitani/SincNet",
         "gpus": "all",
         "output_dir": null,

--- a/scenario_configs/mnist_baseline.json
+++ b/scenario_configs/mnist_baseline.json
@@ -47,7 +47,7 @@
         "name": "ImageClassificationTask"
     },
     "sysconfig": {
-        "docker_image": "twosixarmory/pytorch:0.14.4",
+        "docker_image": "twosixarmory/pytorch:0.14.6",
         "external_github_repo": null,
         "gpus": "all",
         "output_dir": null,

--- a/scenario_configs/resisc10_poison_dlbd.json
+++ b/scenario_configs/resisc10_poison_dlbd.json
@@ -114,7 +114,7 @@
         "name": "RESISC10"
     },
     "sysconfig": {
-        "docker_image": "twosixarmory/pytorch:0.14.4",
+        "docker_image": "twosixarmory/pytorch:0.14.6",
         "external_github_repo": null,
         "gpus": "all",
         "output_dir": null,

--- a/scenario_configs/resisc45_baseline_densenet121.json
+++ b/scenario_configs/resisc45_baseline_densenet121.json
@@ -45,7 +45,7 @@
         "name": "ImageClassificationTask"
     },
     "sysconfig": {
-        "docker_image": "twosixarmory/pytorch:0.14.4",
+        "docker_image": "twosixarmory/pytorch:0.14.6",
         "external_github_repo": null,
         "gpus": "all",
         "output_dir": null,

--- a/scenario_configs/resisc45_baseline_densenet121_cascade.json
+++ b/scenario_configs/resisc45_baseline_densenet121_cascade.json
@@ -70,7 +70,7 @@
         "name": "ImageClassificationTask"
     },
     "sysconfig": {
-        "docker_image": "twosixarmory/pytorch:0.14.4",
+        "docker_image": "twosixarmory/pytorch:0.14.6",
         "external_github_repo": null,
         "gpus": "all",
         "output_dir": null,

--- a/scenario_configs/resisc45_baseline_densenet121_finetune.json
+++ b/scenario_configs/resisc45_baseline_densenet121_finetune.json
@@ -45,7 +45,7 @@
         "name": "ImageClassificationTask"
     },
     "sysconfig": {
-        "docker_image": "twosixarmory/pytorch:0.14.4",
+        "docker_image": "twosixarmory/pytorch:0.14.6",
         "external_github_repo": null,
         "gpus": "all",
         "output_dir": null,

--- a/scenario_configs/resisc45_baseline_densenet121_patch.json
+++ b/scenario_configs/resisc45_baseline_densenet121_patch.json
@@ -58,7 +58,7 @@
         "name": "ImageClassificationTask"
     },
     "sysconfig": {
-        "docker_image": "twosixarmory/pytorch:0.14.4",
+        "docker_image": "twosixarmory/pytorch:0.14.6",
         "external_github_repo": null,
         "gpus": "all",
         "output_dir": null,

--- a/scenario_configs/resisc45_baseline_densenet121_sweep_eps.json
+++ b/scenario_configs/resisc45_baseline_densenet121_sweep_eps.json
@@ -68,7 +68,7 @@
         "name": "ImageClassificationTask"
     },
     "sysconfig": {
-        "docker_image": "twosixarmory/pytorch:0.14.4",
+        "docker_image": "twosixarmory/pytorch:0.14.6",
         "external_github_repo": null,
         "gpus": "all",
         "output_dir": null,

--- a/scenario_configs/resisc45_baseline_densenet121_targeted.json
+++ b/scenario_configs/resisc45_baseline_densenet121_targeted.json
@@ -52,7 +52,7 @@
         "name": "ImageClassificationTask"
     },
     "sysconfig": {
-        "docker_image": "twosixarmory/pytorch:0.14.4",
+        "docker_image": "twosixarmory/pytorch:0.14.6",
         "external_github_repo": null,
         "gpus": "all",
         "output_dir": null,

--- a/scenario_configs/so2sat_eo_masked_pgd_defended.json
+++ b/scenario_configs/so2sat_eo_masked_pgd_defended.json
@@ -136,7 +136,7 @@
         "name": "So2SatClassification"
     },
     "sysconfig": {
-        "docker_image": "twosixarmory/pytorch:0.14.4",
+        "docker_image": "twosixarmory/pytorch:0.14.6",
         "external_github_repo": null,
         "gpus": "all",
         "output_dir": null,

--- a/scenario_configs/so2sat_eo_masked_pgd_undefended.json
+++ b/scenario_configs/so2sat_eo_masked_pgd_undefended.json
@@ -90,7 +90,7 @@
         "name": "So2SatClassification"
     },
     "sysconfig": {
-        "docker_image": "twosixarmory/pytorch:0.14.4",
+        "docker_image": "twosixarmory/pytorch:0.14.6",
         "external_github_repo": null,
         "gpus": "all",
         "output_dir": null,

--- a/scenario_configs/so2sat_sar_masked_pgd_defended.json
+++ b/scenario_configs/so2sat_sar_masked_pgd_defended.json
@@ -136,7 +136,7 @@
         "name": "So2SatClassification"
     },
     "sysconfig": {
-        "docker_image": "twosixarmory/pytorch:0.14.4",
+        "docker_image": "twosixarmory/pytorch:0.14.6",
         "external_github_repo": null,
         "gpus": "all",
         "output_dir": null,

--- a/scenario_configs/so2sat_sar_masked_pgd_undefended.json
+++ b/scenario_configs/so2sat_sar_masked_pgd_undefended.json
@@ -90,7 +90,7 @@
         "name": "So2SatClassification"
     },
     "sysconfig": {
-        "docker_image": "twosixarmory/pytorch:0.14.4",
+        "docker_image": "twosixarmory/pytorch:0.14.6",
         "external_github_repo": null,
         "gpus": "all",
         "output_dir": null,

--- a/scenario_configs/ucf101_baseline_finetune.json
+++ b/scenario_configs/ucf101_baseline_finetune.json
@@ -52,7 +52,7 @@
         "name": "Ucf101"
     },
     "sysconfig": {
-        "docker_image": "twosixarmory/pytorch:0.14.4",
+        "docker_image": "twosixarmory/pytorch:0.14.6",
         "external_github_repo": "yusong-tan/MARS",
         "gpus": "all",
         "output_dir": null,

--- a/scenario_configs/ucf101_baseline_pretrained_targeted.json
+++ b/scenario_configs/ucf101_baseline_pretrained_targeted.json
@@ -58,7 +58,7 @@
         "name": "Ucf101"
     },
     "sysconfig": {
-        "docker_image": "twosixarmory/pytorch:0.14.4",
+        "docker_image": "twosixarmory/pytorch:0.14.6",
         "external_github_repo": "yusong-tan/MARS",
         "gpus": "all",
         "output_dir": null,

--- a/scenario_configs/ucf101_pretrained_flicker_defended.json
+++ b/scenario_configs/ucf101_pretrained_flicker_defended.json
@@ -67,7 +67,7 @@
         "name": "Ucf101"
     },
     "sysconfig": {
-        "docker_image": "twosixarmory/pytorch:0.14.4",
+        "docker_image": "twosixarmory/pytorch:0.14.6",
         "external_github_repo": "yusong-tan/MARS",
         "gpus": "all",
         "output_dir": null,

--- a/scenario_configs/ucf101_pretrained_flicker_undefended.json
+++ b/scenario_configs/ucf101_pretrained_flicker_undefended.json
@@ -55,7 +55,7 @@
         "name": "Ucf101"
     },
     "sysconfig": {
-        "docker_image": "twosixarmory/pytorch:0.14.4",
+        "docker_image": "twosixarmory/pytorch:0.14.6",
         "external_github_repo": "yusong-tan/MARS",
         "gpus": "all",
         "output_dir": null,

--- a/scenario_configs/ucf101_pretrained_frame_saliency_defended.json
+++ b/scenario_configs/ucf101_pretrained_frame_saliency_defended.json
@@ -76,7 +76,7 @@
         "name": "Ucf101"
     },
     "sysconfig": {
-        "docker_image": "twosixarmory/pytorch:0.14.4",
+        "docker_image": "twosixarmory/pytorch:0.14.6",
         "external_github_repo": "yusong-tan/MARS",
         "gpus": "all",
         "output_dir": null,

--- a/scenario_configs/ucf101_pretrained_frame_saliency_undefended.json
+++ b/scenario_configs/ucf101_pretrained_frame_saliency_undefended.json
@@ -64,7 +64,7 @@
         "name": "Ucf101"
     },
     "sysconfig": {
-        "docker_image": "twosixarmory/pytorch:0.14.4",
+        "docker_image": "twosixarmory/pytorch:0.14.6",
         "external_github_repo": "yusong-tan/MARS",
         "gpus": "all",
         "output_dir": null,

--- a/scenario_configs/ucf101_pretrained_masked_pgd_defended.json
+++ b/scenario_configs/ucf101_pretrained_masked_pgd_defended.json
@@ -73,7 +73,7 @@
         "name": "Ucf101"
     },
     "sysconfig": {
-        "docker_image": "twosixarmory/pytorch:0.14.4",
+        "docker_image": "twosixarmory/pytorch:0.14.6",
         "external_github_repo": "yusong-tan/MARS",
         "gpus": "all",
         "output_dir": null,

--- a/scenario_configs/ucf101_pretrained_masked_pgd_undefended.json
+++ b/scenario_configs/ucf101_pretrained_masked_pgd_undefended.json
@@ -61,7 +61,7 @@
         "name": "Ucf101"
     },
     "sysconfig": {
-        "docker_image": "twosixarmory/pytorch:0.14.4",
+        "docker_image": "twosixarmory/pytorch:0.14.6",
         "external_github_repo": "yusong-tan/MARS",
         "gpus": "all",
         "output_dir": null,

--- a/scenario_configs/xview_frcnn_masked_pgd_defended.json
+++ b/scenario_configs/xview_frcnn_masked_pgd_defended.json
@@ -64,7 +64,7 @@
         "name": "ObjectDetectionTask"
     },
     "sysconfig": {
-        "docker_image": "twosixarmory/pytorch:0.14.4",
+        "docker_image": "twosixarmory/pytorch:0.14.6",
         "external_github_repo": null,
         "gpus": "all",
         "output_dir": null,

--- a/scenario_configs/xview_frcnn_masked_pgd_undefended.json
+++ b/scenario_configs/xview_frcnn_masked_pgd_undefended.json
@@ -51,7 +51,7 @@
         "name": "ObjectDetectionTask"
     },
     "sysconfig": {
-        "docker_image": "twosixarmory/pytorch:0.14.4",
+        "docker_image": "twosixarmory/pytorch:0.14.6",
         "external_github_repo": null,
         "gpus": "all",
         "output_dir": null,

--- a/scenario_configs/xview_frcnn_robust_dpatch_defended.json
+++ b/scenario_configs/xview_frcnn_robust_dpatch_defended.json
@@ -66,7 +66,7 @@
         "name": "ObjectDetectionTask"
     },
     "sysconfig": {
-        "docker_image": "twosixarmory/pytorch:0.14.4",
+        "docker_image": "twosixarmory/pytorch:0.14.6",
         "external_github_repo": null,
         "gpus": "all",
         "output_dir": null,

--- a/scenario_configs/xview_frcnn_robust_dpatch_undefended.json
+++ b/scenario_configs/xview_frcnn_robust_dpatch_undefended.json
@@ -53,7 +53,7 @@
         "name": "ObjectDetectionTask"
     },
     "sysconfig": {
-        "docker_image": "twosixarmory/pytorch:0.14.4",
+        "docker_image": "twosixarmory/pytorch:0.14.6",
         "external_github_repo": null,
         "gpus": "all",
         "output_dir": null,

--- a/scenario_configs/xview_frcnn_sweep_patch_size.json
+++ b/scenario_configs/xview_frcnn_sweep_patch_size.json
@@ -95,7 +95,7 @@
         "name": "ObjectDetectionTask"
     },
     "sysconfig": {
-        "docker_image": "twosixarmory/pytorch:0.14.4",
+        "docker_image": "twosixarmory/pytorch:0.14.6",
         "external_github_repo": null,
         "gpus": "all",
         "output_dir": null,

--- a/scenario_configs/xview_frcnn_targeted.json
+++ b/scenario_configs/xview_frcnn_targeted.json
@@ -60,7 +60,7 @@
         "name": "ObjectDetectionTask"
     },
     "sysconfig": {
-        "docker_image": "twosixarmory/pytorch:0.14.4",
+        "docker_image": "twosixarmory/pytorch:0.14.6",
         "external_github_repo": null,
         "gpus": "all",
         "output_dir": null,

--- a/tests/scenarios/broken/invalid_dataset_framework.json
+++ b/tests/scenarios/broken/invalid_dataset_framework.json
@@ -46,7 +46,7 @@
         "name": "ImageClassificationTask"
     },
     "sysconfig": {
-        "docker_image": "twosixarmory/tf1:0.14.4",
+        "docker_image": "twosixarmory/tf1:0.14.6",
         "external_github_repo": null,
         "gpus": "all",
         "output_dir": null,

--- a/tests/scenarios/broken/invalid_module.json
+++ b/tests/scenarios/broken/invalid_module.json
@@ -39,7 +39,7 @@
         "name": "fgm_attack"
     },
     "sysconfig": {
-        "docker_image": "twosixarmory/tf1:0.14.4",
+        "docker_image": "twosixarmory/tf1:0.14.6",
         "external_github_repo": null,
         "gpus": "",
         "output_dir": null,

--- a/tests/scenarios/broken/missing_scenario.json
+++ b/tests/scenarios/broken/missing_scenario.json
@@ -40,7 +40,7 @@
         "wrapper_kwargs": {}
     },
     "sysconfig": {
-        "docker_image": "twosixarmory/tf1:0.14.4",
+        "docker_image": "twosixarmory/tf1:0.14.6",
         "external_github_repo": null,
         "gpus": "all",
         "output_dir": null,

--- a/tests/scenarios/pytorch/image_classification.json
+++ b/tests/scenarios/pytorch/image_classification.json
@@ -46,7 +46,7 @@
         "name": "ImageClassificationTask"
     },
     "sysconfig": {
-        "docker_image": "twosixarmory/pytorch:0.14.4",
+        "docker_image": "twosixarmory/pytorch:0.14.6",
         "external_github_repo": null,
         "gpus": "all",
         "output_dir": null,

--- a/tests/scenarios/pytorch/image_classification_pretrained.json
+++ b/tests/scenarios/pytorch/image_classification_pretrained.json
@@ -44,7 +44,7 @@
         "name": "ImageClassificationTask"
     },
     "sysconfig": {
-        "docker_image": "twosixarmory/pytorch:0.14.4",
+        "docker_image": "twosixarmory/pytorch:0.14.6",
         "external_github_repo": null,
         "gpus": "all",
         "output_dir": null,

--- a/tests/scenarios/tf1/image_classification.json
+++ b/tests/scenarios/tf1/image_classification.json
@@ -46,7 +46,7 @@
         "name": "ImageClassificationTask"
     },
     "sysconfig": {
-        "docker_image": "twosixarmory/tf1:0.14.4",
+        "docker_image": "twosixarmory/tf1:0.14.6",
         "external_github_repo": null,
         "gpus": "all",
         "output_dir": null,

--- a/tests/scenarios/tf1/image_classification_pretrained.json
+++ b/tests/scenarios/tf1/image_classification_pretrained.json
@@ -44,7 +44,7 @@
         "name": "ImageClassificationTask"
     },
     "sysconfig": {
-        "docker_image": "twosixarmory/tf1:0.14.4",
+        "docker_image": "twosixarmory/tf1:0.14.6",
         "external_github_repo": null,
         "gpus": "all",
         "output_dir": null,

--- a/tests/scenarios/tf1/image_classification_tfgraph.json
+++ b/tests/scenarios/tf1/image_classification_tfgraph.json
@@ -46,7 +46,7 @@
         "name": "ImageClassificationTask"
     },
     "sysconfig": {
-        "docker_image": "twosixarmory/tf1:0.14.4",
+        "docker_image": "twosixarmory/tf1:0.14.6",
         "external_github_repo": null,
         "gpus": "all",
         "output_dir": null,


### PR DESCRIPTION
There was a source-only release which did not bump the version numbers outside of branch `no-docker-mode`. Since no-docker-mode might never be integrated to develop/master, I've cut this catch-up change.

This version represents perhaps the next version to ship. It IS NOT the version that we just shipped (as is often the case for typical releases).