### PR TITLE
Move apricot metadata to proper file

### DIFF
--- a/armory/data/adversarial/apricot_metadata.py
+++ b/armory/data/adversarial/apricot_metadata.py
@@ -1,3 +1,9 @@
+# The APRICOT dataset uses class ID 12 to correspond to adversarial patches. Since this
+# number may correspond to real classes in other datasets, we convert this label 12 in the
+# APRICOT dataset to the ADV_PATCH_MAGIC_NUMBER_LABEL_ID. We choose a negative integer
+# since it is unlikely that such a number represents the ID of a class in another dataset
+ADV_PATCH_MAGIC_NUMBER_LABEL_ID = -10
+
 APRICOT_MODELS = [
     {
         "classifier": "resnet50",

--- a/armory/data/adversarial_datasets.py
+++ b/armory/data/adversarial_datasets.py
@@ -23,13 +23,7 @@ from armory.data.adversarial import (  # noqa: F401
     carla_video_tracking_dev as cvtd,
     carla_video_tracking_test as cvtt,
 )
-
-
-# The APRICOT dataset uses class ID 12 to correspond to adversarial patches. Since this
-# number may correspond to real classes in other datasets, we convert this label 12 in the
-# APRICOT dataset to the ADV_PATCH_MAGIC_NUMBER_LABEL_ID. We choose a negative integer
-# since it is unlikely that such a number represents the ID of a class in another dataset
-ADV_PATCH_MAGIC_NUMBER_LABEL_ID = -10
+from armory.data.adversarial.apricot_metadata import ADV_PATCH_MAGIC_NUMBER_LABEL_ID
 
 
 imagenet_adversarial_context = datasets.ImageContext(x_shape=(224, 224, 3))

--- a/armory/utils/metrics.py
+++ b/armory/utils/metrics.py
@@ -17,8 +17,10 @@ import cProfile
 import pstats
 from scipy import stats
 
-from armory.data.adversarial_datasets import ADV_PATCH_MAGIC_NUMBER_LABEL_ID
-from armory.data.adversarial.apricot_metadata import APRICOT_PATCHES
+from armory.data.adversarial.apricot_metadata import (
+    ADV_PATCH_MAGIC_NUMBER_LABEL_ID,
+    APRICOT_PATCHES,
+)
 from armory.logs import log
 
 


### PR DESCRIPTION
Currently, if you import `armory.utils.metrics`, it will end up importing `armory.data.adversarial_datasets` and `armory.data.datasets` in order to get a single constant, which actually takes some time and seems like an odd pattern.

Since we already have a metadata file for the other apricot constants, I am moving this constant to that file. Now `armory.utils.metrics` will only import that single metadata file, which is quite small.