### PR TITLE
Documentation & Dockerfile cleanup/fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,8 +119,8 @@ Agency (DARPA).
 
 <!-- MARKDOWN LINKS & IMAGES -->
 <!-- https://www.markdownguide.org/basic-syntax/#reference-style-links -->
-[ci-badge]: /../../workflows/GitHub%20CI/badge.svg
-[ci-url]: /../../actions/
+[ci-badge]: https://github.com/twosixlabs/armory/workflows/GitHub%20CI/badge.svg
+[ci-url]: https://github.com/twosixlabs/armory/actions/
 [pypi-badge]: https://badge.fury.io/py/armory-testbed.svg
 [pypi-url]: https://pypi.org/project/armory-testbed
 [python-badge]: https://img.shields.io/pypi/pyversions/armory-testbed

--- a/docker/Dockerfile-carla-mot
+++ b/docker/Dockerfile-carla-mot
@@ -12,24 +12,4 @@ RUN pip install --no-cache-dir \
 RUN pip install --no-cache-dir \
     cython-bbox
 
-
-WORKDIR /armory-repo
-
-RUN echo "Updating pip" && \
-    pip install --upgrade pip && \
-    echo "Building ART" && \
-    pip install --no-cache-dir \
-    adversarial-robustness-toolbox==1.12.1
-
-# NOTE: This COPY command is filtered using the `.dockerignore` file
-#       in the root of the repo.
-COPY ./ /armory-repo
-
-RUN echo "Building Armory from local source" && \
-    pip install --no-compile --no-cache-dir --editable . && \
-    echo "Configuring Armory..." && \
-    armory configure --use-default && \
-    echo "Cleaning up..." && \
-    rm -rf /armory-repo/.git
-
 WORKDIR /workspace

--- a/docs/no_docker_mode.md
+++ b/docs/no_docker_mode.md
@@ -8,7 +8,7 @@ First you will need to clone the armory repo (or if you plan to be a developer,
 see [Contributing to Armory](./contributing.md) to clone a fork of the repo).
 For the following, the repo directory will be referred to as `[armory-repo]`.
 
-Virtual environment setup for conda is failry straight forward:
+Virtual environment setup for conda is fairly straight forward:
 ```bash
 wget --quiet https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -O ~/miniconda.sh
 /bin/bash ~/miniconda.sh -b -p /opt/conda

--- a/docs/no_docker_mode.md
+++ b/docs/no_docker_mode.md
@@ -8,14 +8,24 @@ First you will need to clone the armory repo (or if you plan to be a developer,
 see [Contributing to Armory](./contributing.md) to clone a fork of the repo).
 For the following, the repo directory will be referred to as `[armory-repo]`.
 
-Now you will want to create a clean python virtual environment and activate
-that environment.  For example:
+Virtual environment setup for conda is failry straight forward:
+```bash
+wget --quiet https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -O ~/miniconda.sh
+/bin/bash ~/miniconda.sh -b -p /opt/conda
+conda install -c conda-forge -n base mamba \
+mamba env update -f environment.yml -n base --prune
+mamba clean --all
+```
+
+Alternatively, if your system already has the necessary libraries installed, a virtual
+environment can be created with the following commands:
 ```bash
 cd [armory-repo]
-python37 -m venv venv37
-source venv37/bin/activate
+python38 -m venv venv38
+source venv38/bin/activate
 ```
-or you can setup your virtualenv using another tool (e.g. conda, pyenv, etc.).
+
+Check out the [Dockerfiles](../docker) for more information on enviroment setup.
 
 Once this is complete, and you have ensured you are in the `[armory-repo]` directory,
 you can setup the environment with the following:

--- a/docs/no_docker_mode.md
+++ b/docs/no_docker_mode.md
@@ -25,7 +25,7 @@ python38 -m venv venv38
 source venv38/bin/activate
 ```
 
-Check out the [Dockerfiles](../docker) for more information on enviroment setup.
+Check out the [Dockerfiles](../docker) for more information on environment setup.
 
 Once this is complete, and you have ensured you are in the `[armory-repo]` directory,
 you can setup the environment with the following:


### PR DESCRIPTION
### Why:

Closes:
  - [Fix links to CI badge and project logo for pypi and readthedocs #1679 ](https://github.com/twosixlabs/armory/issues/1679)
  - [find a way to avoid a duplicate armory installation in Dockerfile-carla-mot #1671](https://github.com/twosixlabs/armory/issues/1671)

### What's being changed (if available, include any code snippets, screenshots, or gifs):

  - `README.md` now links assets directly to the TwoSix Armory repo.
  - `docs/no_docker_mode.md` elaborate on the environment setup steps.
  - `docker/Dockerfile-carla-mot` remove initial image configuration; now inherits updated `pytorch` base image.
