### PR TITLE
WIP: Mscoco tf2

### DIFF
--- a/armory/baseline_models/tf_graph/mscoco_frcnn.py
+++ b/armory/baseline_models/tf_graph/mscoco_frcnn.py
@@ -6,9 +6,9 @@ object_detection/g3doc/tf1_detection_zoo.md)
 """
 
 from art.estimators.object_detection.tensorflow_faster_rcnn import TensorFlowFasterRCNN
-import tensorflow as tf
+import tensorflow.compat.v1 as tf
 
-tf.compat.v1.disable_eager_execution()
+tf.disable_eager_execution()
 
 
 def get_art_model(model_kwargs, wrapper_kwargs, weights_file=None):


### PR DESCRIPTION
Fixes #1330 

This update should fix it from our side.

However, I now run into the following error in the ART import:
```
File "/workspace/armory/baseline_models/tf_graph/mscoco_frcnn.py", line 20, in get_art_model
model = TensorFlowFasterRCNN(
        └ <class 'art.estimators.object_detection.tensorflow_faster_rcnn.TensorFlowFasterRCNN'>
File "/opt/conda/lib/python3.8/site-packages/art/estimators/object_detection/tensorflow_faster_rcnn.py", line 161, in __init__
self._model, self._predictions, self._losses, self._detections = self._load_model(
│    │       │                  │             │                  │    └ <staticmethod object at 0x7fd5a6a40e80>
│    │       │                  │             │                  └ TensorFlowFasterRCNN(sess=None, channels_first=False, model=None, clip_values=[0. 1.], preprocessing=StandardisationMeanStd(m...
│    │       │                  │             └ TensorFlowFasterRCNN(sess=None, channels_first=False, model=None, clip_values=[0. 1.], preprocessing=StandardisationMeanStd(m...
│    │       │                  └ TensorFlowFasterRCNN(sess=None, channels_first=False, model=None, clip_values=[0. 1.], preprocessing=StandardisationMeanStd(m...
│    │       └ TensorFlowFasterRCNN(sess=None, channels_first=False, model=None, clip_values=[0. 1.], preprocessing=StandardisationMeanStd(m...
│    └ None
└ TensorFlowFasterRCNN(sess=None, channels_first=False, model=None, clip_values=[0. 1.], preprocessing=StandardisationMeanStd(m...
File "/opt/conda/lib/python3.8/site-packages/art/estimators/object_detection/tensorflow_faster_rcnn.py", line 263, in _load_model
from object_detection.builders import model_builder
File "/opt/conda/lib/python3.8/site-packages/object_detection/builders/model_builder.py", line 55, in <module>
from object_detection.models import center_net_resnet_v1_fpn_feature_extractor
File "/opt/conda/lib/python3.8/site-packages/object_detection/models/center_net_resnet_v1_fpn_feature_extractor.py", line 24, in <module>
from object_detection.models.keras_models import resnet_v1
File "/opt/conda/lib/python3.8/site-packages/object_detection/models/keras_models/resnet_v1.py", line 24, in <module>
from tensorflow.python.keras.applications import resnet
ModuleNotFoundError: No module named 'tensorflow.python.keras.applications'
```

The error is in the object_detection codebase, so not something we can easily fix. Maybe this requires moving to resnet_v2 ? 