### PR TITLE
add pytest loguru logcap fixure with tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -170,3 +170,23 @@ def dataset_generator():
         return dataset
 
     return generator
+
+
+# override caplog fixture to receve loguru messages as described in
+# https://loguru.readthedocs.io/en/stable/resources/migration.html#making-things-work-with-pytest-and-caplog
+
+from loguru import logger as loguru_logger
+from _pytest.logging import LogCaptureFixture
+
+# It is good that this fixture is implemented as a generator function so
+# that we don't have to worry about the armory.logs sinks added or removed.
+# This fixture adds and removes it's own sink only for the duration of the
+# pytest function. If we find that messages disappear after this fixture is
+# used, we might have to be more delicate in setting up the other sinks.
+
+
+@pytest.fixture
+def caplog(caplog: LogCaptureFixture):
+    handler_id = loguru_logger.add(caplog.handler, format="{message}")
+    yield caplog
+    loguru_logger.remove(handler_id)

--- a/tests/unit/test_logging.py
+++ b/tests/unit/test_logging.py
@@ -1,0 +1,30 @@
+import pytest
+from armory.logs import log
+
+# test the loguru based logs module for proper pytest caplog behavior
+# there is a modified caplog fixture in tests/conftest.py
+
+
+def function_that_warns():
+    log.warning("this is a wally warning")
+
+
+def function_that_errors():
+    log.error("this is a wally error")
+
+
+def test_warns_function(caplog):
+    function_that_warns()
+    # because we known function that warns only makes one log message we know
+    # that all records should be WARNING
+    for record in caplog.records:
+        assert record.levelname == "WARNING"
+    assert "wally" in caplog.text
+    assert "this is a wally warning" in caplog.text
+
+
+def test_error_function(caplog):
+    function_that_errors()
+    for record in caplog.records:
+        assert record.levelname == "ERROR"
+    assert "wally" in caplog.text

--- a/tests/unit/test_logging.py
+++ b/tests/unit/test_logging.py
@@ -1,4 +1,3 @@
-import pytest
 from armory.logs import log
 
 # test the loguru based logs module for proper pytest caplog behavior


### PR DESCRIPTION
This uses the loguru suggested change to the pytest `caplog` mechanism for assertions on logging output. Sample use can be seen in tests/unit/test_logging.py.