### PR TITLE
Clip CARLA video tracking inputs (and labels, correspondingly)

### DIFF
--- a/armory/data/adversarial_datasets.py
+++ b/armory/data/adversarial_datasets.py
@@ -744,6 +744,25 @@ def carla_obj_det_test(
     )
 
 
+class ClipVideoTrackingLabels:
+    """
+    Truncate labels for CARLA video tracking, when max_frames is set
+    """
+
+    def __init__(self, max_frames):
+        max_frames = int(max_frames)
+        if max_frames <= 0:
+            raise ValueError(f"max_frames {max_frames} must be > 0")
+        self.max_frames = max_frames
+
+    def __call__(self, x, labels):
+        boxes, patch_metadata_dict = labels
+        boxes = boxes[:, : self.max_frames, :]
+        for k in patch_metadata_dict:
+            patch_metadata_dict[k] = patch_metadata_dict[k][:, : self.max_frames, ::]
+        return boxes, patch_metadata_dict
+
+
 def carla_video_tracking_label_preprocessing(x, y):
     box_labels, patch_metadata = y
     box_array = np.squeeze(box_labels, axis=0)
@@ -762,6 +781,7 @@ def carla_video_tracking_dev(
     cache_dataset: bool = True,
     framework: str = "numpy",
     shuffle_files: bool = False,
+    max_frames: int = None,
     **kwargs,
 ):
     """
@@ -774,6 +794,18 @@ def carla_video_tracking_dev(
         )
     if batch_size != 1:
         raise ValueError("carla_obj_det_dev batch size must be set to 1")
+
+    if max_frames:
+        clip = datasets.ClipFrames(max_frames)
+        clip_labels = ClipVideoTrackingLabels(max_frames)
+    else:
+        clip = None
+        clip_labels = None
+
+    preprocessing_fn = datasets.preprocessing_chain(clip, preprocessing_fn)
+    label_preprocessing_fn = datasets.label_preprocessing_chain(
+        clip_labels, label_preprocessing_fn
+    )
 
     return datasets._generator_from_tfds(
         "carla_video_tracking_dev:2.0.0",

--- a/armory/data/datasets.py
+++ b/armory/data/datasets.py
@@ -564,7 +564,9 @@ def preprocessing_chain(*args):
 
 def label_preprocessing_chain(*args):
     """
-    Wraps and returns a sequence of label preprocessing functions
+    Wraps and returns a sequence of label preprocessing functions.
+    Note that this function differs from preprocessing_chain() in that
+    it chains across (x, y) instead of just x
     """
     functions = [x for x in args if x is not None]
     if not functions:

--- a/armory/data/datasets.py
+++ b/armory/data/datasets.py
@@ -548,7 +548,7 @@ def _generator_from_tfds(
 
 def preprocessing_chain(*args):
     """
-    Wraps and returns a sequence of functions
+    Wraps and returns a sequence of preprocessing functions
     """
     functions = [x for x in args if x is not None]
     if not functions:
@@ -558,6 +558,22 @@ def preprocessing_chain(*args):
         for function in functions:
             x = function(x)
         return x
+
+    return wrapped
+
+
+def label_preprocessing_chain(*args):
+    """
+    Wraps and returns a sequence of label preprocessing functions
+    """
+    functions = [x for x in args if x is not None]
+    if not functions:
+        return None
+
+    def wrapped(x, y):
+        for function in functions:
+            y = function(x, y)
+        return y
 
     return wrapped
 


### PR DESCRIPTION
Addresses #1543. Done so via a `"max_frames"` dataset kwarg that defaults to `None` and can be set from the dataset config as such:

```
 "dataset": {
        "batch_size": 1,
        "eval_split": "dev",
        "framework": "numpy",
        "module": "armory.data.adversarial_datasets",
        "name": "carla_video_tracking_dev",
        "max_frames": 30
    },
```