### PR TITLE
build.sh has been obsoleted

### DIFF
--- a/.github/workflows/end2end_cron.yml
+++ b/.github/workflows/end2end_cron.yml
@@ -31,8 +31,9 @@ jobs:
           pip install -e .
           imageTag=$(python setup.py --version | sed  -e 's/dev[0-9][0-9]*+//' -e 's/\.d[0-9][0-9]*$//')
           echo "Image Tag -> $imageTag"
-          echo "::set-output name=imageTag::$imageTag"
-          bash docker/build.sh base pytorch pytorch-deepspeech tf2 --tag $imageTag --base-tag $imageTag
+          python docker/build.py pytorch
+          python docker/build.py pytorch-deepspeech
+          python docker/build.py tf2
     outputs:
       imageTag: ${{ steps.docker-build.outputs.imageTag }}
   docker-pytorch-end2end:


### PR DESCRIPTION
Convert build.sh to build.py in end2end CI tests.