### PR TITLE
For Issue #1375 - Eval5 carla obj det robust dpatch

### DIFF
--- a/armory/art_experimental/attacks/carla_obj_det_patch.py
+++ b/armory/art_experimental/attacks/carla_obj_det_patch.py
@@ -4,6 +4,9 @@ from armory.logs import log
 from art.attacks.evasion import RobustDPatch
 import cv2
 import numpy as np
+from typing import Optional, List, Dict
+from tqdm.auto import trange
+import math
 
 from armory.utils.external_repo import ExternalRepoImport
 
@@ -119,7 +122,7 @@ def apply_ccm(patch, ccm, gamma=2.2, Vandermonde=True, degree=1):
     return corrected_RGB
 
 
-def insert_transformed_patch(patch, image, gs_shape, patch_coords=[], image_coords=[]):
+def insert_transformed_patch(patch, image, gs_shape, rgb, patch_coords=[], image_coords=[]):
     """
     Insert patch to image based on given or selected coordinates
 
@@ -130,6 +133,8 @@ def insert_transformed_patch(patch, image, gs_shape, patch_coords=[], image_coor
             image as numpy array
         gs_shape
             green screen shape
+        rgb
+            true if gs_im is RGB, false otherwise
         patch_coords
             patch coordinates to map to image [numpy array]
         image_coords
@@ -166,34 +171,37 @@ def insert_transformed_patch(patch, image, gs_shape, patch_coords=[], image_coor
     im_out_cp = np.copy(im_out)
     before = im_cp_one.astype("float32") + im_out_cp.astype("float32")
 
-    v_avg = 0.5647  # V value (in HSV) for the green screen, which is #00903a
+    if rgb:
+        v_avg = 0.5647  # V value (in HSV) for the green screen, which is #00903a
 
-    # mask image for patch insert
-    image_cp = np.copy(image)
-    image_cp[mask_out == 0] = 0
+        # mask image for patch insert
+        image_cp = np.copy(image)
+        image_cp[mask_out == 0] = 0
 
-    # convert to HSV space for shadow estimation
-    target_hsv = cv2.cvtColor(image_cp, cv2.COLOR_BGR2HSV)
-    target_hsv = target_hsv.astype("float32")
-    target_hsv /= 255.0
+        # convert to HSV space for shadow estimation
+        target_hsv = cv2.cvtColor(image_cp, cv2.COLOR_BGR2HSV)
+        target_hsv = target_hsv.astype("float32")
+        target_hsv /= 255.0
 
-    # apply shadows to patch
-    ratios = target_hsv[:, :, 2] / v_avg
-    im_out = im_out.astype("float32")
-    im_out[:, :, 0] = im_out[:, :, 0] * ratios
-    im_out[:, :, 1] = im_out[:, :, 1] * ratios
-    im_out[:, :, 2] = im_out[:, :, 2] * ratios
-    im_out[im_out > 255.0] = 255.0
+        # apply shadows to patch
+        ratios = target_hsv[:, :, 2] / v_avg
+        im_out = im_out.astype("float32")
+        im_out[:, :, 0] = im_out[:, :, 0] * ratios
+        im_out[:, :, 1] = im_out[:, :, 1] * ratios
+        im_out[:, :, 2] = im_out[:, :, 2] * ratios
+        im_out[im_out > 255.0] = 255.0
 
-    im_cp_two = np.copy(image)
-    im_cp_two[mask_out != 0] = 0
-    final = im_cp_two.astype("float32") + im_out.astype("float32")
+        im_cp_two = np.copy(image)
+        im_cp_two[mask_out != 0] = 0
+        final = im_cp_two.astype("float32") + im_out.astype("float32")
+    else:
+        final = None
 
     return before, final
 
 
 def insert_patch(
-    gs_coords, gs_im, patch, gs_shape, cc_gt, cc_scene, apply_realistic_effects
+    gs_coords, gs_im, patch, gs_shape, cc_gt, cc_scene, apply_realistic_effects, rgb
 ):
     """
     :param gs_coords: green screen coordinates in [(x0,y0),(x1,y1),...] format. Type ndarray.
