### PR TITLE
move ucf101 clipping to data

### DIFF
--- a/armory/baseline_models/pytorch/ucf101_mars.py
+++ b/armory/baseline_models/pytorch/ucf101_mars.py
@@ -277,7 +277,8 @@ class OuterModel(torch.nn.Module):
         max_frames = int(max_frames)
         if max_frames:
             logger.warning(
-                "Deprecation warning: max_frames should be used as kwarg in ucf101 dataset, not in MARS model"
+                "Deprecation warning: max_frames should be used as kwarg in ucf101 dataset, not in MARS model. "
+                "This will be removed in version 0.16.0"
             )
         if max_frames < 0:
             raise ValueError(f"max_frames {max_frames} cannot be negative")

--- a/armory/baseline_models/pytorch/ucf101_mars.py
+++ b/armory/baseline_models/pytorch/ucf101_mars.py
@@ -275,6 +275,10 @@ class OuterModel(torch.nn.Module):
         """
         super().__init__()
         max_frames = int(max_frames)
+        if max_frames:
+            logger.warning(
+                "Deprecation warning: max_frames should be used as kwarg in ucf101 dataset, not in MARS model"
+            )
         if max_frames < 0:
             raise ValueError(f"max_frames {max_frames} cannot be negative")
         self.max_frames = max_frames

--- a/armory/data/datasets.py
+++ b/armory/data/datasets.py
@@ -1355,6 +1355,28 @@ def resisc10(
     )
 
 
+class ClipFrames:
+    """
+    Clip Video Frames
+        Assumes first two dims are (batch, frames, ...)
+    """
+
+    def __init__(self, max_frames):
+        max_frames = int(max_frames)
+        if max_frames <= 0:
+            raise ValueError(f"max_frames {max_frames} must be > 0")
+        self.max_frames = max_frames
+
+    def __call__(self, batch):
+        if batch.dtype == np.object:
+            clipped_batch = np.empty_like(batch, dtype=np.object)
+            clipped_batch[:] = [x[: self.max_frames] for x in batch]
+            print(clipped_batch.shape, clipped_batch.dtype, batch.shape, batch.dtype)
+            return clipped_batch
+        else:
+            return batch[:, : self.max_frames]
+
+
 def ucf101(
     split: str = "train",
     epochs: int = 1,
@@ -1365,13 +1387,21 @@ def ucf101(
     cache_dataset: bool = True,
     framework: str = "numpy",
     shuffle_files: bool = True,
+    max_frames: int = None,
     **kwargs,
 ) -> ArmoryDataGenerator:
     """
     UCF 101 Action Recognition Dataset
         https://www.crcv.ucf.edu/data/UCF101.php
