### PR TITLE
Fix Flicker defended config

### DIFF
--- a/armory/art_experimental/defences/video_compression_normalized.py
+++ b/armory/art_experimental/defences/video_compression_normalized.py
@@ -41,7 +41,7 @@ class VideoCompressionNormalized(VideoCompression):
         return x, y
 
 
-class VideoCompressionNormalizedPytorch(VideoCompressionPyTorch):
+class VideoCompressionNormalizedPyTorch(VideoCompressionPyTorch):
     """
     Convert x from [0,1] to [0, 255] and back, if necessary
     """

--- a/scenario_configs/eval1-4/ucf101/ucf101_pretrained_flicker_defended.json
+++ b/scenario_configs/eval1-4/ucf101/ucf101_pretrained_flicker_defended.json
@@ -34,7 +34,7 @@
             "video_format": "avi"
         },
         "module": "armory.art_experimental.defences.video_compression_normalized",
-        "name": "VideoCompressionNormalized",
+        "name": "VideoCompressionNormalizedPyTorch",
         "type": "Preprocessor"
     },
     "metric": {


### PR DESCRIPTION
Fixes #1471 

The error was due to using a PyTorch framework attack on a non-PyTorch defense. Changing to the PyTorch defense (plus a little typo change for consistency) fixed the issue.