### PR TITLE
Minor update to CARLA Robust Dpath attack 

### DIFF
--- a/armory/art_experimental/attacks/carla_obj_det_patch.py
+++ b/armory/art_experimental/attacks/carla_obj_det_patch.py
@@ -473,7 +473,7 @@ class CARLADapricotPatch(RobustDPatch):
                 self.patch_geometric_shape,
                 cc_gt=self.cc_gt,
                 cc_scene=self.cc_scene,
-                apply_realistic_effects=True,
+                apply_realistic_effects=False,
                 rgb=True,
             )
 
@@ -606,14 +606,15 @@ class CARLADapricotPatch(RobustDPatch):
                 x.shape[-1],
             )
 
-            self.patch_geometric_shape = str(y_patch_metadata[i]["shape"])
+            patch_geometric_shape = y_patch_metadata[i].get("shape", "rect")
+            self.patch_geometric_shape = str(patch_geometric_shape)
 
             # this masked to embed patch into the background in the event of occlusion
             self.binarized_patch_mask = y_patch_metadata[i]["mask"]
 
             # get colorchecker information from ground truth and scene
-            self.cc_gt = y_patch_metadata[i]["cc_ground_truth"]
-            self.cc_scene = y_patch_metadata[i]["cc_scene"]
+            self.cc_gt = y_patch_metadata[i].get("cc_ground_truth", None)
+            self.cc_scene = y_patch_metadata[i].get("cc_scene", None)
 
             # self._patch needs to be re-initialized with the correct shape
             if self.estimator.clip_values is None:
@@ -661,7 +662,7 @@ class CARLADapricotPatch(RobustDPatch):
                 self.patch_geometric_shape,
                 cc_gt=self.cc_gt,
                 cc_scene=self.cc_scene,
-                apply_realistic_effects=True,
+                apply_realistic_effects=False,
                 rgb=True,
             )
 

--- a/armory/art_experimental/attacks/carla_obj_det_patch.py
+++ b/armory/art_experimental/attacks/carla_obj_det_patch.py
@@ -616,6 +616,9 @@ class CARLADapricotPatch(RobustDPatch):
             self.cc_gt = y_patch_metadata[i].get("cc_ground_truth", None)
             self.cc_scene = y_patch_metadata[i].get("cc_scene", None)
 
+            # Prior to Eval 5 (dev set version 2.0.0), this was set to True. It's now being
+            # set False to be more aligned with AdversarialPatch attack. This line is essentially
+            # 'if dev set version >= 2.0.0', since these variables are None as of 2.0.0 / Eval 5
             if self.cc_gt is None or self.cc_scene is None:
                 self.apply_realistic_effects = False
             else:

--- a/armory/art_experimental/attacks/carla_obj_det_patch.py
+++ b/armory/art_experimental/attacks/carla_obj_det_patch.py
@@ -473,7 +473,7 @@ class CARLADapricotPatch(RobustDPatch):
                 self.patch_geometric_shape,
                 cc_gt=self.cc_gt,
                 cc_scene=self.cc_scene,
-                apply_realistic_effects=False,
+                apply_realistic_effects=self.apply_realistic_effects,
                 rgb=True,
             )
 
@@ -616,6 +616,11 @@ class CARLADapricotPatch(RobustDPatch):
             self.cc_gt = y_patch_metadata[i].get("cc_ground_truth", None)
             self.cc_scene = y_patch_metadata[i].get("cc_scene", None)
 
+            if self.cc_gt is None or self.cc_scene is None:
+                self.apply_realistic_effects = False
+            else:
+                self.apply_realistic_effects = True
+
             # self._patch needs to be re-initialized with the correct shape
             if self.estimator.clip_values is None:
                 self._patch = np.zeros(shape=self.patch_shape)
@@ -662,7 +667,7 @@ class CARLADapricotPatch(RobustDPatch):
                 self.patch_geometric_shape,
                 cc_gt=self.cc_gt,
                 cc_scene=self.cc_scene,
-                apply_realistic_effects=False,
+                apply_realistic_effects=self.apply_realistic_effects,
                 rgb=True,
             )
 


### PR DESCRIPTION
@lcadalzo Minor update to remove dependency on `shape`, `cc_ground_truth`, and `cc_scene` keywords in Eval5 adversarial datasets