### PR TITLE
Release fix

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,7 +41,6 @@ jobs:
         run: |
           rm -rf /usr/share/dotnet &
           pip install -r requirements.txt
-          pip install -e .
           version=$(python -m armory --version)
           docker login --username ${{ secrets.DOCKER_USERNAME }} --password ${{ secrets.DOCKER_PASSWORD }}
           docker pull twosixarmory/tf2:latest
@@ -65,7 +64,6 @@ jobs:
         run: |
           rm -rf /usr/share/dotnet &
           pip install -r requirements.txt
-          pip install -e .
           version=$(python -m armory --version)
           docker login --username ${{ secrets.DOCKER_USERNAME }} --password ${{ secrets.DOCKER_PASSWORD }}
           docker pull twosixarmory/pytorch:latest
@@ -89,7 +87,6 @@ jobs:
         run: |
           rm -rf /usr/share/dotnet &
           pip install -r requirements.txt
-          pip install -e .
           version=$(python -m armory --version)
           docker login --username ${{ secrets.DOCKER_USERNAME }} --password ${{ secrets.DOCKER_PASSWORD }}
           docker pull twosixarmory/pytorch-deepspeech:latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,6 +41,7 @@ jobs:
         run: |
           rm -rf /usr/share/dotnet &
           pip install -r requirements.txt
+          pip install -e .
           version=$(python -m armory --version)
           docker login --username ${{ secrets.DOCKER_USERNAME }} --password ${{ secrets.DOCKER_PASSWORD }}
           docker pull twosixarmory/tf2:latest
@@ -64,6 +65,7 @@ jobs:
         run: |
           rm -rf /usr/share/dotnet &
           pip install -r requirements.txt
+          pip install -e .
           version=$(python -m armory --version)
           docker login --username ${{ secrets.DOCKER_USERNAME }} --password ${{ secrets.DOCKER_PASSWORD }}
           docker pull twosixarmory/pytorch:latest
@@ -87,6 +89,7 @@ jobs:
         run: |
           rm -rf /usr/share/dotnet &
           pip install -r requirements.txt
+          pip install -e .
           version=$(python -m armory --version)
           docker login --username ${{ secrets.DOCKER_USERNAME }} --password ${{ secrets.DOCKER_PASSWORD }}
           docker pull twosixarmory/pytorch-deepspeech:latest


### PR DESCRIPTION
Fixes #1531

This updates the build script to not require pip installation. We already require it to be run from the root of the armory repo, so it seems weird to require a pip install to simply import armory.