### PR TITLE
Externally downloaded repos (requirements in armory repo but not in docker image)

### DIFF
--- a/STYLE.md
+++ b/STYLE.md
@@ -36,7 +36,7 @@ chmod 755 .git/hooks/pre-commit
 ```
 
 # Import Style
-Imports in python files should be organized into three blocks, after the docstring, and before other code:
+Imports in python files should be organized into three blocks, lexically ordered, after the docstring, and before other code:
 * Block 1: built-in package imports
 * Block 2: external package imports
 * Block 3: internal package imports
@@ -54,9 +54,8 @@ import requests
 import numpy as np
 from art import defences
 
-from armory.docker.management import ManagementInstance                                   
+from armory.docker.management import ManagementInstance
 from armory.utils.external_repo import download_and_extract_repos
-
 
 logger = logging.getLogger(__name__)
 # ...
@@ -64,3 +63,21 @@ logger = logging.getLogger(__name__)
 
 Exceptions are allowed for import error handling, required import ordering, or in-class/function imports.
 
+## Additional Import Block for Downloaded GitHub Repos
+
+A fourth import block may be added for external package imports that require downloading an external github repo via armory.
+This is typically only used for some baseline models and art experimental attacks.
+This must use the `armory.errors.ExternalRepoImport` context manager as follows (one `with` statement per external repo):
+```
+from armory.errors import ExternalRepoImport
+
+with ExternalRepoImport(
+    repo="colour-science/colour@v0.3.16",
+    experiment="carla_obj_det_dpatch_undefended.json",
+):
+    import colour
+```
+
+`repo` refers to the GitHub repo name (optionally with `@tag`).
+`experiment` refers to the `.json` file in the `scenario_config` directory that uses this repo.
+These repos are specifically *NOT* installed in the armory-supported docker containers and conda environments, and are downloaded at runtime.

--- a/armory/art_experimental/attacks/carla_obj_det_patch.py
+++ b/armory/art_experimental/attacks/carla_obj_det_patch.py
@@ -1,10 +1,17 @@
 import logging
-import numpy as np
-import cv2
-import colour
 import random
 
+import numpy as np
+import cv2
 from art.attacks.evasion import RobustDPatch
+
+from armory.errors import ExternalRepoImport
+
+with ExternalRepoImport(
+    repo="colour-science/colour@v0.3.16",
+    experiment="carla_obj_det_dpatch_undefended.json",
+):
+    import colour
 
 logger = logging.getLogger(__name__)
 

--- a/armory/art_experimental/attacks/carla_obj_det_patch.py
+++ b/armory/art_experimental/attacks/carla_obj_det_patch.py
@@ -1,9 +1,9 @@
 import logging
 import random
 
-import numpy as np
-import cv2
 from art.attacks.evasion import RobustDPatch
+import cv2
+import numpy as np
 
 from armory.errors import ExternalRepoImport
 

--- a/armory/baseline_models/pytorch/carla_goturn.py
+++ b/armory/baseline_models/pytorch/carla_goturn.py
@@ -1,14 +1,22 @@
-import torch
+import logging
 from typing import Optional
-import numpy as np
-from art.estimators.object_tracking import PyTorchGoturn
 
-# Load model from MITRE external repo: https://github.com/yusong-tan/pygoturn
-# This needs to be defined in your config's `external_github_repo` field to be
-# downloaded and placed on the PYTHONPATH
-from pygoturn.src.model import GoNet  # clone from https://github.com/amoudgl/pygoturn
+logger = logging.getLogger(__name__)
+
+from art.estimators.object_tracking import PyTorchGoturn
+import numpy as np
+import torch
+
+from armory.errors import ExternalRepoImport
 
 # load amoudgl model and instantiate ART PyTorchGoTurn model
+with ExternalRepoImport(
+    repo="amoudgl/pygoturn",
+    experiment="carla_video_tracking_goturn_advtextures_defended.json",
+):
+    from pygoturn.src.model import GoNet
+
+
 DEVICE = torch.device("cuda" if torch.cuda.is_available() else "cpu")
 
 

--- a/armory/baseline_models/pytorch/carla_goturn.py
+++ b/armory/baseline_models/pytorch/carla_goturn.py
@@ -1,8 +1,6 @@
 import logging
 from typing import Optional
 
-logger = logging.getLogger(__name__)
-
 from art.estimators.object_tracking import PyTorchGoturn
 import numpy as np
 import torch
@@ -15,6 +13,8 @@ with ExternalRepoImport(
     experiment="carla_video_tracking_goturn_advtextures_defended.json",
 ):
     from pygoturn.src.model import GoNet
+
+logger = logging.getLogger(__name__)
 
 
 DEVICE = torch.device("cuda" if torch.cuda.is_available() else "cpu")

--- a/armory/baseline_models/pytorch/carla_goturn.py
+++ b/armory/baseline_models/pytorch/carla_goturn.py
@@ -1,4 +1,3 @@
-import logging
 from typing import Optional
 
 from art.estimators.object_tracking import PyTorchGoturn
@@ -13,9 +12,6 @@ with ExternalRepoImport(
     experiment="carla_video_tracking_goturn_advtextures_defended.json",
 ):
     from pygoturn.src.model import GoNet
-
-logger = logging.getLogger(__name__)
-
 
 DEVICE = torch.device("cuda" if torch.cuda.is_available() else "cpu")
 

--- a/armory/baseline_models/pytorch/deep_speech.py
+++ b/armory/baseline_models/pytorch/deep_speech.py
@@ -8,17 +8,19 @@ import os
 from typing import Optional
 
 from art import config
+from art.estimators.speech_recognition import PyTorchDeepSpeech
 
 from armory import paths
 from armory.errors import ExternalRepoImport
 
-config.set_data_path(os.path.join(paths.runtime_paths().saved_model_dir, "art"))
-
+# Test for external repo at import time to fail fast
 with ExternalRepoImport(
     repo="SeanNaren/deepspeech.pytorch@V3.0",
     experiment="librispeech_asr_snr_undefended.json",
 ):
-    from art.estimators.speech_recognition import PyTorchDeepSpeech
+    from deepspeech_pytorch.model import DeepSpeech  # noqa: F401
+
+config.set_data_path(os.path.join(paths.runtime_paths().saved_model_dir, "art"))
 
 
 def get_art_model(

--- a/armory/baseline_models/pytorch/deep_speech.py
+++ b/armory/baseline_models/pytorch/deep_speech.py
@@ -7,11 +7,18 @@ Model contributed by: MITRE Corporation
 import os
 from typing import Optional
 
-from armory import paths
 from art import config
 
+from armory import paths
+from armory.errors import ExternalRepoImport
+
 config.set_data_path(os.path.join(paths.runtime_paths().saved_model_dir, "art"))
-from art.estimators.speech_recognition import PyTorchDeepSpeech
+
+with ExternalRepoImport(
+    repo="SeanNaren/deepspeech.pytorch@V3.0",
+    experiment="librispeech_asr_snr_undefended.json",
+):
+    from art.estimators.speech_recognition import PyTorchDeepSpeech
 
 
 def get_art_model(

--- a/armory/baseline_models/pytorch/sincnet.py
+++ b/armory/baseline_models/pytorch/sincnet.py
@@ -12,11 +12,12 @@ import numpy as np
 import torch
 from torch import nn
 
+from armory.errors import ExternalRepoImport
 
-# Load model from MITRE external repo: https://github.com/hkakitani/SincNet
-# This needs to be defined in your config's `external_github_repo` field to be
-# downloaded and placed on the PYTHONPATH
-from SincNet import dnn_models
+with ExternalRepoImport(
+    repo="hkakitani/SincNet", experiment="librispeech_baseline_sincnet.json",
+):
+    from SincNet import dnn_models
 
 logger = logging.getLogger(__name__)
 

--- a/armory/baseline_models/pytorch/ucf101_mars.py
+++ b/armory/baseline_models/pytorch/ucf101_mars.py
@@ -11,9 +11,14 @@ from PIL import Image
 import torch
 from torch import optim
 
-from MARS.opts import parse_opts
-from MARS.models.model import generate_model
-from MARS.dataset import preprocess_data
+from armory.errors import ExternalRepoImport
+
+with ExternalRepoImport(
+    repo="yusong-tan/MARS", experiment="ucf101_baseline_finetune.json",
+):
+    from MARS.opts import parse_opts
+    from MARS.models.model import generate_model
+    from MARS.dataset import preprocess_data
 
 logger = logging.getLogger(__name__)
 

--- a/armory/errors.py
+++ b/armory/errors.py
@@ -5,10 +5,10 @@ logger = logging.getLogger(__name__)
 
 
 class ExternalRepoImport(contextlib.AbstractContextManager):
-    def __enter__(self, repo="", experiment=""):
+    def __init__(self, repo="", experiment=""):
+        super().__init__()
         url = f"https://github.com/{repo}"
         name = repo.split("/")[-1].split("@")[0]
-
         self.error_message = "\n".join(
             [
                 f"{name} is an external repo.",
@@ -18,11 +18,8 @@ class ExternalRepoImport(contextlib.AbstractContextManager):
             ]
         )
 
-        return self
-
     def __exit__(self, exc_type, exc_val, exc_tb):
-        if isinstance(exc_type, ImportError):
-            logger.exception()
+        if exc_type is not None and issubclass(exc_type, ImportError):
             logger.error(self.error_message)
             return False
         return True

--- a/armory/errors.py
+++ b/armory/errors.py
@@ -1,0 +1,28 @@
+import contextlib
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+class ExternalRepoImport(contextlib.AbstractContextManager):
+    def __enter__(self, repo="", experiment=""):
+        url = f"https://github.com/{repo}"
+        name = repo.split("/")[-1].split("@")[0]
+
+        self.error_message = "\n".join(
+            [
+                f"{name} is an external repo.",
+                f"Please download from {url} and place on local environment PYTHONPATH",
+                "    OR place in experimental config `external_github_repo` field.",
+                f"    See scenario_configs/{experiment} for an example.",
+            ]
+        )
+
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        if isinstance(exc_type, ImportError):
+            logger.exception()
+            logger.error(self.error_message)
+            return False
+        return True


### PR DESCRIPTION
Fixes #1302

When the repo is not available, you should get a nice logging error message. To replicate, you can launch a pytorch container and run interactively: 
```
I have no name!@54d56b3aa2eb:/workspace$ python
Python 3.8.10 (default, Jun  4 2021, 15:09:15) 
[GCC 7.5.0] :: Anaconda, Inc. on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import logging
>>> import coloredlogs
>>> coloredlogs.install(logging.DEBUG)
>>> from armory.baseline_models.pytorch import ucf101_mars
2022-03-07 21:25:58 54d56b3aa2eb armory.errors[25] ERROR MARS is an external repo.
Please download from https://github.com/yusong-tan/MARS and place on local environment PYTHONPATH
    OR place in experimental config `external_github_repo` field.
    See scenario_configs/ucf101_baseline_finetune.json for an example.
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/workspace/armory/baseline_models/pytorch/ucf101_mars.py", line 19, in <module>
    from MARS.opts import parse_opts
ModuleNotFoundError: No module named 'MARS'
```

When it is available (e.g., when using the basic configs), it shouldn't make any noise.