@@ -203,26 +211,20 @@ def insert_patch(
     :param cc_gt: colorchecker ground truth values. Type ndarray.
     :param cc_scene: colorchecker values in the scene. Type ndarray.
     :param apply_realistic_effects: apply effects such as color correction, blurring, and shadowing. Type bool.
+    :param rgb: true if gs_im is RGB, false otherwise
     """
 
     if apply_realistic_effects:
         # calculate color matrix
         ccm = calculate_ccm(cc_scene, cc_gt, Vandermonde=True)
 
-        # get edge coords
-        edge_coords = [
-            (gs_coords[0, 0] + 10, gs_coords[0, 1] - 20),
-            (gs_coords[0, 0] + 10, gs_coords[0, 1] + 20),
-        ]
-        edge_coords = np.array(edge_coords)
-
         # apply color matrix to patch
         patch = apply_ccm(patch.astype("float32"), ccm)
 
-        # resize patch and apply blurring
+        # resize patch
         scale = (np.amax(gs_coords[:, 1]) - np.amin(gs_coords[:, 1])) / patch.shape[0]
         patch = cv2.resize(
-            patch, (int(patch.shape[1] * scale), int(patch.shape[0] * scale))
+            patch, (int(patch.shape[1] * scale), int(patch.shape[0] * scale)), interpolation=cv2.INTER_CUBIC
         )
 
         # datatype correction
@@ -230,7 +232,8 @@ def insert_patch(
     patch = patch.astype("uint8")
 
     # convert for use with cv2
-    patch = cv2.cvtColor(patch, cv2.COLOR_RGB2BGR)
+    if rgb:
+        patch = cv2.cvtColor(patch, cv2.COLOR_RGB2BGR)
 
     enlarged_coords = np.copy(gs_coords)
     pad_amt_x = int(0.03 * (enlarged_coords[2, 0] - enlarged_coords[0, 0]))
@@ -246,7 +249,7 @@ def insert_patch(
 
     # insert transformed patch
     image_digital, image_physical = insert_transformed_patch(
-        patch, gs_im, gs_shape, image_coords=enlarged_coords
+        patch, gs_im, gs_shape, image_coords=enlarged_coords, rgb=rgb
     )
 
     if apply_realistic_effects:
@@ -257,9 +260,140 @@ def insert_patch(
 
 class CARLADapricotPatch(RobustDPatch):
     def __init__(self, estimator, **kwargs):
-        # attack only RGB channels, assuming they have indices (0,1,2)
-        self.attacked_channels = (0, 1, 2)
+        # Maximum depth perturbation from a flat patch
+        self.depth_delta_meters = kwargs.pop("depth_delta_meters", 3)
+        self.learning_rate_depth = kwargs.pop("learning_rate_depth", 0.0001)
+        self.max_depth = None
+        self.min_depth = None
+
         super().__init__(estimator=estimator, **kwargs)
+
+    def inner_generate(  # type: ignore
+        self, x: np.ndarray, y: Optional[List[Dict[str, np.ndarray]]] = None, **kwargs
+    ) -> np.ndarray:
+        """
+        Generate RobustDPatch.
+        :param x: Sample images.
+        :param y: Target labels for object detector.
+        :return: Adversarial patch.
+        """
+        channel_index = 1 if self.estimator.channels_first else x.ndim - 1
+        if x.shape[channel_index] != self.patch_shape[channel_index - 1]:
+            raise ValueError("The color channel index of the images and the patch have to be identical.")
+        if y is None and self.targeted:
+            raise ValueError("The targeted version of RobustDPatch attack requires target labels provided to `y`.")
+        if y is not None and not self.targeted:
+            raise ValueError("The RobustDPatch attack does not use target labels.")
+        if x.ndim != 4:  # pragma: no cover
+            raise ValueError("The adversarial patch can only be applied to images.")
+
+        # Check whether patch fits into the cropped images:
+        if self.estimator.channels_first:
+            image_height, image_width = x.shape[2:4]
+        else:
+            image_height, image_width = x.shape[1:3]
+
+        if not self.estimator.native_label_is_pytorch_format and y is not None:
+            from art.estimators.object_detection.utils import convert_tf_to_pt
+
+            y = convert_tf_to_pt(y=y, height=x.shape[1], width=x.shape[2])
+
+        if y is not None:
+            for i_image in range(x.shape[0]):
+                y_i = y[i_image]["boxes"]
+                for i_box in range(y_i.shape[0]):
+                    x_1, y_1, x_2, y_2 = y_i[i_box]
+                    if (  # pragma: no cover
+                        x_1 < self.crop_range[1]
+                        or y_1 < self.crop_range[0]
+                        or x_2 > image_width - self.crop_range[1] + 1
+                        or y_2 > image_height - self.crop_range[0] + 1
+                    ):
+                        raise ValueError("Cropping is intersecting with at least one box, reduce `crop_range`.")
+
+        if (  # pragma: no cover
+            self.patch_location[0] + self.patch_shape[0] > image_height - self.crop_range[0]
+            or self.patch_location[1] + self.patch_shape[1] > image_width - self.crop_range[1]
+        ):
+            raise ValueError("The patch (partially) lies outside the cropped image.")
+
+        for i_step in trange(self.max_iter, desc="RobustDPatch iteration", disable=not self.verbose):
+            num_batches = math.ceil(x.shape[0] / self.batch_size)
+            patch_gradients_old = np.zeros_like(self._patch)
+
+            for e_step in range(self.sample_size):
+
+                for i_batch in range(num_batches):
+                    i_batch_start = i_batch * self.batch_size
+                    i_batch_end = min((i_batch + 1) * self.batch_size, x.shape[0])
+
+                    if y is None:
+                        y_batch = y
+                    else:
+                        y_batch = y[i_batch_start:i_batch_end]
+
+                    # Sample and apply the random transformations:
+                    patched_images, patch_target, transforms = self._augment_images_with_patch(
+                        x[i_batch_start:i_batch_end], y_batch, self._patch, channels_first=self.estimator.channels_first
+                    )
+
+                    gradients = self.estimator.loss_gradient(
+                        x=patched_images,
+                        y=patch_target,
+                        standardise_output=True,
+                    )
+
+                    gradients = self._untransform_gradients(
+                        gradients, transforms, channels_first=self.estimator.channels_first
+                    )
+
+                    patch_gradients = patch_gradients_old + np.sum(gradients, axis=0)
+
+                    patch_gradients_old = patch_gradients
+
+            # Write summary
+            if self.summary_writer is not None:  # pragma: no cover
+                x_patched, y_patched, _ = self._augment_images_with_patch(
+                    x, y, self._patch, channels_first=self.estimator.channels_first
+                )
+
+                self.summary_writer.update(
+                    batch_id=0,
+                    global_step=i_step,
+                    grad=np.expand_dims(patch_gradients, axis=0),
+                    patch=self._patch,
+                    estimator=self.estimator,
+                    x=x_patched,
+                    y=y_patched,
+                    targeted=self.targeted,
+                )
+
+            if patch_gradients.shape[2] == 6:
+                patch_gradients[:, :, 3:] = np.mean(patch_gradients[:, :, 3:], axis=2, keepdims=True)
+
+            self._patch[:, :, :3] = self._patch[:, :, :3] + np.sign(patch_gradients[:, :, :3]) * (1 - 2 * int(self.targeted)) * self.learning_rate                
+            
+            if patch_gradients.shape[2] == 6: # depth uses a different learning rate than rgb
+                self._patch[:, :, 3:] = self._patch[:, :, 3:] + np.sign(patch_gradients[:, :, 3:]) * (1 - 2 * int(self.targeted)) * self.learning_rate_depth
+
+            if self.estimator.clip_values is not None:
+                self._patch = np.clip(
+                    self._patch,
+                    a_min=self.estimator.clip_values[0],
+                    a_max=self.estimator.clip_values[1],
+                )
+
+            if self._patch.shape[-1] == 6:
+                self._patch[:,:,3:] = np.clip(
+                    self._patch[:,:,3:],
+                    a_min=self.min_depth,
+                    a_max=self.max_depth,
+                )
+
+        if self.summary_writer is not None:
+            self.summary_writer.reset()
+
+        return self._patch
 
     def _augment_images_with_patch(self, x, y, patch, channels_first):
         """
@@ -300,11 +434,12 @@ class CARLADapricotPatch(RobustDPatch):
             rgb_img_with_patch = insert_patch(
                 gs_coords,
                 rgb_img[:, :, ::-1],  # input image needs to be BGR
-                patch_copy[:, :, self.attacked_channels] * 255.0,
+                patch_copy[:, :, :3] * 255.0,
                 self.patch_geometric_shape,
                 cc_gt=self.cc_gt,
                 cc_scene=self.cc_scene,
                 apply_realistic_effects=True,
+                rgb=True,
             )
 
             # embed patch into background
@@ -315,8 +450,26 @@ class CARLADapricotPatch(RobustDPatch):
             if xi.shape[-1] == 3:
                 img_with_patch = rgb_img_with_patch.copy()
             else:
+                # apply patch using DAPRICOT transform to Depth channels only
+                # insert_patch() uses BGR color ordering for input and output
+                depth_img_with_patch = insert_patch(
+                    gs_coords,
+                    depth_img[:, :, ::-1],  # input image needs to be BGR
+                    patch_copy[:, :, 3:] * 255.0,
+                    self.patch_geometric_shape,
+                    cc_gt=self.cc_gt,
+                    cc_scene=self.cc_scene,
+                    apply_realistic_effects=False,
+                    rgb=False,
+                )
+
+                # embed patch into background
+                depth_img_with_patch[
+                    np.all(self.binarized_patch_mask == 0, axis=-1)
+                ] = depth_img[np.all(self.binarized_patch_mask == 0, axis=-1)][:, ::-1]
+
                 img_with_patch = np.concatenate(
-                    (depth_img[:, :, ::-1], rgb_img_with_patch), axis=-1
+                    (depth_img_with_patch, rgb_img_with_patch), axis=-1
                 )
 
             x_patch.append(img_with_patch[:, :, ::-1] / 255.0)  # convert back to RGB
@@ -384,11 +537,11 @@ class CARLADapricotPatch(RobustDPatch):
             gradients_tmp.append(grads_tmp)
         gradients = np.asarray(gradients_tmp)
 
-        # get channels not attacked and then set the gradients of those channels to zero
-        non_attacked_channels = list(
-            set(range(gradients.shape[-1])) - set(self.attacked_channels)
-        )
-        gradients[..., non_attacked_channels] = 0.0
+        # # get channels not attacked and then set the gradients of those channels to zero
+        # non_attacked_channels = list(
+        #     set(range(gradients.shape[-1])) - set(self.attacked_channels)
+        # )
+        # gradients[..., non_attacked_channels] = 0.0
 
         return gradients
 
@@ -399,6 +552,65 @@ class CARLADapricotPatch(RobustDPatch):
             ith dictionary contains bounding boxes, class labels, and class scores
         param y_patch_metadata: Patch metadata. List of N dictionaries, ith dictionary contains patch metadata for x[i]
         """
+        def in_polygon(x, y, vertices):
+            """
+            Determine if a point (x,y) is inside a polygon with given vertices
+            Ref: https://www.eecs.umich.edu/courses/eecs380/HANDOUTS/PROJ2/InsidePoly.html
+            """
+            n_pts = len(vertices)
+            i = 0
+            j = n_pts - 1
+            c = False
+
+            while i < n_pts:
+                if (
+                    # y coordinate of the point has to be between the y coordinates of the i-th and j-th vertices
+                    ((vertices[i][1] <= y) and (y < vertices[j][1]))
+                    or ((vertices[j][1] <= y) and (y < vertices[i][1]))
+                ) and (
+                    # x coordinate of the point is to the left of the line connecting i-th and j-th vertices
+                    x
+                    < (vertices[j][0] - vertices[i][0])
+                    * (y - vertices[i][1])
+                    / (vertices[j][1] - vertices[i][1])
+                    + vertices[i][0]
+                ):
+                    c = not c
+                j = i
+                i = i + 1
+            return c
+
+        def get_avg_depth_value(depth_img, patch_coords):
+            # Return the average depth value of a patch with coordinates given by patch_coords
+            avg_depth = 0.0
+            count = 0
+            for i in range(depth_img.shape[1]):
+                for j in range(depth_img.shape[0]):
+                    if in_polygon(i, j, patch_coords):
+                        avg_depth = avg_depth + depth_img[j, i]
+                        count = count + 1
+            return avg_depth / count
+
+        # Reference: https://github.com/carla-simulator/data-collector/blob/master/carla/image_converter.py
+        def linear_to_log(depth_meters):
+            """
+            Convert linear depth in meters to logorithmic depth between [0,1]
+            """
+            # Reference https://carla.readthedocs.io/en/latest/ref_sensors/#depth-camera
+            normalized_depth = depth_meters / 1000.0
+            # Convert to logarithmic depth.
+            depth_log = 1.0 + np.log(normalized_depth) / 5.70378
+            depth_log = np.clip(depth_log, 0.0, 1.0)
+            return depth_log
+
+        def log_to_linear(depth_log):
+            """
+            Convert log depth between [0,1] to linear depth in meters
+            """
+            normalized_depth = np.exp((depth_log - 1.0) * 5.70378)
+            depth_meters = normalized_depth * 1000.0
+            return depth_meters
+
         if x.shape[0] > 1:
             log.info("To perform per-example patch attack, batch size must be 1")
         assert x.shape[-1] in [3, 6], "x must have either 3 or 6 color channels"
@@ -445,12 +657,27 @@ class CARLADapricotPatch(RobustDPatch):
 
             self.gs_coords = [gs_coords]
 
+            if (
+                self.patch_shape[2] == 6
+            ):  # initialize depth patch with average depth value of green screen
+                if "avg_patch_depth" in y_patch_metadata[i]:  # for Eval 5+ metadata
+                    avg_patch_depth = y_patch_metadata[i]["avg_patch_depth"]
+                else:  # backward compatible with Eval 4 metadata
+                    avg_patch_depth = get_avg_depth_value(x[i][:, :, 3], gs_coords)
+                
+                avg_patch_depth_meters = log_to_linear(avg_patch_depth)
+                max_depth_meters = avg_patch_depth_meters + self.depth_delta_meters
+                min_depth_meters = avg_patch_depth_meters - self.depth_delta_meters
+                self.max_depth = linear_to_log(max_depth_meters)
+                self.min_depth = linear_to_log(min_depth_meters)
+                self._patch[:, :, 3:] = avg_patch_depth
+
             if y is None:
-                patch = super().generate(
+                patch = self.inner_generate(
                     np.expand_dims(x[i], axis=0)
                 )  # untargeted attack
             else:
-                patch = super().generate(
+                patch = self.inner_generate(
                     np.expand_dims(x[i], axis=0), y=[y[i]]
                 )  # targeted attack
 
@@ -459,11 +686,12 @@ class CARLADapricotPatch(RobustDPatch):
             rgb_img_with_patch = insert_patch(
                 self.gs_coords[0],
                 rgb_img[:, :, ::-1],
-                patch[:, :, self.attacked_channels] * 255.0,
+                patch[:, :, :3] * 255.0,
                 self.patch_geometric_shape,
                 cc_gt=self.cc_gt,
                 cc_scene=self.cc_scene,
                 apply_realistic_effects=True,
+                rgb=True,
             )
 
             # embed patch into background
@@ -474,8 +702,26 @@ class CARLADapricotPatch(RobustDPatch):
             if x.shape[-1] == 3:
                 img_with_patch = rgb_img_with_patch.copy()
             else:
+                # apply patch using DAPRICOT transform to Depth channels only
+                # insert_patch() uses BGR color ordering for input and output
+                depth_img_with_patch = insert_patch(
+                    self.gs_coords[0],
+                    depth_img[:, :, ::-1],
+                    patch[:, :, 3:] * 255.0,
+                    self.patch_geometric_shape,
+                    cc_gt=self.cc_gt,
+                    cc_scene=self.cc_scene,
+                    apply_realistic_effects=False,
+                    rgb=False,
+                )
+
+                # embed patch into background
+                depth_img_with_patch[
+                    np.all(self.binarized_patch_mask == 0, axis=-1)
+                ] = depth_img[np.all(self.binarized_patch_mask == 0, axis=-1)][:, ::-1]
+
                 img_with_patch = np.concatenate(
-                    (depth_img[:, :, ::-1], rgb_img_with_patch), axis=-1
+                    (depth_img_with_patch, rgb_img_with_patch), axis=-1
                 )
             attacked_images.append(img_with_patch[:, :, ::-1] / 255.0)
 

--- a/armory/art_experimental/attacks/carla_obj_det_patch.py
+++ b/armory/art_experimental/attacks/carla_obj_det_patch.py
@@ -9,6 +9,11 @@ from tqdm.auto import trange
 import math
 
 from armory.utils.external_repo import ExternalRepoImport
+from armory.art_experimental.attacks.carla_obj_det_utils import (
+    get_avg_depth_value,
+    log_to_linear,
+    linear_to_log,
+)
 
 with ExternalRepoImport(
     repo="colour-science/colour@v0.3.16",
@@ -576,65 +581,6 @@ class CARLADapricotPatch(RobustDPatch):
             ith dictionary contains bounding boxes, class labels, and class scores
         param y_patch_metadata: Patch metadata. List of N dictionaries, ith dictionary contains patch metadata for x[i]
         """
-
-        def in_polygon(x, y, vertices):
-            """
-            Determine if a point (x,y) is inside a polygon with given vertices
-            Ref: https://www.eecs.umich.edu/courses/eecs380/HANDOUTS/PROJ2/InsidePoly.html
-            """
-            n_pts = len(vertices)
-            i = 0
-            j = n_pts - 1
-            c = False
-
-            while i < n_pts:
-                if (
-                    # y coordinate of the point has to be between the y coordinates of the i-th and j-th vertices
-                    ((vertices[i][1] <= y) and (y < vertices[j][1]))
-                    or ((vertices[j][1] <= y) and (y < vertices[i][1]))
-                ) and (
-                    # x coordinate of the point is to the left of the line connecting i-th and j-th vertices
-                    x
-                    < (vertices[j][0] - vertices[i][0])
-                    * (y - vertices[i][1])
-                    / (vertices[j][1] - vertices[i][1])
-                    + vertices[i][0]
-                ):
-                    c = not c
-                j = i
-                i = i + 1
-            return c
-
-        def get_avg_depth_value(depth_img, patch_coords):
-            # Return the average depth value of a patch with coordinates given by patch_coords
-            avg_depth = 0.0
-            count = 0
-            for i in range(depth_img.shape[1]):
-                for j in range(depth_img.shape[0]):
-                    if in_polygon(i, j, patch_coords):
-                        avg_depth = avg_depth + depth_img[j, i]
-                        count = count + 1
-            return avg_depth / count
-
-        # Reference: https://github.com/carla-simulator/data-collector/blob/master/carla/image_converter.py
-        def linear_to_log(depth_meters):
-            """
-            Convert linear depth in meters to logorithmic depth between [0,1]
-            """
-            # Reference https://carla.readthedocs.io/en/latest/ref_sensors/#depth-camera
-            normalized_depth = depth_meters / 1000.0
-            # Convert to logarithmic depth.
-            depth_log = 1.0 + np.log(normalized_depth) / 5.70378
-            depth_log = np.clip(depth_log, 0.0, 1.0)
-            return depth_log
-
-        def log_to_linear(depth_log):
-            """
-            Convert log depth between [0,1] to linear depth in meters
-            """
-            normalized_depth = np.exp((depth_log - 1.0) * 5.70378)
-            depth_meters = normalized_depth * 1000.0
-            return depth_meters
 
         if x.shape[0] > 1:
             log.info("To perform per-example patch attack, batch size must be 1")

--- a/armory/art_experimental/attacks/carla_obj_det_utils.py
+++ b/armory/art_experimental/attacks/carla_obj_det_utils.py
@@ -1,0 +1,64 @@
+import numpy as np
+
+
+def in_polygon(x, y, vertices):
+    """
+    Determine if a point (x,y) is inside a polygon with given vertices
+    Ref: https://www.eecs.umich.edu/courses/eecs380/HANDOUTS/PROJ2/InsidePoly.html
+    """
+    n_pts = len(vertices)
+    i = 0
+    j = n_pts - 1
+    c = False
+
+    while i < n_pts:
+        if (
+            # y coordinate of the point has to be between the y coordinates of the i-th and j-th vertices
+            ((vertices[i][1] <= y) and (y < vertices[j][1]))
+            or ((vertices[j][1] <= y) and (y < vertices[i][1]))
+        ) and (
+            # x coordinate of the point is to the left of the line connecting i-th and j-th vertices
+            x
+            < (vertices[j][0] - vertices[i][0])
+            * (y - vertices[i][1])
+            / (vertices[j][1] - vertices[i][1])
+            + vertices[i][0]
+        ):
+            c = not c
+        j = i
+        i = i + 1
+    return c
+
+
+def get_avg_depth_value(depth_img, patch_coords):
+    # Return the average depth value of a patch with coordinates given by patch_coords
+    avg_depth = 0.0
+    count = 0
+    for i in range(depth_img.shape[1]):
+        for j in range(depth_img.shape[0]):
+            if in_polygon(i, j, patch_coords):
+                avg_depth = avg_depth + depth_img[j, i]
+                count = count + 1
+    return avg_depth / count
+
+
+# Reference: https://github.com/carla-simulator/data-collector/blob/master/carla/image_converter.py
+def linear_to_log(depth_meters):
+    """
+    Convert linear depth in meters to logorithmic depth between [0,1]
+    """
+    # Reference https://carla.readthedocs.io/en/latest/ref_sensors/#depth-camera
+    normalized_depth = depth_meters / 1000.0
+    # Convert to logarithmic depth.
+    depth_log = 1.0 + np.log(normalized_depth) / 5.70378
+    depth_log = np.clip(depth_log, 0.0, 1.0)
+    return depth_log
+
+
+def log_to_linear(depth_log):
+    """
+    Convert log depth between [0,1] to linear depth in meters
+    """
+    normalized_depth = np.exp((depth_log - 1.0) * 5.70378)
+    depth_meters = normalized_depth * 1000.0
+    return depth_meters

--- a/scenario_configs/carla_obj_det_dpatch_defended.json
+++ b/scenario_configs/carla_obj_det_dpatch_defended.json
@@ -64,7 +64,7 @@
         "name": "CarlaObjectDetectionTask"
     },
     "sysconfig": {
-        "docker_image": "twosixarmory/pytorch:0.14.5.g8b9a84d",
+        "docker_image": "twosixarmory/pytorch",
         "external_github_repo": "colour-science/colour@v0.3.16",
         "gpus": "all",
         "output_dir": null,

--- a/scenario_configs/carla_obj_det_dpatch_defended.json
+++ b/scenario_configs/carla_obj_det_dpatch_defended.json
@@ -6,7 +6,7 @@
         "kwargs": {
             "batch_size": 1,
             "learning_rate": 0.01,
-            "max_iter": 10000,
+            "max_iter": 2000,
             "verbose": true
         },
         "module": "armory.art_experimental.attacks.carla_obj_det_patch",
@@ -64,7 +64,7 @@
         "name": "CarlaObjectDetectionTask"
     },
     "sysconfig": {
-        "docker_image": "twosixarmory/pytorch",
+        "docker_image": "twosixarmory/pytorch:0.14.5.g8b9a84d",
         "external_github_repo": "colour-science/colour@v0.3.16",
         "gpus": "all",
         "output_dir": null,

--- a/scenario_configs/carla_obj_det_dpatch_undefended.json
+++ b/scenario_configs/carla_obj_det_dpatch_undefended.json
@@ -6,7 +6,7 @@
         "kwargs": {
             "batch_size": 1,
             "learning_rate": 0.01,
-            "max_iter": 10000,
+            "max_iter": 2000,
             "verbose": true
         },
         "module": "armory.art_experimental.attacks.carla_obj_det_patch",
@@ -51,7 +51,7 @@
         "name": "CarlaObjectDetectionTask"
     },
     "sysconfig": {
-        "docker_image": "twosixarmory/pytorch",
+        "docker_image": "twosixarmory/pytorch:0.14.5.g8b9a84d",
         "external_github_repo": "colour-science/colour@v0.3.16",
         "gpus": "all",
         "output_dir": null,

--- a/scenario_configs/carla_obj_det_dpatch_undefended.json
+++ b/scenario_configs/carla_obj_det_dpatch_undefended.json
@@ -51,7 +51,7 @@
         "name": "CarlaObjectDetectionTask"
     },
     "sysconfig": {
-        "docker_image": "twosixarmory/pytorch:0.14.5.g8b9a84d",
+        "docker_image": "twosixarmory/pytorch",
         "external_github_repo": "colour-science/colour@v0.3.16",
         "gpus": "all",
         "output_dir": null,

--- a/scenario_configs/carla_obj_det_multimodal_dpatch_defended.json
+++ b/scenario_configs/carla_obj_det_multimodal_dpatch_defended.json
@@ -5,8 +5,10 @@
         "knowledge": "white",
         "kwargs": {
             "batch_size": 1,
+            "depth_delta_meters": 3,
             "learning_rate": 0.01,
-            "max_iter": 20000,
+            "learning_rate_depth": 0.0001,
+            "max_iter": 2000,
             "verbose": true
         },
         "module": "armory.art_experimental.attacks.carla_obj_det_patch",
@@ -49,7 +51,7 @@
         "name": "CarlaObjectDetectionTask"
     },
     "sysconfig": {
-        "docker_image": "twosixarmory/pytorch",
+        "docker_image": "twosixarmory/pytorch:0.14.5.g8b9a84d",
         "external_github_repo": "colour-science/colour@v0.3.16",
         "gpus": "all",
         "output_dir": null,

--- a/scenario_configs/carla_obj_det_multimodal_dpatch_defended.json
+++ b/scenario_configs/carla_obj_det_multimodal_dpatch_defended.json
@@ -51,7 +51,7 @@
         "name": "CarlaObjectDetectionTask"
     },
     "sysconfig": {
-        "docker_image": "twosixarmory/pytorch:0.14.5.g8b9a84d",
+        "docker_image": "twosixarmory/pytorch",
         "external_github_repo": "colour-science/colour@v0.3.16",
         "gpus": "all",
         "output_dir": null,

--- a/scenario_configs/carla_obj_det_multimodal_dpatch_undefended.json
+++ b/scenario_configs/carla_obj_det_multimodal_dpatch_undefended.json
@@ -5,8 +5,10 @@
         "knowledge": "white",
         "kwargs": {
             "batch_size": 1,
+            "depth_delta_meters": 3,
             "learning_rate": 0.01,
-            "max_iter": 20000,
+            "learning_rate_depth": 0.0001,
+            "max_iter": 2000,
             "verbose": true
         },
         "module": "armory.art_experimental.attacks.carla_obj_det_patch",
@@ -49,7 +51,7 @@
         "name": "CarlaObjectDetectionTask"
     },
     "sysconfig": {
-        "docker_image": "twosixarmory/pytorch",
+        "docker_image": "twosixarmory/pytorch:0.14.5.g8b9a84d",
         "external_github_repo": "colour-science/colour@v0.3.16",
         "gpus": "all",
         "output_dir": null,

--- a/scenario_configs/carla_obj_det_multimodal_dpatch_undefended.json
+++ b/scenario_configs/carla_obj_det_multimodal_dpatch_undefended.json
@@ -51,7 +51,7 @@
         "name": "CarlaObjectDetectionTask"
     },
     "sysconfig": {
-        "docker_image": "twosixarmory/pytorch:0.14.5.g8b9a84d",
+        "docker_image": "twosixarmory/pytorch",
         "external_github_repo": "colour-science/colour@v0.3.16",
         "gpus": "all",
         "output_dir": null,


### PR DESCRIPTION
Updated `art_experimental carla_obj_det_patch` to attack both RGB and Depth.

For reference, I got the following results on `test` using `large` split (note, the multimodal defended model was trained to defend against RGB attack only, so ignore its performance on the updated attack)

- carla_obj_det_multimodal_dpatch_defended.json: 0.33 mAP / 42 hallucinations per image
- carla_obj_det_multimodal_dpatch_undefended.json: 0.34 mAP / 14 hallucinations per image
- carla_obj_det_dpatch_undefended.json: 0.18 mAP / 11 hallucinations per image
- carla_obj_det_dpatch_defended.json: 0.18 mAP / 9 hallucinations per image