### PR TITLE
remove [all] target from pyproject and CI because it lags CI badly

### DIFF
--- a/.github/workflows/2-test-stand-alone.yml
+++ b/.github/workflows/2-test-stand-alone.yml
@@ -45,7 +45,7 @@ jobs:
       - name: ⚙️ Installing Armory
         shell: bash
         run: |
-          pip install --no-compile --editable '.[developer,all]'
+          pip install --no-compile --editable '.[developer,engine,pytorch]'
           armory configure --use-defaults
 
       - name: 🤞 Run Host Configuration Tests

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -121,11 +121,6 @@ jupyter = [
     "jupyterlab == 3.4.7",
 ]
 
-all = [
-    "armory-testbed[pytorch,tensorflow,deepspeech,jupyter]",
-]
-
-
 [build-system]
 build-backend = "hatchling.build"
 requires = [


### PR DESCRIPTION
The `[all]` target causes 2+ hour pip installations because it is computationally hard when versions are unpinned. Also, we don't need such an installation. 