+
+    max_frames, if it exists, will clip the inputs to a set number of frames
     """
-    preprocessing_fn = preprocessing_chain(preprocessing_fn, fit_preprocessing_fn)
+    if max_frames:
+        clip = ClipFrames(max_frames)
+    else:
+        clip = None
+
+    preprocessing_fn = preprocessing_chain(clip, preprocessing_fn, fit_preprocessing_fn)
 
     return _generator_from_tfds(
         "ucf101/ucf101_1:2.0.0",

--- a/armory/data/datasets.py
+++ b/armory/data/datasets.py
@@ -1371,7 +1371,6 @@ class ClipFrames:
         if batch.dtype == np.object:
             clipped_batch = np.empty_like(batch, dtype=np.object)
             clipped_batch[:] = [x[: self.max_frames] for x in batch]
-            print(clipped_batch.shape, clipped_batch.dtype, batch.shape, batch.dtype)
             return clipped_batch
         else:
             return batch[:, : self.max_frames]

--- a/scenario_configs/ucf101_baseline_finetune.json
+++ b/scenario_configs/ucf101_baseline_finetune.json
@@ -18,6 +18,7 @@
     "dataset": {
         "batch_size": 1,
         "framework": "numpy",
+        "max_frames": 512,
         "module": "armory.data.datasets",
         "name": "ucf101"
     },
@@ -38,7 +39,6 @@
             "nb_epochs": 10
         },
         "model_kwargs": {
-            "max_frames": 512,
             "model_status": "kinetics_pretrained"
         },
         "module": "armory.baseline_models.pytorch.ucf101_mars",

--- a/scenario_configs/ucf101_baseline_pretrained_targeted.json
+++ b/scenario_configs/ucf101_baseline_pretrained_targeted.json
@@ -25,6 +25,7 @@
     "dataset": {
         "batch_size": 1,
         "framework": "numpy",
+        "max_frames": 512,
         "module": "armory.data.datasets",
         "name": "ucf101"
     },
@@ -44,7 +45,6 @@
             "nb_epochs": 10
         },
         "model_kwargs": {
-            "max_frames": 512,
             "model_status": "ucf101_trained"
         },
         "module": "armory.baseline_models.pytorch.ucf101_mars",

--- a/scenario_configs/ucf101_pretrained_flicker_defended.json
+++ b/scenario_configs/ucf101_pretrained_flicker_defended.json
@@ -20,6 +20,7 @@
     "dataset": {
         "batch_size": 1,
         "framework": "numpy",
+        "max_frames": 512,
         "module": "armory.data.datasets",
         "name": "ucf101"
     },
@@ -53,7 +54,6 @@
             "nb_epochs": 10
         },
         "model_kwargs": {
-            "max_frames": 512,
             "model_status": "ucf101_trained"
         },
         "module": "armory.baseline_models.pytorch.ucf101_mars",

--- a/scenario_configs/ucf101_pretrained_flicker_undefended.json
+++ b/scenario_configs/ucf101_pretrained_flicker_undefended.json
@@ -20,6 +20,7 @@
     "dataset": {
         "batch_size": 1,
         "framework": "numpy",
+        "max_frames": 512,
         "module": "armory.data.datasets",
         "name": "ucf101"
     },
@@ -41,7 +42,6 @@
             "nb_epochs": 10
         },
         "model_kwargs": {
-            "max_frames": 512,
             "model_status": "ucf101_trained"
         },
         "module": "armory.baseline_models.pytorch.ucf101_mars",

--- a/scenario_configs/ucf101_pretrained_frame_saliency_defended.json
+++ b/scenario_configs/ucf101_pretrained_frame_saliency_defended.json
@@ -28,6 +28,7 @@
     "dataset": {
         "batch_size": 1,
         "framework": "numpy",
+        "max_frames": 512,
         "module": "armory.data.datasets",
         "name": "ucf101"
     },
@@ -62,7 +63,6 @@
             "nb_epochs": 10
         },
         "model_kwargs": {
-            "max_frames": 512,
             "model_status": "ucf101_trained"
         },
         "module": "armory.baseline_models.pytorch.ucf101_mars",

--- a/scenario_configs/ucf101_pretrained_frame_saliency_undefended.json
+++ b/scenario_configs/ucf101_pretrained_frame_saliency_undefended.json
@@ -28,6 +28,7 @@
     "dataset": {
         "batch_size": 1,
         "framework": "numpy",
+        "max_frames": 512,
         "module": "armory.data.datasets",
         "name": "ucf101"
     },
@@ -50,7 +51,6 @@
             "nb_epochs": 10
         },
         "model_kwargs": {
-            "max_frames": 512,
             "model_status": "ucf101_trained"
         },
         "module": "armory.baseline_models.pytorch.ucf101_mars",

--- a/scenario_configs/ucf101_pretrained_masked_pgd_defended.json
+++ b/scenario_configs/ucf101_pretrained_masked_pgd_defended.json
@@ -26,6 +26,7 @@
     "dataset": {
         "batch_size": 1,
         "framework": "numpy",
+        "max_frames": 512,
         "module": "armory.data.datasets",
         "name": "ucf101"
     },
@@ -59,7 +60,6 @@
             "nb_epochs": 10
         },
         "model_kwargs": {
-            "max_frames": 512,
             "model_status": "ucf101_trained"
         },
         "module": "armory.baseline_models.pytorch.ucf101_mars",

--- a/scenario_configs/ucf101_pretrained_masked_pgd_undefended.json
+++ b/scenario_configs/ucf101_pretrained_masked_pgd_undefended.json
@@ -26,6 +26,7 @@
     "dataset": {
         "batch_size": 1,
         "framework": "numpy",
+        "max_frames": 512,
         "module": "armory.data.datasets",
         "name": "ucf101"
     },
@@ -47,7 +48,6 @@
             "nb_epochs": 10
         },
         "model_kwargs": {
-            "max_frames": 512,
             "model_status": "ucf101_trained"
         },
         "module": "armory.baseline_models.pytorch.ucf101_mars",


### PR DESCRIPTION
Fixes #1150 

This change is computationally helpful, as it moves clipping to the beginning of the preprocessing pipeline instead of the model's forward pass (and implicitly, the gradient computation).

Can test the functionality directly with
```
import numpy as np
from armory.data import datasets
max_frames = 5
x,y = next(datasets.ucf101(batch_size=1, max_frames=max_frames))
assert x.shape[1] == max_frames

x,y = next(datasets.ucf101(batch_size=2, max_frames=max_frames))
assert x.dtype == np.object
assert all([x_i.shape[0] == max_frames for x_i in x])
```

Otherwise, the scenarios should work as before.