### PR TITLE
document armory base image build

### DIFF
--- a/docker/build-base.sh
+++ b/docker/build-base.sh
@@ -1,4 +1,44 @@
+#!/usr/bin/env bash
+set -e
+
+usage() { echo "usage: $0 [--dry-run] [--push]" 1>&2; exit 1; }
+
+dryrun=
+push=
+
+while [ "${1:-}" != "" ]; do
+    case "$1" in
+        -n|--dry-run)
+            echo "dry-run requested. not building or pushing to docker hub"
+            dryrun="echo" ;;
+        --push)
+            push=true ;;
+        *)
+            usage ;;
+    esac
+    shift
+done
+
 echo "Building the base image locally"
-docker build --force-rm --file ./docker/Dockerfile-base -t twosixarmory/base:latest --progress=auto .
-echo "If building the framework images locally, use the '--no-pull' argument. E.g.:"
-echo "    python docker/build.py all --no-pull"
+$dryrun docker build --force-rm --file ./docker/Dockerfile-base -t twosixarmory/base:latest --progress=auto .
+
+if [[ -z "$push" ]]; then
+    echo ""
+    echo "If building the framework images locally, use the '--no-pull' argument. E.g.:"
+    echo "    python docker/build.py all --no-pull"
+    exit 0
+fi
+
+tag=$(python -m setuptools_scm | sed -e 's/dev[0-9][0-9]*+//' -e 's/\.d[0-9][0-9]*$//')
+echo tagging twosixarmory/base:latest as $tag for dockerhub tracking
+$dryrun docker tag twosixarmory/base:latest twosixarmory/base:$tag
+
+echo ""
+echo "If you have not run 'docker login', with the proper credentials, these pushes will fail"
+echo "see docs/docker.md for instructions"
+echo ""
+
+# the second push should result in no new upload, it just tag the new image as
+# latest
+$dryrun docker push twosixarmory/base:$tag
+$dryrun docker push twosixarmory/base:latest

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -4,19 +4,19 @@ inside a docker container.
 
 
 ## Images
-There are four docker images that are currently published to dockerhub for every release of 
+There are four docker images that are currently published to dockerhub for every release of
 the armory framework:
 
-1. `twosixarmory/tf1:<version>` 
-2. `twosixarmory/tf2:<version>` 
-3. `twosixarmory/pytorch:<version>` 
-4. `twosixarmory/pytorch-deepspeech:<version>` 
+1. `twosixarmory/tf1:<version>`
+2. `twosixarmory/tf2:<version>`
+3. `twosixarmory/pytorch:<version>`
+4. `twosixarmory/pytorch-deepspeech:<version>`
 
-When using `armory launch` or `armory exec` the framework specific arguments will 
-utilize one of these three images. 
+When using `armory launch` or `armory exec` the framework specific arguments will
+utilize one of these three images.
 
-When running `armory run <path/to/config.json>` the image launched will be whatever is 
-specified in the `docker_image` field. This enables users to extend our base images 
+When running `armory run <path/to/config.json>` the image launched will be whatever is
+specified in the `docker_image` field. This enables users to extend our base images
 and run evaluations on an image that has all additional requirements for their defense.
 
 
@@ -27,7 +27,7 @@ either the `"docker_image"` field of the [config file](configuration_files.md)
 of `armory run <path/to/config.json>` or in the CLI of the `launch` and `exec` commands,
 as in `run launch <custom_image:tag>`.
 
-Note: since Armory executes commands on detached containers, the `CMD` of the Docker image 
+Note: since Armory executes commands on detached containers, the `CMD` of the Docker image
 will be *ignored* and replaced with `tail -f /dev/null` to ensure that the container does not
 exit while those commands are being executed.
 
@@ -63,21 +63,21 @@ Once inside the container, you should be able to run or import armory as require
 I have no name!@c10db6c70a81:/workspace$ armory version
 0.13.0
 I have no name!@c10db6c70a81:/workspace$ python
-Python 3.7.6 (default, Jan  8 2020, 19:59:22) 
+Python 3.7.6 (default, Jan  8 2020, 19:59:22)
 [GCC 7.3.0] :: Anaconda, Inc. on linux
 Type "help", "copyright", "credits" or "license" for more information.
 >>> import armory
->>> 
+>>>
 ```
 
-Note: We do not recommend using `--interactive` mode for installing custom requirements. You may 
+Note: We do not recommend using `--interactive` mode for installing custom requirements. You may
 run into permissions issues, as everything is installed as root, but the armory user is not run
 as root, to prevent potential security issues. Instead, we recommend creating a custom Docker image,
 as described above.
 
 ## Building Images from Source
-When using a released version of armory, docker images will be pulled as needed when 
-evaluations are ran. However if there are issues downloading the images (e.g. proxy) 
+When using a released version of armory, docker images will be pulled as needed when
+evaluations are ran. However if there are issues downloading the images (e.g. proxy)
 they can be built from the release branch of the repo:
 ```
 git checkout -b r0.14.0
