### PR TITLE
use version string from armory version for base image tag

### DIFF
--- a/docker/build-base.sh
+++ b/docker/build-base.sh
@@ -29,7 +29,7 @@ if [[ -z "$push" ]]; then
     exit 0
 fi
 
-tag=$(python -m setuptools_scm | sed -e 's/dev[0-9][0-9]*+//' -e 's/\.d[0-9][0-9]*$//')
+tag=$(python -m armory --version)
 echo tagging twosixarmory/base:latest as $tag for dockerhub tracking
 $dryrun docker tag twosixarmory/base:latest twosixarmory/base:$tag
 


### PR DESCRIPTION
In #1521 we backed off (slightly) from a firm dependence on the setuptools_scm module.  The `armory.__version__` attribute is now the authoritative armory version, so use that to create the base tag.