### PR TITLE
buildable docker containers

### DIFF
--- a/docker/Dockerfile-base
+++ b/docker/Dockerfile-base
@@ -22,9 +22,10 @@ RUN apt-get -y -qq update && \
     build-essential \
     git \
     curl \
-#    libgl1-mesa-glx \
+    libgl1-mesa-glx \
 #    libglib2.0-0 \
     && rm -rf /var/lib/apt/lists/*
+# libgl1-mesa-glx is needed for cv2 (opencv-python)
 
 # Install Conda
 RUN wget --quiet https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -O ~/miniconda.sh && \

--- a/docker/Dockerfile-pytorch-deepspeech
+++ b/docker/Dockerfile-pytorch-deepspeech
@@ -1,7 +1,4 @@
 ARG base_image_tag
-ARG armory_version
-ARG armory_build_type
-
 
 FROM twosixarmory/base:${base_image_tag} AS armory-local
 
@@ -10,11 +7,6 @@ WORKDIR /armory-repo
 # NOTE: This COPY command is filtered using the `.dockerignore` file
 #       in the root of the repo.
 COPY ./ /armory-repo
-
-# NOTE: installed after pip installs in base container,
-#       but doesn't seem to cause issues at the moment
-#       pip install librosa does not install sndfile dependency
-RUN /opt/conda/bin/conda install -c conda-forge librosa
 
 RUN echo "Building Armory from local source"                                     && \
     echo "Updating Base Image..."                                                && \

--- a/docker/Dockerfile-tf2
+++ b/docker/Dockerfile-tf2
@@ -1,25 +1,6 @@
 ARG base_image_tag
-ARG armory_version
-ARG armory_build_type
-
 
 FROM twosixarmory/base:${base_image_tag} as armory-base
-
-# This section installs tensorflow object detection API from:
-#    - repo:           https://github.com/tensorflow/models/
-#    - commit:        79354e14a4b41ff9019f4a5ebd12cfa498917182
-#    - subdirectory:  /research/object_detection/packages/tf2/setup.py
-
-WORKDIR /tmp/models/research
-
-RUN git clone https://github.com/tensorflow/models.git                  && \
-      cd models/research                                                && \
-      git checkout 79354e14a4b41ff9019f4a5ebd12cfa498917182             && \
-    protoc object_detection/protos/*.proto --python_out=.               && \
-    cp object_detection/packages/tf2/setup.py .                         && \
-    /opt/conda/bin/pip install --no-cache-dir tf-models-official==2.8   && \
-    /opt/conda/bin/pip install --use-feature=in-tree-build .
-
 
 FROM armory-base AS armory-local
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,7 +84,7 @@ datasets-builder = [
 math = [
     "numpy",
     "scipy",
-    "scikit-learn",
+    "scikit-learn < 1.1.0",
     "matplotlib",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,21 +61,19 @@ developer =[
 
 engine = [
     "adversarial-robustness-toolbox==1.12.1",
-    "Pillow == 9.2.0",           # Data dependencies
-    "boto3 == 1.24.72",          # Needed for armory.data.utils
-    "botocore == 1.27.77",       # Needed for armory.data.utils
-    "ffmpeg-python == 0.2.0",    # Needed for armory.utils.export
-    "opencv-python == 4.6.0.66",  # Needed for CARLA baseline scenario
-    "pydub >= 0.24.1",           # this is in ART's extra-requires
-    "tensorboardx == 2.5.1",
+    "Pillow",           # Data dependencies
+    "boto3",          # Needed for armory.data.utils
+    "botocore",       # Needed for armory.data.utils
+    "ffmpeg-python",    # Needed for armory.utils.export
+    "opencv-python",  # Needed for CARLA baseline scenario
+    "pydub",           # this is in ART's extra-requires
+    "tensorboardx",
 ]
 
 datasets = [
-    "tensorflow-datasets == 4.6.0",
-    # TODO: this duplicate "tensorflow" is unclean. Unfortunately, tfds does
-    # not require "tensorflow" so we need to add it here.
-    "tensorflow == 2.8.0",
-    "protobuf==3.20.1",
+    "tensorflow-datasets >= 4.6.0",
+    "tensorflow >= 2.10.0",
+    "protobuf",
 ]
 
 datasets-builder = [
@@ -84,41 +82,39 @@ datasets-builder = [
 ]
 
 math = [
-    "numpy >= 1.21.0",
-    "scipy >= 1.3.2",
-    "scikit-learn >= 1.0.0",
-    "matplotlib == 3.5.3",
+    "numpy",
+    "scipy",
+    "scikit-learn",
+    "matplotlib",
 ]
 
 pytorch = [
     "armory-testbed[engine,datasets,math]",
-    "torch == 1.12.1",
-    "torchvision == 0.13.1",
-    "torchaudio == 0.12.1",
+    "torch",
+    "torchvision",
+    "torchaudio",
 ]
 
 tensorflow = [
     "armory-testbed[engine,datasets,math]",
-    "tensorflow == 2.8.0",
     "tf-models-official",
-    "object_detection @ git+https://github.com/tensorflow/models/#subdirectory=research/object_detection/packages/tf2",
 ]
 
 deepspeech = [
     "armory-testbed[pytorch,engine,datasets,math]",
     "python-levenshtein",
-    "torchmetrics == 0.9.3",
-    "sox == 1.4.1",
-    "librosa == 0.9.2",
-    "google-cloud-storage == 2.5.0",
+    "torchmetrics < 0.8.0",
+    "sox",
+    "librosa",
+    "google-cloud-storage",
     "transformers",
-    "pytorch-lightning == 1.4.9",
-    "hydra-core == 1.2.0",
+    "pytorch-lightning < 1.5.0",
+    "hydra-core",
     "hydra-configs-pytorch-lightning @ git+https://github.com/romesco/hydra-lightning/#subdirectory=hydra-configs-pytorch-lightning",
 ]
 
 jupyter = [
-    "jupyterlab == 3.4.7",
+    "jupyterlab",
 ]
 
 all = [


### PR DESCRIPTION
Bare minimum fixes to make `tf2` and `pytorch-deepspeech` containers build properly. Goal is to enable armory release on Friday, as the bigger updates will likely need to wait (e.g., removing the `tf2` and `pytorch-deepspeech` containers).

This removes the TF Object Detection API dependency from both the `tf2` dockerfile and `pyproject.toml`, as it is not actively being supported and causes dependency hell.

`librosa` is now in base, so I removed its install from the `pytorch-deepspeech` dockerfile.

The only other changes were to remove version information from `pyproject.toml` except where explicitly needed.