@@ -85,21 +85,21 @@ bash docker/build.sh <tf1|tf2|pytorch|all>
 ```
 
 ## Docker Volume Mounts
-When launching an ARMORY instance several host directories will be mounted within the 
-docker container. Note, the host directory path for datasets, saved_models, and 
+When launching an ARMORY instance several host directories will be mounted within the
+docker container. Note, the host directory path for datasets, saved_models, and
 outputs are configurable. To modify those directories simply run `armory configure`.
 The defaults are shown below:
 
 
-| Host Path   | Docker Path   | 
-|:----------: | :-----------: | 
-| os.getcwd() | /workspace    |  
+| Host Path   | Docker Path   |
+|:----------: | :-----------: |
+| os.getcwd() | /workspace    |
 | ~/.armory/datasets | /armory/datasets |
 | ~/.armory/saved_models | /armory/saved_models |
 | ~/.armory/outputs | /armory/outputs |
 
 
-When using these paths in code, armory provides a programatic way to access these 
+When using these paths in code, armory provides a programatic way to access these
 directories.
 
 ### PyTorch model persistent storage
@@ -108,7 +108,7 @@ If you are using the Armory PyTorch container, published models from PyTorch Hub
 will often need to be retieved from a remote source. To avoid re-download of
 that data on each container run, these will be stored in the
 `/armory/saved_models/pytorch` container directory which is normally mapped to
-`~/.armory/saved_models` on the host as shown in the table above. 
+`~/.armory/saved_models` on the host as shown in the table above.
 
 
 #### Utilizing the paths
@@ -165,7 +165,7 @@ armory launch tf1 --gpus=1,4 --interactive
 armory exec pytorch --gpus=0 -- nvidia-smi
 ```
 
-### CUDA 
+### CUDA
 
 The TensorFlow versions we support require CUDA 10+.
 
@@ -183,16 +183,16 @@ in `docker/pytorch/Dockerfile` and build the pytorch container locally.
 
 
 ## Docker Setup
-Depending on the evaluation, you may need to increase the default memory allocation for 
-docker containers on your system. 
+Depending on the evaluation, you may need to increase the default memory allocation for
+docker containers on your system.
 
-Linux does not limit memory allocation, but on Mac and Windows this defaults to 2 GB 
+Linux does not limit memory allocation, but on Mac and Windows this defaults to 2 GB
 which is likely insufficient. See the docker documentation to change this:
 * [Mac](https://docs.docker.com/docker-for-mac/)
 * [Windows](https://docs.docker.com/docker-for-windows/)
 
 
-## Docker Image Maintenance 
+## Docker Image Maintenance
 Since there are new docker images for every release of ARMORY, you may want to clean up
 your docker image cache as you increase versions.
 
@@ -210,8 +210,8 @@ docker ps
 ```
 ARMORY will attempt to gracefully shut down all containers it launches;
 however, certain errors may prevent shutdown and leave running containers.
-To shut down these containers, please see the docs for 
-[docker stop](https://docs.docker.com/engine/reference/commandline/stop/) 
+To shut down these containers, please see the docs for
+[docker stop](https://docs.docker.com/engine/reference/commandline/stop/)
 and [docker kill](https://docs.docker.com/engine/reference/commandline/kill/).
 
 ## Running without docker
@@ -242,3 +242,54 @@ x, y = next(ds)
 NOTE: The listing of libraries needed for Armory when run on host is available at
 `host-requirements.txt`. You will need to manually install the requirements in
 that file that match your framework (TF1, TF2, PyTorch).
+
+# publishing a new base
+
+As of armory v0.15, there is a base docker image which is pushed to dockerhub
+occasionally.  The container description is in [Dockerfile-base](docker/Dockerfile-base)
+and there is a tiny [build-base.sh](docker/build-base.sh) helper script.
+
+We do not currently have any verification tests for this build.
+**TODO**: add validation tests and make this a CI deployment job, perhaps.
+
+
+## docker credentials
+
+In the GARD Keeper Password manager is the password for twosixarmory on dockerhub.
+Run
+
+    docker login --username twosixarmory
+
+and give it the password when prompted.  It should respond `Login Succeeded`
+
+## push the new image
+
+This step is "push to production": it changes the latest image on our official
+repository, so has the potential to break all container builds by any armory
+user anywhere.
+
+If you do discover a breaking change, the only fix is to push a new image, since
+[dockerhub does not allow reversion](https://stackoverflow.com/questions/55475080/how-can-i-revert-my-last-push-on-hub-docker-com)
+
+There is a `--dry-run` option which allows you to see what commands would be run.
+It's a good idea to run that first:
+
+    bash docker/build-base.sh --dry-run --push
+
+When satisfied that you want that run:
+
+    bash docker/build-base.sh --push
+
+Will tag the image properly and push it to dockerhub.  There will be two
+new tags created at https://hub.docker.com/r/twosixarmory/base
+
+    twosixarmory/base:latest
+    twosixarmory/base:VERSION
+
+both with the same digest.
+
+You might want to end with
+
+    docker logout
+
+to avoid accidental `docker push` commands from using the shared account.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,6 @@
+# build-system taken from https://github.com/pypa/setuptools_scm/#pyprojecttoml-usage
+[build-system]
+requires = ["setuptools>=45", "setuptools_scm[toml]>=6.2"]
+
+[tool.setuptools_scm]
+# this empty section is needed to make the plugin work


### PR DESCRIPTION
In documenting this simple task I found there was too much operator knowledge needed, so I fixed it.

The [docker.md instructions for publishing a new base](docs/docker.md#publishing_a_new_base) should be
self explanatory. If not, that's a bug