### PR TITLE
use isort to sort python imports

### DIFF
--- a/armory/__init__.py
+++ b/armory/__init__.py
@@ -2,8 +2,7 @@
 Adversarial Robustness Evaluation Test Bed
 """
 from armory.logs import log
-from armory.utils import version, typedef
-
+from armory.utils import typedef, version
 
 Config = typedef.Config
 

--- a/armory/__main__.py
+++ b/armory/__main__.py
@@ -15,21 +15,18 @@ import os
 import re
 import sys
 
-import docker
 from jsonschema import ValidationError
 
 import armory
-
-from armory.logs import log
-
-from armory import paths
-from armory import arguments
-from armory.configuration import load_global_config, save_config
-from armory.eval import Evaluator
-from armory.docker import images
-from armory.utils.configuration import load_config, load_config_stdin
-import armory.utils.version
 import armory.logs
+import armory.utils.version
+import docker
+from armory import arguments, paths
+from armory.configuration import load_global_config, save_config
+from armory.docker import images
+from armory.eval import Evaluator
+from armory.logs import log
+from armory.utils.configuration import load_config, load_config_stdin
 
 
 class PortNumber(argparse.Action):
@@ -452,8 +449,7 @@ def download(command_args, prog, description):
     if args.no_docker:
         log.info("Downloading requested datasets and model weights in host mode...")
         paths.set_mode("host")
-        from armory.data import datasets
-        from armory.data import model_weights
+        from armory.data import datasets, model_weights
 
         datasets.download_all(args.download_config, args.scenario)
         model_weights.download_all(args.download_config, args.scenario)

--- a/armory/__main__.py
+++ b/armory/__main__.py
@@ -18,15 +18,15 @@ import sys
 from jsonschema import ValidationError
 
 import armory
-import armory.logs
-import armory.utils.version
-import docker
 from armory import arguments, paths
 from armory.configuration import load_global_config, save_config
 from armory.docker import images
 from armory.eval import Evaluator
+import armory.logs
 from armory.logs import log
 from armory.utils.configuration import load_config, load_config_stdin
+import armory.utils.version
+import docker
 
 
 class PortNumber(argparse.Action):

--- a/armory/art_experimental/attacks/carla_adversarial_texture.py
+++ b/armory/art_experimental/attacks/carla_adversarial_texture.py
@@ -1,7 +1,7 @@
-import numpy as np
-import torch
 from typing import Optional
 
+import numpy as np
+import torch
 from art.attacks.evasion import AdversarialTexturePyTorch
 
 

--- a/armory/art_experimental/attacks/carla_adversarial_texture.py
+++ b/armory/art_experimental/attacks/carla_adversarial_texture.py
@@ -1,8 +1,8 @@
 from typing import Optional
 
+from art.attacks.evasion import AdversarialTexturePyTorch
 import numpy as np
 import torch
-from art.attacks.evasion import AdversarialTexturePyTorch
 
 
 class AdversarialPhysicalTexture(AdversarialTexturePyTorch):

--- a/armory/art_experimental/attacks/carla_mot_adversarial_patch.py
+++ b/armory/art_experimental/attacks/carla_mot_adversarial_patch.py
@@ -1,14 +1,15 @@
-import numpy as np
-from armory.logs import log
 import os
-import cv2
+from typing import Optional, Tuple
 
+import cv2
+import numpy as np
+import torch
 from art.attacks.evasion.adversarial_patch.adversarial_patch_pytorch import (
     AdversarialPatchPyTorch,
 )
-from typing import Optional, Tuple
 from tqdm import trange
-import torch
+
+from armory.logs import log
 
 
 class CARLAMOTAdversarialPatchPyTorch(AdversarialPatchPyTorch):

--- a/armory/art_experimental/attacks/carla_mot_adversarial_patch.py
+++ b/armory/art_experimental/attacks/carla_mot_adversarial_patch.py
@@ -1,12 +1,12 @@
 import os
 from typing import Optional, Tuple
 
-import cv2
-import numpy as np
-import torch
 from art.attacks.evasion.adversarial_patch.adversarial_patch_pytorch import (
     AdversarialPatchPyTorch,
 )
+import cv2
+import numpy as np
+import torch
 from tqdm import trange
 
 from armory.logs import log

--- a/armory/art_experimental/attacks/carla_mot_patch.py
+++ b/armory/art_experimental/attacks/carla_mot_patch.py
@@ -1,14 +1,14 @@
-import random
-
-from armory.logs import log
-from art.attacks.evasion import RobustDPatch
+import math
 import os
+import random
+from typing import Dict, List, Optional
+
 import cv2
 import numpy as np
-from typing import Optional, List, Dict
+from art.attacks.evasion import RobustDPatch
 from tqdm.auto import trange
-import math
 
+from armory.logs import log
 from armory.utils.external_repo import ExternalRepoImport
 
 with ExternalRepoImport(

--- a/armory/art_experimental/attacks/carla_mot_patch.py
+++ b/armory/art_experimental/attacks/carla_mot_patch.py
@@ -3,9 +3,9 @@ import os
 import random
 from typing import Dict, List, Optional
 
+from art.attacks.evasion import RobustDPatch
 import cv2
 import numpy as np
-from art.attacks.evasion import RobustDPatch
 from tqdm.auto import trange
 
 from armory.logs import log

--- a/armory/art_experimental/attacks/carla_obj_det_adversarial_patch.py
+++ b/armory/art_experimental/attacks/carla_obj_det_adversarial_patch.py
@@ -1,17 +1,15 @@
-import numpy as np
-from armory.logs import log
 import os
-import cv2
+from typing import Optional
 
+import cv2
+import numpy as np
+import torch
 from art.attacks.evasion.adversarial_patch.adversarial_patch_pytorch import (
     AdversarialPatchPyTorch,
 )
-from typing import Optional
-import torch
 
-from armory.art_experimental.attacks.carla_obj_det_utils import (
-    linear_depth_to_rgb,
-)
+from armory.art_experimental.attacks.carla_obj_det_utils import linear_depth_to_rgb
+from armory.logs import log
 
 
 class CARLAAdversarialPatchPyTorch(AdversarialPatchPyTorch):

--- a/armory/art_experimental/attacks/carla_obj_det_adversarial_patch.py
+++ b/armory/art_experimental/attacks/carla_obj_det_adversarial_patch.py
@@ -1,12 +1,12 @@
 import os
 from typing import Optional
 
-import cv2
-import numpy as np
-import torch
 from art.attacks.evasion.adversarial_patch.adversarial_patch_pytorch import (
     AdversarialPatchPyTorch,
 )
+import cv2
+import numpy as np
+import torch
 
 from armory.art_experimental.attacks.carla_obj_det_utils import linear_depth_to_rgb
 from armory.logs import log

--- a/armory/art_experimental/attacks/carla_obj_det_patch.py
+++ b/armory/art_experimental/attacks/carla_obj_det_patch.py
@@ -3,9 +3,9 @@ import os
 import random
 from typing import Dict, List, Optional
 
+from art.attacks.evasion import RobustDPatch
 import cv2
 import numpy as np
-from art.attacks.evasion import RobustDPatch
 from tqdm.auto import trange
 
 from armory.art_experimental.attacks.carla_obj_det_utils import linear_depth_to_rgb

--- a/armory/art_experimental/attacks/carla_obj_det_patch.py
+++ b/armory/art_experimental/attacks/carla_obj_det_patch.py
@@ -1,18 +1,16 @@
-import random
-
-from armory.logs import log
-from art.attacks.evasion import RobustDPatch
+import math
 import os
+import random
+from typing import Dict, List, Optional
+
 import cv2
 import numpy as np
-from typing import Optional, List, Dict
+from art.attacks.evasion import RobustDPatch
 from tqdm.auto import trange
-import math
 
+from armory.art_experimental.attacks.carla_obj_det_utils import linear_depth_to_rgb
+from armory.logs import log
 from armory.utils.external_repo import ExternalRepoImport
-from armory.art_experimental.attacks.carla_obj_det_utils import (
-    linear_depth_to_rgb,
-)
 
 with ExternalRepoImport(
     repo="colour-science/colour@v0.3.16",

--- a/armory/art_experimental/attacks/cascading_attack.py
+++ b/armory/art_experimental/attacks/cascading_attack.py
@@ -1,4 +1,5 @@
 from art.attacks.evasion import AutoAttack
+
 from armory.utils.config_loading import load_attack
 
 

--- a/armory/art_experimental/attacks/dapricot_patch.py
+++ b/armory/art_experimental/attacks/dapricot_patch.py
@@ -1,10 +1,10 @@
 """
 Copyright 2021 The MITRE Corporation. All rights reserved
 """
-import numpy as np
-import cv2
 import math
 
+import cv2
+import numpy as np
 from art.attacks.evasion import ProjectedGradientDescent
 
 

--- a/armory/art_experimental/attacks/dapricot_patch.py
+++ b/armory/art_experimental/attacks/dapricot_patch.py
@@ -3,9 +3,9 @@ Copyright 2021 The MITRE Corporation. All rights reserved
 """
 import math
 
+from art.attacks.evasion import ProjectedGradientDescent
 import cv2
 import numpy as np
-from art.attacks.evasion import ProjectedGradientDescent
 
 
 def shape_coords(h, w, obj_shape):

--- a/armory/art_experimental/attacks/fgm_binary_search.py
+++ b/armory/art_experimental/attacks/fgm_binary_search.py
@@ -4,8 +4,8 @@ Updated version of art.attacks.fast_gradient.py
 Uses binary search to quickly find optimal epsilon values per test point
 """
 
-import numpy as np
 from art.attacks.evasion import FastGradientMethod
+import numpy as np
 
 
 class FGMBinarySearch(FastGradientMethod):

--- a/armory/art_experimental/attacks/frame.py
+++ b/armory/art_experimental/attacks/frame.py
@@ -1,5 +1,6 @@
 def get_frame_saliency(classifier, inner_config=None, **kwargs):
     from art.attacks.evasion import FrameSaliencyAttack
+
     from armory.utils import config_loading
 
     attacker = config_loading.load_attack(inner_config, classifier)

--- a/armory/art_experimental/attacks/gradient_matching.py
+++ b/armory/art_experimental/attacks/gradient_matching.py
@@ -1,8 +1,8 @@
 import os
 
 import numpy as np
-
 from art.attacks.poisoning.gradient_matching_attack import GradientMatchingAttack
+
 from armory.logs import log
 
 

--- a/armory/art_experimental/attacks/gradient_matching.py
+++ b/armory/art_experimental/attacks/gradient_matching.py
@@ -1,7 +1,7 @@
 import os
 
-import numpy as np
 from art.attacks.poisoning.gradient_matching_attack import GradientMatchingAttack
+import numpy as np
 
 from armory.logs import log
 

--- a/armory/art_experimental/attacks/pgd_patch.py
+++ b/armory/art_experimental/attacks/pgd_patch.py
@@ -1,5 +1,5 @@
-from art.attacks.evasion import ProjectedGradientDescent
 import numpy as np
+from art.attacks.evasion import ProjectedGradientDescent
 
 from armory.logs import log
 

--- a/armory/art_experimental/attacks/pgd_patch.py
+++ b/armory/art_experimental/attacks/pgd_patch.py
@@ -1,5 +1,5 @@
-import numpy as np
 from art.attacks.evasion import ProjectedGradientDescent
+import numpy as np
 
 from armory.logs import log
 

--- a/armory/art_experimental/attacks/poison_loader_audio.py
+++ b/armory/art_experimental/attacks/poison_loader_audio.py
@@ -1,6 +1,5 @@
 import librosa
 import numpy as np
-
 from art.attacks.poisoning import PoisoningAttackBackdoor
 
 # from art.attacks.poisoning.perturbations.audio_perturbations import (

--- a/armory/art_experimental/attacks/poison_loader_audio.py
+++ b/armory/art_experimental/attacks/poison_loader_audio.py
@@ -1,6 +1,6 @@
+from art.attacks.poisoning import PoisoningAttackBackdoor
 import librosa
 import numpy as np
-from art.attacks.poisoning import PoisoningAttackBackdoor
 
 # from art.attacks.poisoning.perturbations.audio_perturbations import (
 #    insert_audio_trigger,

--- a/armory/art_experimental/attacks/poison_loader_dlbd.py
+++ b/armory/art_experimental/attacks/poison_loader_dlbd.py
@@ -3,8 +3,8 @@ This module enables loading of different perturbation functions in poisoning
 """
 import os
 
-from art.attacks.poisoning import PoisoningAttackBackdoor
-from art.attacks.poisoning import perturbations
+from art.attacks.poisoning import PoisoningAttackBackdoor, perturbations
+
 import armory
 
 

--- a/armory/art_experimental/attacks/robust_dpatch.py
+++ b/armory/art_experimental/attacks/robust_dpatch.py
@@ -1,5 +1,5 @@
-from art.attacks.evasion import RobustDPatch
 import numpy as np
+from art.attacks.evasion import RobustDPatch
 
 from armory.logs import log
 

--- a/armory/art_experimental/attacks/robust_dpatch.py
+++ b/armory/art_experimental/attacks/robust_dpatch.py
@@ -1,5 +1,5 @@
-import numpy as np
 from art.attacks.evasion import RobustDPatch
+import numpy as np
 
 from armory.logs import log
 

--- a/armory/art_experimental/attacks/snr_pgd.py
+++ b/armory/art_experimental/attacks/snr_pgd.py
@@ -308,16 +308,10 @@ class SNR_PGD(ProjectedGradientDescentPyTorch):
                      perturbed.
         :return: Perturbations.
         """
-        # Get gradient wrt loss; invert it if attack is targeted
-        import art
-        import torch  # lgtm [py/repeated-import]
+        import torch
 
-        if art.__version__.startswith("1.4"):
-            grad = self.estimator.loss_gradient_framework(x, y) * (
-                1 - 2 * int(self.targeted)
-            )
-        else:
-            grad = self.estimator.loss_gradient(x=x, y=y) * (1 - 2 * int(self.targeted))
+        # Get gradient wrt loss; invert it if attack is targeted
+        grad = self.estimator.loss_gradient(x=x, y=y) * (1 - 2 * int(self.targeted))
         assert x.shape == grad.shape
 
         # Apply mask

--- a/armory/art_experimental/attacks/snr_pgd.py
+++ b/armory/art_experimental/attacks/snr_pgd.py
@@ -1,8 +1,8 @@
-import numpy as np
 from art.attacks.evasion import (
     ProjectedGradientDescentNumpy,
     ProjectedGradientDescentPyTorch,
 )
+import numpy as np
 
 from armory.logs import log
 

--- a/armory/art_experimental/attacks/snr_pgd.py
+++ b/armory/art_experimental/attacks/snr_pgd.py
@@ -1,8 +1,8 @@
-from art.attacks.evasion import (
-    ProjectedGradientDescentPyTorch,
-    ProjectedGradientDescentNumpy,
-)
 import numpy as np
+from art.attacks.evasion import (
+    ProjectedGradientDescentNumpy,
+    ProjectedGradientDescentPyTorch,
+)
 
 from armory.logs import log
 
@@ -308,10 +308,9 @@ class SNR_PGD(ProjectedGradientDescentPyTorch):
                      perturbed.
         :return: Perturbations.
         """
-        import torch  # lgtm [py/repeated-import]
-
         # Get gradient wrt loss; invert it if attack is targeted
         import art
+        import torch  # lgtm [py/repeated-import]
 
         if art.__version__.startswith("1.4"):
             grad = self.estimator.loss_gradient_framework(x, y) * (

--- a/armory/art_experimental/attacks/sweep.py
+++ b/armory/art_experimental/attacks/sweep.py
@@ -1,7 +1,7 @@
 from importlib import import_module
 
-import numpy as np
 from art.attacks import EvasionAttack
+import numpy as np
 
 from armory.logs import log
 

--- a/armory/art_experimental/attacks/sweep.py
+++ b/armory/art_experimental/attacks/sweep.py
@@ -3,7 +3,6 @@ from importlib import import_module
 import numpy as np
 from art.attacks import EvasionAttack
 
-
 from armory.logs import log
 
 

--- a/armory/art_experimental/attacks/video_frame_border.py
+++ b/armory/art_experimental/attacks/video_frame_border.py
@@ -1,5 +1,5 @@
-from art.attacks.evasion import ProjectedGradientDescent
 import numpy as np
+from art.attacks.evasion import ProjectedGradientDescent
 
 
 class FrameBorderPatch(ProjectedGradientDescent):

--- a/armory/art_experimental/attacks/video_frame_border.py
+++ b/armory/art_experimental/attacks/video_frame_border.py
@@ -1,5 +1,5 @@
-import numpy as np
 from art.attacks.evasion import ProjectedGradientDescent
+import numpy as np
 
 
 class FrameBorderPatch(ProjectedGradientDescent):

--- a/armory/art_experimental/defences/jpeg_compression_multichannel_image.py
+++ b/armory/art_experimental/defences/jpeg_compression_multichannel_image.py
@@ -1,5 +1,5 @@
-from art.defences.preprocessor import JpegCompression
 import numpy as np
+from art.defences.preprocessor import JpegCompression
 
 
 class JpegCompressionMultiChannelImage(JpegCompression):

--- a/armory/art_experimental/defences/jpeg_compression_multichannel_image.py
+++ b/armory/art_experimental/defences/jpeg_compression_multichannel_image.py
@@ -1,5 +1,5 @@
-import numpy as np
 from art.defences.preprocessor import JpegCompression
+import numpy as np
 
 
 class JpegCompressionMultiChannelImage(JpegCompression):

--- a/armory/art_experimental/defences/jpeg_compression_normalized.py
+++ b/armory/art_experimental/defences/jpeg_compression_normalized.py
@@ -1,5 +1,5 @@
-import numpy as np
 from art.defences.preprocessor import JpegCompression
+import numpy as np
 
 
 class JpegCompressionNormalized(JpegCompression):

--- a/armory/art_experimental/defences/jpeg_compression_normalized.py
+++ b/armory/art_experimental/defences/jpeg_compression_normalized.py
@@ -1,5 +1,5 @@
-from art.defences.preprocessor import JpegCompression
 import numpy as np
+from art.defences.preprocessor import JpegCompression
 
 
 class JpegCompressionNormalized(JpegCompression):

--- a/armory/art_experimental/defences/random_affine_pytorch.py
+++ b/armory/art_experimental/defences/random_affine_pytorch.py
@@ -1,4 +1,4 @@
-from typing import Tuple, List, TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING, List, Optional, Tuple
 
 from art.preprocessing.expectation_over_transformation.pytorch import EoTPyTorch
 

--- a/armory/art_experimental/defences/video_compression_normalized.py
+++ b/armory/art_experimental/defences/video_compression_normalized.py
@@ -1,5 +1,5 @@
-import numpy as np
 from art.defences.preprocessor import VideoCompression, VideoCompressionPyTorch
+import numpy as np
 
 
 class VideoCompressionNormalized(VideoCompression):

--- a/armory/art_experimental/defences/video_compression_normalized.py
+++ b/armory/art_experimental/defences/video_compression_normalized.py
@@ -1,6 +1,5 @@
-from art.defences.preprocessor import VideoCompression
-from art.defences.preprocessor import VideoCompressionPyTorch
 import numpy as np
+from art.defences.preprocessor import VideoCompression, VideoCompressionPyTorch
 
 
 class VideoCompressionNormalized(VideoCompression):

--- a/armory/art_experimental/poison_detection/random_filter.py
+++ b/armory/art_experimental/poison_detection/random_filter.py
@@ -1,5 +1,4 @@
 import numpy as np
-
 from art.defences.detector.poison import PoisonFilteringDefence
 
 from armory.logs import log

--- a/armory/art_experimental/poison_detection/random_filter.py
+++ b/armory/art_experimental/poison_detection/random_filter.py
@@ -1,5 +1,5 @@
-import numpy as np
 from art.defences.detector.poison import PoisonFilteringDefence
+import numpy as np
 
 from armory.logs import log
 

--- a/armory/baseline_models/keras/cifar.py
+++ b/armory/baseline_models/keras/cifar.py
@@ -3,8 +3,8 @@ CNN model for 32x32x3 image classification
 """
 from typing import Optional
 
-import tensorflow as tf
 from art.estimators.classification import KerasClassifier
+import tensorflow as tf
 from tensorflow.keras.layers import Conv2D, Dense, Flatten, MaxPooling2D
 from tensorflow.keras.models import Sequential
 

--- a/armory/baseline_models/keras/cifar.py
+++ b/armory/baseline_models/keras/cifar.py
@@ -4,9 +4,9 @@ CNN model for 32x32x3 image classification
 from typing import Optional
 
 import tensorflow as tf
-from tensorflow.keras.models import Sequential
-from tensorflow.keras.layers import Dense, Flatten, Conv2D, MaxPooling2D
 from art.estimators.classification import KerasClassifier
+from tensorflow.keras.layers import Conv2D, Dense, Flatten, MaxPooling2D
+from tensorflow.keras.models import Sequential
 
 tf.compat.v1.disable_eager_execution()
 

--- a/armory/baseline_models/keras/densenet121_resisc45.py
+++ b/armory/baseline_models/keras/densenet121_resisc45.py
@@ -5,9 +5,9 @@ Model contributed by: MITRE Corporation
 """
 from typing import Optional
 
+from art.estimators.classification import KerasClassifier
 import numpy as np
 import tensorflow as tf
-from art.estimators.classification import KerasClassifier
 from tensorflow.keras.applications.densenet import DenseNet121
 from tensorflow.keras.layers import Dense, GlobalAveragePooling2D, Lambda
 from tensorflow.keras.models import Model

--- a/armory/baseline_models/keras/densenet121_resisc45.py
+++ b/armory/baseline_models/keras/densenet121_resisc45.py
@@ -5,12 +5,12 @@ Model contributed by: MITRE Corporation
 """
 from typing import Optional
 
-from art.estimators.classification import KerasClassifier
 import numpy as np
 import tensorflow as tf
+from art.estimators.classification import KerasClassifier
 from tensorflow.keras.applications.densenet import DenseNet121
+from tensorflow.keras.layers import Dense, GlobalAveragePooling2D, Lambda
 from tensorflow.keras.models import Model
-from tensorflow.keras.layers import GlobalAveragePooling2D, Dense, Lambda
 
 tf.compat.v1.disable_eager_execution()
 

--- a/armory/baseline_models/keras/inception_resnet_v2.py
+++ b/armory/baseline_models/keras/inception_resnet_v2.py
@@ -3,8 +3,8 @@ Inception_ResNet_v2 CNN model for 299x299x3 image classification
 """
 from typing import Optional
 
-from art.estimators.classification import KerasClassifier
 import tensorflow as tf
+from art.estimators.classification import KerasClassifier
 from tensorflow.keras.applications.inception_resnet_v2 import InceptionResNetV2
 from tensorflow.keras.layers import Lambda
 from tensorflow.keras.models import Model

--- a/armory/baseline_models/keras/inception_resnet_v2.py
+++ b/armory/baseline_models/keras/inception_resnet_v2.py
@@ -3,8 +3,8 @@ Inception_ResNet_v2 CNN model for 299x299x3 image classification
 """
 from typing import Optional
 
-import tensorflow as tf
 from art.estimators.classification import KerasClassifier
+import tensorflow as tf
 from tensorflow.keras.applications.inception_resnet_v2 import InceptionResNetV2
 from tensorflow.keras.layers import Lambda
 from tensorflow.keras.models import Model

--- a/armory/baseline_models/keras/micronnet_gtsrb.py
+++ b/armory/baseline_models/keras/micronnet_gtsrb.py
@@ -5,8 +5,8 @@ Model contributed by: MITRE Corporation
 """
 from typing import Optional
 
-import tensorflow as tf
 from art.estimators.classification import KerasClassifier
+import tensorflow as tf
 from tensorflow.keras import Input, Model
 from tensorflow.keras.layers import (
     Activation,

--- a/armory/baseline_models/keras/micronnet_gtsrb.py
+++ b/armory/baseline_models/keras/micronnet_gtsrb.py
@@ -6,10 +6,17 @@ Model contributed by: MITRE Corporation
 from typing import Optional
 
 import tensorflow as tf
-from tensorflow.keras import Model, Input
-from tensorflow.keras.layers import Dense, Conv2D, Activation, Lambda
-from tensorflow.keras.layers import Flatten, BatchNormalization, MaxPooling2D
 from art.estimators.classification import KerasClassifier
+from tensorflow.keras import Input, Model
+from tensorflow.keras.layers import (
+    Activation,
+    BatchNormalization,
+    Conv2D,
+    Dense,
+    Flatten,
+    Lambda,
+    MaxPooling2D,
+)
 
 tf.compat.v1.disable_eager_execution()
 

--- a/armory/baseline_models/keras/mnist.py
+++ b/armory/baseline_models/keras/mnist.py
@@ -4,9 +4,9 @@ CNN model for 28x28x1 image classification
 from typing import Optional
 
 import tensorflow as tf
-from tensorflow.keras.models import Sequential
-from tensorflow.keras.layers import Dense, Flatten, Conv2D, MaxPooling2D
 from art.estimators.classification import KerasClassifier
+from tensorflow.keras.layers import Conv2D, Dense, Flatten, MaxPooling2D
+from tensorflow.keras.models import Sequential
 
 tf.compat.v1.disable_eager_execution()
 

--- a/armory/baseline_models/keras/mnist.py
+++ b/armory/baseline_models/keras/mnist.py
@@ -3,8 +3,8 @@ CNN model for 28x28x1 image classification
 """
 from typing import Optional
 
-import tensorflow as tf
 from art.estimators.classification import KerasClassifier
+import tensorflow as tf
 from tensorflow.keras.layers import Conv2D, Dense, Flatten, MaxPooling2D
 from tensorflow.keras.models import Sequential
 

--- a/armory/baseline_models/keras/resnet50.py
+++ b/armory/baseline_models/keras/resnet50.py
@@ -3,8 +3,8 @@ ResNet50 CNN model for 244x244x3 image classification
 """
 from typing import Optional
 
-import tensorflow as tf
 from art.estimators.classification import KerasClassifier
+import tensorflow as tf
 from tensorflow.keras.applications.resnet50 import ResNet50
 from tensorflow.keras.layers import Lambda
 from tensorflow.keras.models import Model

--- a/armory/baseline_models/keras/so2sat.py
+++ b/armory/baseline_models/keras/so2sat.py
@@ -1,9 +1,9 @@
 from copy import deepcopy
 from typing import Optional
 
+from art.estimators.classification import KerasClassifier
 import numpy as np
 import tensorflow as tf
-from art.estimators.classification import KerasClassifier
 from tensorflow import slice
 from tensorflow.keras import Model, Sequential
 from tensorflow.keras.layers import (

--- a/armory/baseline_models/keras/so2sat.py
+++ b/armory/baseline_models/keras/so2sat.py
@@ -1,13 +1,20 @@
+from copy import deepcopy
 from typing import Optional
 
 import numpy as np
-from copy import deepcopy
 import tensorflow as tf
-from tensorflow import slice
-from tensorflow.keras import Sequential, Model
-from tensorflow.keras.layers import Dense, Flatten, Conv2D
-from tensorflow.keras.layers import MaxPooling2D, Input, concatenate, Lambda
 from art.estimators.classification import KerasClassifier
+from tensorflow import slice
+from tensorflow.keras import Model, Sequential
+from tensorflow.keras.layers import (
+    Conv2D,
+    Dense,
+    Flatten,
+    Input,
+    Lambda,
+    MaxPooling2D,
+    concatenate,
+)
 from tensorflow.keras.optimizers import SGD
 
 tf.compat.v1.disable_eager_execution()

--- a/armory/baseline_models/pytorch/carla_goturn.py
+++ b/armory/baseline_models/pytorch/carla_goturn.py
@@ -1,8 +1,8 @@
 from typing import Optional
 
+from art.estimators.object_tracking import PyTorchGoturn
 import numpy as np
 import torch
-from art.estimators.object_tracking import PyTorchGoturn
 
 from armory.utils.external_repo import ExternalRepoImport
 

--- a/armory/baseline_models/pytorch/carla_goturn.py
+++ b/armory/baseline_models/pytorch/carla_goturn.py
@@ -1,8 +1,8 @@
 from typing import Optional
 
-from art.estimators.object_tracking import PyTorchGoturn
 import numpy as np
 import torch
+from art.estimators.object_tracking import PyTorchGoturn
 
 from armory.utils.external_repo import ExternalRepoImport
 

--- a/armory/baseline_models/pytorch/carla_mot_frcnn_byte.py
+++ b/armory/baseline_models/pytorch/carla_mot_frcnn_byte.py
@@ -5,9 +5,9 @@ detector with a PyTorch Faster-RCNN Resnet50-FPN object detector
 import dataclasses
 from typing import List, Optional
 
+from art.estimators.object_detection import PyTorchFasterRCNN
 import numpy as np
 import torch
-from art.estimators.object_detection import PyTorchFasterRCNN
 from torchvision import models
 from yolox.tracker.byte_tracker import (  # clone from https://github.com/ifzhang/ByteTrack
     BYTETracker,

--- a/armory/baseline_models/pytorch/carla_mot_frcnn_byte.py
+++ b/armory/baseline_models/pytorch/carla_mot_frcnn_byte.py
@@ -2,16 +2,16 @@
 Modified ByteTrack (https://arxiv.org/pdf/2110.06864.pdf) by replacing YOLOX object
 detector with a PyTorch Faster-RCNN Resnet50-FPN object detector
 """
-from typing import Optional, List
+import dataclasses
+from typing import List, Optional
 
 import numpy as np
-from art.estimators.object_detection import PyTorchFasterRCNN
 import torch
+from art.estimators.object_detection import PyTorchFasterRCNN
 from torchvision import models
-import dataclasses
-from yolox.tracker.byte_tracker import (
+from yolox.tracker.byte_tracker import (  # clone from https://github.com/ifzhang/ByteTrack
     BYTETracker,
-)  # clone from https://github.com/ifzhang/ByteTrack
+)
 
 DEVICE = torch.device("cuda" if torch.cuda.is_available() else "cpu")
 

--- a/armory/baseline_models/pytorch/carla_multimodality_object_detection_frcnn.py
+++ b/armory/baseline_models/pytorch/carla_multimodality_object_detection_frcnn.py
@@ -1,14 +1,13 @@
 """
 PyTorch Faster-RCNN Resnet50-FPN object detection model
 """
+from collections import OrderedDict
 from typing import Optional
 
-from art.estimators.object_detection import PyTorchFasterRCNN
 import torch
+from art.estimators.object_detection import PyTorchFasterRCNN
 from torchvision.models.detection.backbone_utils import resnet_fpn_backbone
 from torchvision.models.detection.faster_rcnn import FasterRCNN
-
-from collections import OrderedDict
 
 DEVICE = torch.device("cuda" if torch.cuda.is_available() else "cpu")
 

--- a/armory/baseline_models/pytorch/carla_multimodality_object_detection_frcnn.py
+++ b/armory/baseline_models/pytorch/carla_multimodality_object_detection_frcnn.py
@@ -4,8 +4,8 @@ PyTorch Faster-RCNN Resnet50-FPN object detection model
 from collections import OrderedDict
 from typing import Optional
 
-import torch
 from art.estimators.object_detection import PyTorchFasterRCNN
+import torch
 from torchvision.models.detection.backbone_utils import resnet_fpn_backbone
 from torchvision.models.detection.faster_rcnn import FasterRCNN
 

--- a/armory/baseline_models/pytorch/carla_multimodality_object_detection_frcnn_robust_fusion.py
+++ b/armory/baseline_models/pytorch/carla_multimodality_object_detection_frcnn_robust_fusion.py
@@ -1,15 +1,14 @@
 """
 PyTorch Faster-RCNN Resnet50-FPN object detection model
 """
+from collections import OrderedDict
 from typing import Optional
 
-from art.estimators.object_detection import PyTorchFasterRCNN
 import torch
 import torch.nn.functional as F
+from art.estimators.object_detection import PyTorchFasterRCNN
 from torchvision.models.detection.backbone_utils import resnet_fpn_backbone
 from torchvision.models.detection.faster_rcnn import FasterRCNN
-
-from collections import OrderedDict
 
 DEVICE = torch.device("cuda" if torch.cuda.is_available() else "cpu")
 

--- a/armory/baseline_models/pytorch/carla_multimodality_object_detection_frcnn_robust_fusion.py
+++ b/armory/baseline_models/pytorch/carla_multimodality_object_detection_frcnn_robust_fusion.py
@@ -4,9 +4,9 @@ PyTorch Faster-RCNN Resnet50-FPN object detection model
 from collections import OrderedDict
 from typing import Optional
 
+from art.estimators.object_detection import PyTorchFasterRCNN
 import torch
 import torch.nn.functional as F
-from art.estimators.object_detection import PyTorchFasterRCNN
 from torchvision.models.detection.backbone_utils import resnet_fpn_backbone
 from torchvision.models.detection.faster_rcnn import FasterRCNN
 

--- a/armory/baseline_models/pytorch/carla_single_modality_object_detection_frcnn.py
+++ b/armory/baseline_models/pytorch/carla_single_modality_object_detection_frcnn.py
@@ -3,8 +3,8 @@ PyTorch Faster-RCNN Resnet50-FPN object detection model
 """
 from typing import Optional
 
-import torch
 from art.estimators.object_detection import PyTorchFasterRCNN
+import torch
 from torchvision import models
 
 DEVICE = torch.device("cuda" if torch.cuda.is_available() else "cpu")

--- a/armory/baseline_models/pytorch/carla_single_modality_object_detection_frcnn.py
+++ b/armory/baseline_models/pytorch/carla_single_modality_object_detection_frcnn.py
@@ -3,8 +3,8 @@ PyTorch Faster-RCNN Resnet50-FPN object detection model
 """
 from typing import Optional
 
-from art.estimators.object_detection import PyTorchFasterRCNN
 import torch
+from art.estimators.object_detection import PyTorchFasterRCNN
 from torchvision import models
 
 DEVICE = torch.device("cuda" if torch.cuda.is_available() else "cpu")

--- a/armory/baseline_models/pytorch/cifar.py
+++ b/armory/baseline_models/pytorch/cifar.py
@@ -3,10 +3,10 @@ CNN model for 32x32x3 image classification
 """
 from typing import Optional
 
+from art.estimators.classification import PyTorchClassifier
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
-from art.estimators.classification import PyTorchClassifier
 
 DEVICE = torch.device("cuda" if torch.cuda.is_available() else "cpu")
 

--- a/armory/baseline_models/pytorch/cifar.py
+++ b/armory/baseline_models/pytorch/cifar.py
@@ -8,7 +8,6 @@ import torch.nn as nn
 import torch.nn.functional as F
 from art.estimators.classification import PyTorchClassifier
 
-
 DEVICE = torch.device("cuda" if torch.cuda.is_available() else "cpu")
 
 

--- a/armory/baseline_models/pytorch/hubert_asr_large.py
+++ b/armory/baseline_models/pytorch/hubert_asr_large.py
@@ -5,10 +5,10 @@ Updated model for LibriSpeech ASR that doesn't require extra dependencies
 # https://pytorch.org/audio/stable/pipelines.html#torchaudio.pipelines.Wav2Vec2Bundle
 from typing import List
 
+from art.estimators.pytorch import PyTorchEstimator
 import numpy as np
 import torch
 import torchaudio
-from art.estimators.pytorch import PyTorchEstimator
 
 # from torchaudio.models.decoder import ctc_decoder
 

--- a/armory/baseline_models/pytorch/hubert_asr_large.py
+++ b/armory/baseline_models/pytorch/hubert_asr_large.py
@@ -8,10 +8,9 @@ from typing import List
 import numpy as np
 import torch
 import torchaudio
+from art.estimators.pytorch import PyTorchEstimator
 
 # from torchaudio.models.decoder import ctc_decoder
-
-from art.estimators.pytorch import PyTorchEstimator
 
 
 DEVICE = torch.device("cuda" if torch.cuda.is_available() else "cpu")

--- a/armory/baseline_models/pytorch/micronnet_gtsrb.py
+++ b/armory/baseline_models/pytorch/micronnet_gtsrb.py
@@ -1,6 +1,6 @@
+from art.estimators.classification import PyTorchClassifier
 import torch
 import torch.nn as nn
-from art.estimators.classification import PyTorchClassifier
 
 nclasses = 43  # GTSRB has 43 classes
 

--- a/armory/baseline_models/pytorch/micronnet_gtsrb_bean_regularization.py
+++ b/armory/baseline_models/pytorch/micronnet_gtsrb_bean_regularization.py
@@ -1,8 +1,8 @@
 from typing import Optional
 
 import torch
-import torch.nn as nn
 from torch import Tensor
+import torch.nn as nn
 
 DEVICE = torch.device("cuda" if torch.cuda.is_available() else "cpu")
 

--- a/armory/baseline_models/pytorch/micronnet_gtsrb_bean_regularization.py
+++ b/armory/baseline_models/pytorch/micronnet_gtsrb_bean_regularization.py
@@ -1,8 +1,8 @@
+from typing import Optional
+
 import torch
 import torch.nn as nn
 from torch import Tensor
-
-from typing import Optional
 
 DEVICE = torch.device("cuda" if torch.cuda.is_available() else "cpu")
 

--- a/armory/baseline_models/pytorch/mnist.py
+++ b/armory/baseline_models/pytorch/mnist.py
@@ -3,10 +3,10 @@ CNN model for 28x28x1 image classification
 """
 from typing import Optional
 
+from art.estimators.classification import PyTorchClassifier
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
-from art.estimators.classification import PyTorchClassifier
 
 DEVICE = torch.device("cuda" if torch.cuda.is_available() else "cpu")
 

--- a/armory/baseline_models/pytorch/resnet18.py
+++ b/armory/baseline_models/pytorch/resnet18.py
@@ -3,10 +3,9 @@ ResNet18 CNN model for NxNx3 image classification
 """
 from typing import Optional
 
-from art.estimators.classification import PyTorchClassifier
 import torch
+from art.estimators.classification import PyTorchClassifier
 from torchvision import models
-
 
 DEVICE = torch.device("cuda" if torch.cuda.is_available() else "cpu")
 

--- a/armory/baseline_models/pytorch/resnet18.py
+++ b/armory/baseline_models/pytorch/resnet18.py
@@ -3,8 +3,8 @@ ResNet18 CNN model for NxNx3 image classification
 """
 from typing import Optional
 
-import torch
 from art.estimators.classification import PyTorchClassifier
+import torch
 from torchvision import models
 
 DEVICE = torch.device("cuda" if torch.cuda.is_available() else "cpu")

--- a/armory/baseline_models/pytorch/resnet18_bean_regularization.py
+++ b/armory/baseline_models/pytorch/resnet18_bean_regularization.py
@@ -4,9 +4,8 @@ ResNet18 model to be used for data interpretations
 from typing import Optional
 
 import torch
-from torchvision.models.resnet import ResNet as resnet
 from torchvision.models.resnet import BasicBlock
-
+from torchvision.models.resnet import ResNet as resnet
 
 DEVICE = torch.device("cuda" if torch.cuda.is_available() else "cpu")
 

--- a/armory/baseline_models/pytorch/resnet50.py
+++ b/armory/baseline_models/pytorch/resnet50.py
@@ -3,8 +3,8 @@ ResNet50 CNN model for 244x244x3 image classification
 """
 from typing import Optional
 
-import torch
 from art.estimators.classification import PyTorchClassifier
+import torch
 from torchvision import models
 
 DEVICE = torch.device("cuda" if torch.cuda.is_available() else "cpu")

--- a/armory/baseline_models/pytorch/resnet50.py
+++ b/armory/baseline_models/pytorch/resnet50.py
@@ -3,10 +3,9 @@ ResNet50 CNN model for 244x244x3 image classification
 """
 from typing import Optional
 
-from art.estimators.classification import PyTorchClassifier
 import torch
+from art.estimators.classification import PyTorchClassifier
 from torchvision import models
-
 
 DEVICE = torch.device("cuda" if torch.cuda.is_available() else "cpu")
 

--- a/armory/baseline_models/pytorch/sincnet.py
+++ b/armory/baseline_models/pytorch/sincnet.py
@@ -6,9 +6,9 @@ Adapted from: https://github.com/mravanelli/SincNet
 """
 from typing import Optional
 
+from art.estimators.classification import PyTorchClassifier
 import numpy as np
 import torch
-from art.estimators.classification import PyTorchClassifier
 from torch import nn
 
 from armory.utils.external_repo import ExternalRepoImport

--- a/armory/baseline_models/pytorch/sincnet.py
+++ b/armory/baseline_models/pytorch/sincnet.py
@@ -6,9 +6,9 @@ Adapted from: https://github.com/mravanelli/SincNet
 """
 from typing import Optional
 
-from art.estimators.classification import PyTorchClassifier
 import numpy as np
 import torch
+from art.estimators.classification import PyTorchClassifier
 from torch import nn
 
 from armory.utils.external_repo import ExternalRepoImport

--- a/armory/baseline_models/pytorch/ucf101_mars.py
+++ b/armory/baseline_models/pytorch/ucf101_mars.py
@@ -4,9 +4,9 @@ Adapted from: https://github.com/craston/MARS
 """
 from typing import Optional, Tuple, Union
 
+from art.estimators.classification import PyTorchClassifier
 import numpy as np
 import torch
-from art.estimators.classification import PyTorchClassifier
 from torch import optim
 
 from armory.utils.external_repo import ExternalRepoImport

--- a/armory/baseline_models/pytorch/ucf101_mars.py
+++ b/armory/baseline_models/pytorch/ucf101_mars.py
@@ -2,11 +2,11 @@
 Model contributed by: MITRE Corporation
 Adapted from: https://github.com/craston/MARS
 """
-from typing import Union, Optional, Tuple
+from typing import Optional, Tuple, Union
 
-from art.estimators.classification import PyTorchClassifier
 import numpy as np
 import torch
+from art.estimators.classification import PyTorchClassifier
 from torch import optim
 
 from armory.utils.external_repo import ExternalRepoImport
@@ -19,7 +19,6 @@ with ExternalRepoImport(
     from MARS.models.model import generate_model
 
 from armory.logs import log
-
 
 DEVICE = torch.device("cuda" if torch.cuda.is_available() else "cpu")
 

--- a/armory/baseline_models/pytorch/xview_frcnn.py
+++ b/armory/baseline_models/pytorch/xview_frcnn.py
@@ -5,8 +5,8 @@ from typing import Optional
 
 import torch
 import torchvision
-from torchvision.models.detection.faster_rcnn import FastRCNNPredictor
 from art.estimators.object_detection import PyTorchFasterRCNN
+from torchvision.models.detection.faster_rcnn import FastRCNNPredictor
 
 DEVICE = torch.device("cuda" if torch.cuda.is_available() else "cpu")
 

--- a/armory/baseline_models/pytorch/xview_frcnn.py
+++ b/armory/baseline_models/pytorch/xview_frcnn.py
@@ -3,9 +3,9 @@ Pytorch Faster-RCNN for xView object detection
 """
 from typing import Optional
 
+from art.estimators.object_detection import PyTorchFasterRCNN
 import torch
 import torchvision
-from art.estimators.object_detection import PyTorchFasterRCNN
 from torchvision.models.detection.faster_rcnn import FastRCNNPredictor
 
 DEVICE = torch.device("cuda" if torch.cuda.is_available() else "cpu")

--- a/armory/baseline_models/tf_graph/audio_resnet50.py
+++ b/armory/baseline_models/tf_graph/audio_resnet50.py
@@ -4,8 +4,8 @@ Resnet for speech commands classification.
 
 from typing import Optional
 
-import tensorflow as tf
 from art.estimators.classification import TensorFlowV2Classifier
+import tensorflow as tf
 from tensorflow import keras
 from tensorflow.keras import losses
 from tensorflow.keras.layers import Lambda

--- a/armory/baseline_models/tf_graph/audio_resnet50.py
+++ b/armory/baseline_models/tf_graph/audio_resnet50.py
@@ -5,11 +5,10 @@ Resnet for speech commands classification.
 from typing import Optional
 
 import tensorflow as tf
+from art.estimators.classification import TensorFlowV2Classifier
+from tensorflow import keras
 from tensorflow.keras import losses
 from tensorflow.keras.layers import Lambda
-from tensorflow import keras
-
-from art.estimators.classification import TensorFlowV2Classifier
 
 
 def get_spectrogram(audio):

--- a/armory/baseline_models/tf_graph/mnist.py
+++ b/armory/baseline_models/tf_graph/mnist.py
@@ -3,8 +3,8 @@ CNN model for 28x28x1 image classification
 """
 import tarfile
 
-import tensorflow.compat.v1 as tf
 from art.estimators.classification import TFClassifier
+import tensorflow.compat.v1 as tf
 
 from armory import paths
 

--- a/armory/baseline_models/tf_graph/mscoco_frcnn.py
+++ b/armory/baseline_models/tf_graph/mscoco_frcnn.py
@@ -5,8 +5,8 @@ TensorFlow1 Detection Model Zoo
 object_detection/g3doc/tf1_detection_zoo.md)
 """
 
-import tensorflow as tf
 from art.estimators.object_detection.tensorflow_faster_rcnn import TensorFlowFasterRCNN
+import tensorflow as tf
 
 tf.compat.v1.disable_eager_execution()
 

--- a/armory/baseline_models/tf_graph/mscoco_frcnn.py
+++ b/armory/baseline_models/tf_graph/mscoco_frcnn.py
@@ -5,8 +5,8 @@ TensorFlow1 Detection Model Zoo
 object_detection/g3doc/tf1_detection_zoo.md)
 """
 
-from art.estimators.object_detection.tensorflow_faster_rcnn import TensorFlowFasterRCNN
 import tensorflow as tf
+from art.estimators.object_detection.tensorflow_faster_rcnn import TensorFlowFasterRCNN
 
 tf.compat.v1.disable_eager_execution()
 

--- a/armory/configuration.py
+++ b/armory/configuration.py
@@ -4,8 +4,8 @@ Utilities for handling the global armory configuration file
 
 import json
 import os
-from collections import defaultdict
 import warnings  # armory.logs initialization depends on this module, use warnings instead
+from collections import defaultdict
 
 
 def get_verify_ssl():

--- a/armory/configuration.py
+++ b/armory/configuration.py
@@ -2,10 +2,10 @@
 Utilities for handling the global armory configuration file
 """
 
+from collections import defaultdict
 import json
 import os
 import warnings  # armory.logs initialization depends on this module, use warnings instead
-from collections import defaultdict
 
 
 def get_verify_ssl():

--- a/armory/data/adversarial/apricot_dev.py
+++ b/armory/data/adversarial/apricot_dev.py
@@ -7,7 +7,7 @@ import os
 import tensorflow.compat.v1 as tf
 import tensorflow_datasets.public_api as tfds
 
-from armory.data.adversarial.apricot_metadata import APRICOT_PATCHES, APRICOT_MODELS
+from armory.data.adversarial.apricot_metadata import APRICOT_MODELS, APRICOT_PATCHES
 
 _CITATION = """
 @misc{braunegg2020apricot,

--- a/armory/data/adversarial/apricot_test.py
+++ b/armory/data/adversarial/apricot_test.py
@@ -7,7 +7,7 @@ import os
 import tensorflow.compat.v1 as tf
 import tensorflow_datasets.public_api as tfds
 
-from armory.data.adversarial.apricot_metadata import APRICOT_PATCHES, APRICOT_MODELS
+from armory.data.adversarial.apricot_metadata import APRICOT_MODELS, APRICOT_PATCHES
 
 _CITATION = """
 @misc{braunegg2020apricot,

--- a/armory/data/adversarial/carla_mot_dev.py
+++ b/armory/data/adversarial/carla_mot_dev.py
@@ -1,12 +1,12 @@
 """carla_mot_dev dataset."""
 
-import os
 import glob
+import os
 import re
+
 import numpy as np
 import tensorflow.compat.v1 as tf
 import tensorflow_datasets as tfds
-
 
 _DESCRIPTION = """
 Synthetic single modality dataset generated using CARLA (https://carla.org).

--- a/armory/data/adversarial/carla_obj_det_dev.py
+++ b/armory/data/adversarial/carla_obj_det_dev.py
@@ -1,9 +1,9 @@
 """carla_obj_det_dev dataset."""
 
 import collections
+from copy import deepcopy
 import json
 import os
-from copy import deepcopy
 
 import numpy as np
 import tensorflow.compat.v1 as tf

--- a/armory/data/adversarial/carla_obj_det_dev.py
+++ b/armory/data/adversarial/carla_obj_det_dev.py
@@ -4,8 +4,8 @@ import collections
 import json
 import os
 from copy import deepcopy
-import numpy as np
 
+import numpy as np
 import tensorflow.compat.v1 as tf
 import tensorflow_datasets as tfds
 

--- a/armory/data/adversarial/carla_obj_det_test.py
+++ b/armory/data/adversarial/carla_obj_det_test.py
@@ -1,9 +1,9 @@
 """carla_obj_det_test dataset."""
 
 import collections
+from copy import deepcopy
 import json
 import os
-from copy import deepcopy
 
 import numpy as np
 import tensorflow.compat.v1 as tf

--- a/armory/data/adversarial/carla_obj_det_test.py
+++ b/armory/data/adversarial/carla_obj_det_test.py
@@ -4,8 +4,8 @@ import collections
 import json
 import os
 from copy import deepcopy
-import numpy as np
 
+import numpy as np
 import tensorflow.compat.v1 as tf
 import tensorflow_datasets as tfds
 

--- a/armory/data/adversarial/carla_over_obj_det_dev.py
+++ b/armory/data/adversarial/carla_over_obj_det_dev.py
@@ -1,9 +1,9 @@
 """carla_obj_det_dev dataset."""
 
 import collections
+from copy import deepcopy
 import json
 import os
-from copy import deepcopy
 
 import numpy as np
 import tensorflow.compat.v1 as tf

--- a/armory/data/adversarial/carla_over_obj_det_dev.py
+++ b/armory/data/adversarial/carla_over_obj_det_dev.py
@@ -4,8 +4,8 @@ import collections
 import json
 import os
 from copy import deepcopy
-import numpy as np
 
+import numpy as np
 import tensorflow.compat.v1 as tf
 import tensorflow_datasets as tfds
 

--- a/armory/data/adversarial/carla_video_tracking_dev.py
+++ b/armory/data/adversarial/carla_video_tracking_dev.py
@@ -3,10 +3,10 @@
 import glob
 import os
 
+from PIL import Image
 import numpy as np
 import tensorflow.compat.v1 as tf
 import tensorflow_datasets as tfds
-from PIL import Image
 
 _DESCRIPTION = """
 Synthetic single modality dataset generated using CARLA (https://carla.org).

--- a/armory/data/adversarial/carla_video_tracking_dev.py
+++ b/armory/data/adversarial/carla_video_tracking_dev.py
@@ -1,11 +1,12 @@
 """carla_video_tracking_dev dataset."""
 
-import os
 import glob
+import os
+
 import numpy as np
-from PIL import Image
 import tensorflow.compat.v1 as tf
 import tensorflow_datasets as tfds
+from PIL import Image
 
 _DESCRIPTION = """
 Synthetic single modality dataset generated using CARLA (https://carla.org).

--- a/armory/data/adversarial/carla_video_tracking_test.py
+++ b/armory/data/adversarial/carla_video_tracking_test.py
@@ -3,10 +3,10 @@
 import glob
 import os
 
+from PIL import Image
 import numpy as np
 import tensorflow.compat.v1 as tf
 import tensorflow_datasets as tfds
-from PIL import Image
 
 _DESCRIPTION = """
 Synthetic single modality dataset generated using CARLA (https://carla.org).

--- a/armory/data/adversarial/carla_video_tracking_test.py
+++ b/armory/data/adversarial/carla_video_tracking_test.py
@@ -1,12 +1,12 @@
 """carla_video_tracking_test dataset."""
 
-import os
 import glob
+import os
+
 import numpy as np
-from PIL import Image
 import tensorflow.compat.v1 as tf
 import tensorflow_datasets as tfds
-
+from PIL import Image
 
 _DESCRIPTION = """
 Synthetic single modality dataset generated using CARLA (https://carla.org).

--- a/armory/data/adversarial/gtsrb_bh_poison_micronnet.py
+++ b/armory/data/adversarial/gtsrb_bh_poison_micronnet.py
@@ -2,9 +2,9 @@
 TensorFlow poison dataset for GTSRB
 """
 
+import numpy as np
 import tensorflow.compat.v2 as tf
 import tensorflow_datasets.public_api as tfds
-import numpy as np
 
 _DESCRIPTION = """\
 GTSRB poison sample dataset for micronNet, poisoning class 1 with custom bullet-hole pattern

--- a/armory/data/adversarial/librispeech_adversarial.py
+++ b/armory/data/adversarial/librispeech_adversarial.py
@@ -2,10 +2,10 @@
 TensorFlow Dataset for adversarial librispeech
 """
 
-import tensorflow.compat.v2 as tf
-import tensorflow_datasets.public_api as tfds
 import os
 
+import tensorflow.compat.v2 as tf
+import tensorflow_datasets.public_api as tfds
 
 _DESCRIPTION = """\
 LibriSpeech-dev-clean adversarial audio dataset for SincNet

--- a/armory/data/adversarial/resisc45_densenet121_univpatch_and_univperturbation_adversarial_224x224.py
+++ b/armory/data/adversarial/resisc45_densenet121_univpatch_and_univperturbation_adversarial_224x224.py
@@ -1,11 +1,10 @@
 """
 TensorFlow Dataset for resisc45 attacked by Adversarial Patch with adv/clean splits
 """
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
+from __future__ import absolute_import, division, print_function
 
 import os
+
 import tensorflow.compat.v2 as tf
 import tensorflow_datasets.public_api as tfds
 

--- a/armory/data/adversarial/ucf101_mars_perturbation_and_patch_adversarial_112x112.py
+++ b/armory/data/adversarial/ucf101_mars_perturbation_and_patch_adversarial_112x112.py
@@ -3,9 +3,7 @@ UFC101 action recognition adversarial dataset generated using
 perturbation and patch attacks
 """
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
+from __future__ import absolute_import, division, print_function
 
 import os
 

--- a/armory/data/adversarial_datasets.py
+++ b/armory/data/adversarial_datasets.py
@@ -4,29 +4,29 @@ Adversarial datasets
 
 from typing import Callable
 
-import tensorflow as tf
 import numpy as np
+import tensorflow as tf
 
 from armory.data import datasets
-from armory.data.adversarial import (  # noqa: F401
-    imagenet_adversarial as IA,
-    librispeech_adversarial as LA,
-    resisc45_densenet121_univpatch_and_univperturbation_adversarial_224x224,
-    ucf101_mars_perturbation_and_patch_adversarial_112x112,
-    gtsrb_bh_poison_micronnet,
-    apricot_dev,
-    apricot_test,
+from armory.data.adversarial import apricot_dev, apricot_test
+from armory.data.adversarial import carla_mot_dev as cmotd
+from armory.data.adversarial import carla_obj_det_dev as codd
+from armory.data.adversarial import carla_obj_det_test as codt
+from armory.data.adversarial import carla_over_obj_det_dev as coodd
+from armory.data.adversarial import carla_video_tracking_dev as cvtd
+from armory.data.adversarial import carla_video_tracking_test as cvtt
+from armory.data.adversarial import (
     dapricot_dev,
     dapricot_test,
-    carla_obj_det_dev as codd,
-    carla_obj_det_test as codt,
-    carla_over_obj_det_dev as coodd,
-    carla_video_tracking_dev as cvtd,
-    carla_video_tracking_test as cvtt,
-    carla_mot_dev as cmotd,
+    gtsrb_bh_poison_micronnet,
+)
+from armory.data.adversarial import imagenet_adversarial as IA  # noqa: F401
+from armory.data.adversarial import librispeech_adversarial as LA
+from armory.data.adversarial import (
+    resisc45_densenet121_univpatch_and_univperturbation_adversarial_224x224,
+    ucf101_mars_perturbation_and_patch_adversarial_112x112,
 )
 from armory.data.adversarial.apricot_metadata import ADV_PATCH_MAGIC_NUMBER_LABEL_ID
-
 
 imagenet_adversarial_context = datasets.ImageContext(x_shape=(224, 224, 3))
 librispeech_adversarial_context = datasets.AudioContext(

--- a/armory/data/adversarial_datasets.py
+++ b/armory/data/adversarial_datasets.py
@@ -8,24 +8,6 @@ import numpy as np
 import tensorflow as tf
 
 from armory.data import datasets
-from armory.data.adversarial import apricot_dev, apricot_test
-from armory.data.adversarial import carla_mot_dev as cmotd
-from armory.data.adversarial import carla_obj_det_dev as codd
-from armory.data.adversarial import carla_obj_det_test as codt
-from armory.data.adversarial import carla_over_obj_det_dev as coodd
-from armory.data.adversarial import carla_video_tracking_dev as cvtd
-from armory.data.adversarial import carla_video_tracking_test as cvtt
-from armory.data.adversarial import (
-    dapricot_dev,
-    dapricot_test,
-    gtsrb_bh_poison_micronnet,
-)
-from armory.data.adversarial import imagenet_adversarial as IA  # noqa: F401
-from armory.data.adversarial import librispeech_adversarial as LA
-from armory.data.adversarial import (
-    resisc45_densenet121_univpatch_and_univperturbation_adversarial_224x224,
-    ucf101_mars_perturbation_and_patch_adversarial_112x112,
-)
 from armory.data.adversarial.apricot_metadata import ADV_PATCH_MAGIC_NUMBER_LABEL_ID
 
 imagenet_adversarial_context = datasets.ImageContext(x_shape=(224, 224, 3))

--- a/armory/data/datasets.py
+++ b/armory/data/datasets.py
@@ -13,11 +13,11 @@ import os
 import re
 from typing import Callable, List, Tuple, Union
 
+from PIL import Image, ImageOps
+from art.data_generators import DataGenerator
 import numpy as np
 import tensorflow as tf
 import tensorflow_datasets as tfds
-from art.data_generators import DataGenerator
-from PIL import Image, ImageOps
 
 from armory import paths
 from armory.data.carla_object_detection import carla_obj_det_train as codt  # noqa: F401

--- a/armory/data/datasets.py
+++ b/armory/data/datasets.py
@@ -11,35 +11,33 @@ The 'downloads' subdirectory under <dataset_dir> is reserved for caching.
 import json
 import os
 import re
-from typing import Callable, Union, Tuple, List
+from typing import Callable, List, Tuple, Union
 
 import numpy as np
-from armory.logs import log
-from PIL import ImageOps, Image
-
 import tensorflow as tf
 import tensorflow_datasets as tfds
 from art.data_generators import DataGenerator
+from PIL import Image, ImageOps
 
-from armory.data.utils import (
-    download_verify_dataset_cache,
-    _read_validate_scenario_config,
-    add_checksums_dir,
-)
 from armory import paths
-from armory.data.librispeech import librispeech_dev_clean_split  # noqa: F401
-from armory.data.librispeech import librispeech_full as lf  # noqa: F401
-from armory.data.resisc45 import resisc45_split  # noqa: F401
-from armory.data.resisc10 import resisc10_poison  # noqa: F401
-from armory.data.ucf101 import ucf101_clean as uc  # noqa: F401
-from armory.data.xview import xview as xv  # noqa: F401
-from armory.data.german_traffic_sign import german_traffic_sign as gtsrb  # noqa: F401
-from armory.data.digit import digit as digit_tfds  # noqa: F401
 from armory.data.carla_object_detection import carla_obj_det_train as codt  # noqa: F401
 from armory.data.carla_overhead_object_detection import (  # noqa: F401
     carla_over_obj_det_train as coodt,
 )
-
+from armory.data.digit import digit as digit_tfds  # noqa: F401
+from armory.data.german_traffic_sign import german_traffic_sign as gtsrb  # noqa: F401
+from armory.data.librispeech import librispeech_dev_clean_split  # noqa: F401
+from armory.data.librispeech import librispeech_full as lf  # noqa: F401
+from armory.data.resisc10 import resisc10_poison  # noqa: F401
+from armory.data.resisc45 import resisc45_split  # noqa: F401
+from armory.data.ucf101 import ucf101_clean as uc  # noqa: F401
+from armory.data.utils import (
+    _read_validate_scenario_config,
+    add_checksums_dir,
+    download_verify_dataset_cache,
+)
+from armory.data.xview import xview as xv  # noqa: F401
+from armory.logs import log
 
 os.environ["KMP_WARNINGS"] = "0"
 

--- a/armory/data/digit/digit.py
+++ b/armory/data/digit/digit.py
@@ -7,7 +7,6 @@ import os
 
 import tensorflow_datasets.public_api as tfds
 
-
 _SAMPLE_RATE = 8000
 _MIN_LENGTH = 1148
 _MAX_LENGTH = 18262

--- a/armory/data/integrate_tfds.py
+++ b/armory/data/integrate_tfds.py
@@ -4,15 +4,15 @@
 # armory.readthedocs.io
 
 import os
-import sys
 import subprocess
+import sys
 
 import tensorflow_datasets as tfds
 
 from armory import paths
-from armory.data.datasets import _parse_dataset_name, CACHED_CHECKSUMS_DIR
-from armory.data.utils import sha256, upload_file_to_s3
+from armory.data.datasets import CACHED_CHECKSUMS_DIR, _parse_dataset_name
 from armory.data.template_boilerplate import fn_template
+from armory.data.utils import sha256, upload_file_to_s3
 from armory.logs import log
 
 

--- a/armory/data/librispeech/librispeech_full.py
+++ b/armory/data/librispeech/librispeech_full.py
@@ -16,14 +16,11 @@
 # Lint as: python3
 """Librispeech dataset."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
+from __future__ import absolute_import, division, print_function
 
 import os
 
 import tensorflow.compat.v2 as tf
-
 import tensorflow_datasets.public_api as tfds
 
 _CITATION = """\

--- a/armory/data/pytorch_loader.py
+++ b/armory/data/pytorch_loader.py
@@ -1,5 +1,5 @@
-import torch
 import tensorflow as tf
+import torch
 
 
 class TFToTorchGenerator(torch.utils.data.IterableDataset):

--- a/armory/data/resisc10/resisc10_poison.py
+++ b/armory/data/resisc10/resisc10_poison.py
@@ -1,9 +1,9 @@
 """resisc10_poison dataset."""
 
 import os
-import tensorflow_datasets as tfds
-import tensorflow as tf
 
+import tensorflow as tf
+import tensorflow_datasets as tfds
 
 _DESCRIPTION = """
 Subset of NWPU-RESISC45 image dataset with 10 classes, each class containing 700 images,

--- a/armory/data/resisc45/resisc45_dataset_partition.py
+++ b/armory/data/resisc45/resisc45_dataset_partition.py
@@ -11,7 +11,6 @@ import shutil
 
 from armory import paths
 
-
 LABELS = [
     "airplane",
     "airport",

--- a/armory/data/ucf101/ucf101_clean.py
+++ b/armory/data/ucf101/ucf101_clean.py
@@ -1,7 +1,6 @@
 """UCF101 with video compression artifacts removed"""
 
 import tensorflow_datasets.public_api as tfds
-
 from tensorflow_datasets.video import ucf101
 
 

--- a/armory/data/utils.py
+++ b/armory/data/utils.py
@@ -12,10 +12,10 @@ import subprocess
 import tarfile
 
 import boto3
-import requests
 from botocore import UNSIGNED
 from botocore.client import Config
 from botocore.exceptions import ClientError
+import requests
 from tqdm import tqdm
 
 from armory import paths

--- a/armory/data/utils.py
+++ b/armory/data/utils.py
@@ -3,25 +3,25 @@ Utils for data processing
 
 """
 import hashlib
-import tarfile
-import os
-import shutil
-import random
-import string
 import json
+import os
+import random
+import shutil
+import string
 import subprocess
+import tarfile
 
 import boto3
+import requests
 from botocore import UNSIGNED
 from botocore.client import Config
 from botocore.exceptions import ClientError
-import requests
 from tqdm import tqdm
 
 from armory import paths
-from armory.logs import log, is_progress
-from armory.data.progress_percentage import ProgressPercentage, ProgressPercentageUpload
 from armory.configuration import get_verify_ssl
+from armory.data.progress_percentage import ProgressPercentage, ProgressPercentageUpload
+from armory.logs import is_progress, log
 
 CHECKSUMS_DIRS = []
 

--- a/armory/docker/host_management.py
+++ b/armory/docker/host_management.py
@@ -1,5 +1,5 @@
-import subprocess
 import os
+import subprocess
 
 from armory.logs import log
 

--- a/armory/docker/images.py
+++ b/armory/docker/images.py
@@ -2,13 +2,13 @@
 Enables programmatic accessing of most recent docker images
 """
 
-import docker
-import docker.errors
 import requests
 
 import armory
+import docker
+import docker.errors
+from armory.logs import is_progress, log
 from armory.utils import version
-from armory.logs import log, is_progress
 
 TAG = version.to_docker_tag(armory.__version__)
 log.trace(f"armory.__version__: {armory.__version__}")

--- a/armory/docker/images.py
+++ b/armory/docker/images.py
@@ -5,10 +5,10 @@ Enables programmatic accessing of most recent docker images
 import requests
 
 import armory
-import docker
-import docker.errors
 from armory.logs import is_progress, log
 from armory.utils import version
+import docker
+import docker.errors
 
 TAG = version.to_docker_tag(armory.__version__)
 log.trace(f"armory.__version__: {armory.__version__}")

--- a/armory/docker/management.py
+++ b/armory/docker/management.py
@@ -3,9 +3,8 @@ Docker orchestration managers for ARMORY.
 """
 
 
-import docker
-
 import armory
+import docker
 from armory import paths
 from armory.logs import log
 

--- a/armory/docker/management.py
+++ b/armory/docker/management.py
@@ -4,9 +4,9 @@ Docker orchestration managers for ARMORY.
 
 
 import armory
-import docker
 from armory import paths
 from armory.logs import log
+import docker
 
 
 class ArmoryInstance(object):

--- a/armory/eval/evaluator.py
+++ b/armory/eval/evaluator.py
@@ -2,24 +2,23 @@
 Evaluators control launching of ARMORY evaluations.
 """
 import base64
-import os
-import json
-import shutil
-import time
 import datetime
+import json
+import os
+import shutil
 import sys
+import time
 
 import requests
 
 import armory
+from armory import environment, paths
 from armory.configuration import load_global_config
 from armory.docker import images
-from armory.docker.management import ManagementInstance, ArmoryInstance
 from armory.docker.host_management import HostManagementInstance
+from armory.docker.management import ArmoryInstance, ManagementInstance
+from armory.logs import added_filters, is_debug, log
 from armory.utils.printing import bold, red
-from armory import paths
-from armory import environment
-from armory.logs import log, is_debug, added_filters
 
 
 class Evaluator(object):

--- a/armory/instrument/__init__.py
+++ b/armory/instrument/__init__.py
@@ -1,17 +1,17 @@
 from armory.instrument.config import MetricsLogger
 from armory.instrument.instrument import (
     FileWriter,
-    LogWriter,
-    Hub,
-    Meter,
     GlobalMeter,
+    Hub,
+    LogWriter,
+    Meter,
     MockSink,
     NullWriter,
-    Probe,
     PrintWriter,
+    Probe,
     ResultsWriter,
     Writer,
+    del_globals,
     get_hub,
     get_probe,
-    del_globals,
 )

--- a/armory/instrument/config.py
+++ b/armory/instrument/config.py
@@ -4,15 +4,9 @@ Set up the meters from a standard config file
 
 import numpy as np
 
-from armory.instrument.instrument import (
-    LogWriter,
-    Meter,
-    ResultsWriter,
-    get_hub,
-)
-from armory.logs import log
-
 from armory import metrics
+from armory.instrument.instrument import LogWriter, Meter, ResultsWriter, get_hub
+from armory.logs import log
 
 
 class MetricsLogger:

--- a/armory/instrument/export.py
+++ b/armory/instrument/export.py
@@ -1,12 +1,12 @@
 import abc
+from copy import deepcopy
 import json
 import os
 import pickle
-from copy import deepcopy
 
+from PIL import Image, ImageDraw
 import ffmpeg
 import numpy as np
-from PIL import Image, ImageDraw
 from scipy.io import wavfile
 
 from armory.instrument import Meter

--- a/armory/instrument/export.py
+++ b/armory/instrument/export.py
@@ -1,15 +1,16 @@
-import os
 import abc
-import numpy as np
-import ffmpeg
-import pickle
-from PIL import Image, ImageDraw
-from scipy.io import wavfile
 import json
+import os
+import pickle
 from copy import deepcopy
 
-from armory.logs import log
+import ffmpeg
+import numpy as np
+from PIL import Image, ImageDraw
+from scipy.io import wavfile
+
 from armory.instrument import Meter
+from armory.logs import log
 
 
 class SampleExporter:

--- a/armory/instrument/instrument.py
+++ b/armory/instrument/instrument.py
@@ -40,7 +40,6 @@ import json
 
 from armory import log
 
-
 _PROBES = {}
 _HUB = None
 

--- a/armory/logs.py
+++ b/armory/logs.py
@@ -20,12 +20,13 @@
 # be considered redundant, but I don't expect the near-duplication to be particularly
 # costly.
 
-import sys
 import datetime
-import loguru
-import logging
-from typing import List
 import functools
+import logging
+import sys
+from typing import List
+
+import loguru
 
 log = loguru.logger
 

--- a/armory/metrics/compute.py
+++ b/armory/metrics/compute.py
@@ -2,8 +2,8 @@
 Computational metrics
 """
 
-import contextlib
 import cProfile
+import contextlib
 import io
 import pstats
 import time

--- a/armory/metrics/perturbation.py
+++ b/armory/metrics/perturbation.py
@@ -9,7 +9,6 @@ import numpy as np
 from armory.logs import log
 from armory.metrics.common import MetricNameSpace, as_batch, set_namespace
 
-
 element = MetricNameSpace()
 batch = MetricNameSpace()
 

--- a/armory/metrics/poisoning.py
+++ b/armory/metrics/poisoning.py
@@ -1,9 +1,9 @@
 import copy
 from importlib import import_module
 
+from PIL import Image
 import numpy as np
 import torch
-from PIL import Image
 
 from armory.data.utils import maybe_download_weights_from_s3
 

--- a/armory/metrics/poisoning.py
+++ b/armory/metrics/poisoning.py
@@ -1,12 +1,11 @@
-from importlib import import_module
 import copy
+from importlib import import_module
 
 import numpy as np
-from PIL import Image
 import torch
+from PIL import Image
 
 from armory.data.utils import maybe_download_weights_from_s3
-
 
 # An armory user may request one of these models under 'adhoc'/'explanatory_model'
 EXPLANATORY_MODEL_CONFIGS = explanatory_model_configs = {

--- a/armory/metrics/task.py
+++ b/armory/metrics/task.py
@@ -2,9 +2,9 @@
 Task metrics (comparing y to y_pred)
 """
 
-from collections import Counter
 import functools
 import os
+from collections import Counter
 
 import numpy as np
 
@@ -121,7 +121,7 @@ class Entailment:
             package="transformers",
             dockerimage="twosixarmory/pytorch-deepspeech",
         ):
-            from transformers import AutoTokenizer, AutoModelForSequenceClassification
+            from transformers import AutoModelForSequenceClassification, AutoTokenizer
 
         self.tokenizer = AutoTokenizer.from_pretrained(model_name, cache_dir=cache_dir)
         self.model = AutoModelForSequenceClassification.from_pretrained(
@@ -1553,9 +1553,10 @@ def _dapricot_patch_target_success(y, y_pred, iou_threshold=0.1, conf_threshold=
 class HOTA_metrics:
     def __init__(self, tracked_classes=["pedestrian"]):
         from collections import defaultdict
-        from TrackEval.trackeval.metrics.hota import (
+
+        from TrackEval.trackeval.metrics.hota import (  # TrackEval repo: https://github.com/JonathonLuiten/TrackEval
             HOTA,
-        )  # TrackEval repo: https://github.com/JonathonLuiten/TrackEval
+        )
 
         self.class_name_to_class_id = {"pedestrian": 1, "vehicle": 2}
         self.tracked_classes = tracked_classes
@@ -1581,9 +1582,9 @@ class HOTA_metrics:
                 <timestep> <object_id> <bbox top-left x> <bbox top-left y> <bbox width> <bbox height> <confidence_score=1> <class_id> <visibility=1>
             - tracked_class is a string representing the class for which HOTA is calculated.
         """
-        from TrackEval.trackeval.datasets._base_dataset import (
+        from TrackEval.trackeval.datasets._base_dataset import (  # TrackEval repo: https://github.com/JonathonLuiten/TrackEval
             _BaseDataset,
-        )  # TrackEval repo: https://github.com/JonathonLuiten/TrackEval
+        )
 
         if gt_data.ndim == 3:
             gt_data = gt_data[0]

--- a/armory/metrics/task.py
+++ b/armory/metrics/task.py
@@ -2,9 +2,9 @@
 Task metrics (comparing y to y_pred)
 """
 
+from collections import Counter
 import functools
 import os
-from collections import Counter
 
 import numpy as np
 

--- a/armory/postprocessing/plot.py
+++ b/armory/postprocessing/plot.py
@@ -4,8 +4,8 @@ Plot output json files
 import json
 import os
 
-import numpy as np
 from matplotlib import pyplot as plt
+import numpy as np
 
 from armory.logs import log
 

--- a/armory/postprocessing/plot.py
+++ b/armory/postprocessing/plot.py
@@ -4,8 +4,8 @@ Plot output json files
 import json
 import os
 
-from matplotlib import pyplot as plt
 import numpy as np
+from matplotlib import pyplot as plt
 
 from armory.logs import log
 

--- a/armory/scenarios/audio_asr.py
+++ b/armory/scenarios/audio_asr.py
@@ -5,10 +5,9 @@ Automatic speech recognition scenario
 import numpy as np
 from art.preprocessing.audio import LFilter, LFilterPyTorch
 
-from armory.scenarios.scenario import Scenario
 from armory.instrument.export import AudioExporter
-
 from armory.logs import log
+from armory.scenarios.scenario import Scenario
 
 
 def load_audio_channel(delay, attenuation, pytorch=True):

--- a/armory/scenarios/audio_asr.py
+++ b/armory/scenarios/audio_asr.py
@@ -2,8 +2,8 @@
 Automatic speech recognition scenario
 """
 
-import numpy as np
 from art.preprocessing.audio import LFilter, LFilterPyTorch
+import numpy as np
 
 from armory.instrument.export import AudioExporter
 from armory.logs import log

--- a/armory/scenarios/audio_classification.py
+++ b/armory/scenarios/audio_classification.py
@@ -2,9 +2,9 @@
 General audio classification scenario
 """
 
-from armory.scenarios.scenario import Scenario
-from armory.logs import log
 from armory.instrument.export import AudioExporter
+from armory.logs import log
+from armory.scenarios.scenario import Scenario
 
 
 class AudioClassificationTask(Scenario):

--- a/armory/scenarios/carla_object_detection.py
+++ b/armory/scenarios/carla_object_detection.py
@@ -4,9 +4,9 @@ CARLA object detection
 Scenario Contributor: MITRE Corporation
 """
 
-from armory.scenarios.object_detection import ObjectDetectionTask
 from armory.instrument.export import ObjectDetectionExporter
 from armory.logs import log
+from armory.scenarios.object_detection import ObjectDetectionTask
 
 
 class CarlaObjectDetectionTask(ObjectDetectionTask):

--- a/armory/scenarios/carla_video_tracking.py
+++ b/armory/scenarios/carla_video_tracking.py
@@ -7,8 +7,8 @@ Scenario Contributor: MITRE Corporation
 
 import numpy as np
 
+from armory.instrument.export import ExportMeter, VideoTrackingExporter
 from armory.scenarios.scenario import Scenario
-from armory.instrument.export import VideoTrackingExporter, ExportMeter
 
 
 class CarlaVideoTracking(Scenario):

--- a/armory/scenarios/dapricot_scenario.py
+++ b/armory/scenarios/dapricot_scenario.py
@@ -6,9 +6,9 @@ import copy
 
 import numpy as np
 
-from armory.scenarios.scenario import Scenario
-from armory.logs import log
 from armory.instrument.export import DApricotExporter, ExportMeter
+from armory.logs import log
+from armory.scenarios.scenario import Scenario
 
 
 class ObjectDetectionTask(Scenario):

--- a/armory/scenarios/image_classification.py
+++ b/armory/scenarios/image_classification.py
@@ -4,8 +4,8 @@ General image recognition scenario for image classification and object detection
 
 import numpy as np
 
-from armory.scenarios.scenario import Scenario
 from armory.instrument.export import ImageClassificationExporter
+from armory.scenarios.scenario import Scenario
 
 
 class ImageClassificationTask(Scenario):

--- a/armory/scenarios/main.py
+++ b/armory/scenarios/main.py
@@ -17,14 +17,15 @@ import base64
 import importlib.resources
 import json
 import os
-import pytest
 import time
 
+import pytest
+
 import armory
-from armory import environment, paths, validation, Config
+from armory import Config, environment, paths, validation
+from armory.logs import log, make_logfiles, update_filters
 from armory.utils import config_loading, external_repo
 from armory.utils.configuration import load_config
-from armory.logs import log, update_filters, make_logfiles
 
 
 def _scenario_setup(config: Config) -> None:

--- a/armory/scenarios/multimodal_so2sat_scenario.py
+++ b/armory/scenarios/multimodal_so2sat_scenario.py
@@ -4,11 +4,11 @@ Multimodal image classification, currently designed for So2Sat dataset
 
 import numpy as np
 
-from armory.logs import log
-from armory.instrument import Meter
-from armory.scenarios.scenario import Scenario
 from armory import metrics
+from armory.instrument import Meter
 from armory.instrument.export import So2SatExporter
+from armory.logs import log
+from armory.scenarios.scenario import Scenario
 
 
 class So2SatClassification(Scenario):

--- a/armory/scenarios/object_detection.py
+++ b/armory/scenarios/object_detection.py
@@ -2,12 +2,12 @@
 General object detection scenario
 """
 
-from armory.scenarios.image_classification import ImageClassificationTask
 from armory.instrument.export import (
-    ObjectDetectionExporter,
-    ExportMeter,
     CocoBoxFormatMeter,
+    ExportMeter,
+    ObjectDetectionExporter,
 )
+from armory.scenarios.image_classification import ImageClassificationTask
 
 
 class ObjectDetectionTask(ImageClassificationTask):

--- a/armory/scenarios/outputs.py
+++ b/armory/scenarios/outputs.py
@@ -14,7 +14,6 @@ results.plot("results_figure.png")  # save results as png
 """
 
 import collections
-
 import json
 
 import numpy as np

--- a/armory/scenarios/poison.py
+++ b/armory/scenarios/poison.py
@@ -3,22 +3,21 @@ Base scenario for poisoning, dirty label backdoor
 """
 
 import copy
-from typing import Optional
 import os
 import random
+from typing import Optional
 
 import numpy as np
 from tensorflow.random import set_seed as tf_set_seed
 
 from armory import metrics
-from armory.metrics.poisoning import ExplanatoryModel
+from armory.instrument import GlobalMeter, LogWriter, Meter, ResultsWriter
 from armory.instrument.export import ImageClassificationExporter
+from armory.logs import log
+from armory.metrics.poisoning import ExplanatoryModel
 from armory.scenarios.scenario import Scenario
 from armory.scenarios.utils import to_categorical
 from armory.utils import config_loading
-from armory.logs import log
-
-from armory.instrument import Meter, GlobalMeter, LogWriter, ResultsWriter
 
 
 class DatasetPoisoner:

--- a/armory/scenarios/poisoning_clbd.py
+++ b/armory/scenarios/poisoning_clbd.py
@@ -6,11 +6,10 @@ import copy
 
 import numpy as np
 
-from armory.utils import config_loading
-from armory.scenarios.poison import DatasetPoisoner
-from armory.scenarios.poison import Poison
-from armory.scenarios.utils import to_categorical, from_categorical
 from armory.logs import log
+from armory.scenarios.poison import DatasetPoisoner, Poison
+from armory.scenarios.utils import from_categorical, to_categorical
+from armory.utils import config_loading
 
 
 class CleanDatasetPoisoner:

--- a/armory/scenarios/poisoning_sleeper_agent.py
+++ b/armory/scenarios/poisoning_sleeper_agent.py
@@ -3,10 +3,10 @@ import copy
 import numpy as np
 from PIL import Image
 
-from armory.scenarios.poison import Poison
 from armory.logs import log
-from armory.utils import config_loading
+from armory.scenarios.poison import Poison
 from armory.scenarios.utils import from_categorical
+from armory.utils import config_loading
 
 
 class DatasetPoisonerSleeperAgent:

--- a/armory/scenarios/poisoning_sleeper_agent.py
+++ b/armory/scenarios/poisoning_sleeper_agent.py
@@ -1,7 +1,7 @@
 import copy
 
-import numpy as np
 from PIL import Image
+import numpy as np
 
 from armory.logs import log
 from armory.scenarios.poison import Poison

--- a/armory/scenarios/poisoning_witches_brew.py
+++ b/armory/scenarios/poisoning_witches_brew.py
@@ -1,13 +1,13 @@
-import os
 import copy
+import os
 
 import numpy as np
 
-from armory.scenarios.poison import Poison
-from armory.logs import log
-from armory.utils import config_loading
 from armory import metrics, paths
-from armory.instrument import Meter, GlobalMeter, LogWriter, ResultsWriter
+from armory.instrument import GlobalMeter, LogWriter, Meter, ResultsWriter
+from armory.logs import log
+from armory.scenarios.poison import Poison
+from armory.utils import config_loading
 
 
 class DatasetPoisonerWitchesBrew:

--- a/armory/scenarios/scenario.py
+++ b/armory/scenarios/scenario.py
@@ -11,12 +11,12 @@ from typing import Optional
 from tqdm import tqdm
 
 import armory
-from armory import Config, paths, metrics
-from armory.instrument import get_hub, get_probe, del_globals, MetricsLogger
+from armory import Config, metrics, paths
+from armory.instrument import MetricsLogger, del_globals, get_hub, get_probe
 from armory.instrument.export import ExportMeter, PredictionMeter
+from armory.logs import log
 from armory.metrics import compute
 from armory.utils import config_loading, json_utils
-from armory.logs import log
 
 
 class Scenario:

--- a/armory/scenarios/utils.py
+++ b/armory/scenarios/utils.py
@@ -1,5 +1,5 @@
-from typing import Tuple
 from collections import defaultdict
+from typing import Tuple
 
 import numpy as np
 

--- a/armory/scenarios/video_ucf101_scenario.py
+++ b/armory/scenarios/video_ucf101_scenario.py
@@ -4,8 +4,8 @@ Classifier evaluation within ARMORY
 Scenario Contributor: MITRE Corporation
 """
 
-from armory.scenarios.scenario import Scenario
 from armory.instrument.export import VideoClassificationExporter
+from armory.scenarios.scenario import Scenario
 
 
 class Ucf101(Scenario):

--- a/armory/utils/__init__.py
+++ b/armory/utils/__init__.py
@@ -2,6 +2,4 @@
 ARMORY Utilities
 """
 
-from armory.utils import configuration
-from armory.utils import external_repo
-from armory.utils import printing
+from armory.utils import configuration, external_repo, printing

--- a/armory/utils/config_loading.py
+++ b/armory/utils/config_loading.py
@@ -3,6 +3,7 @@ Helper utilies to load things from armory configuration files.
 """
 
 from importlib import import_module
+
 from armory.logs import log
 
 # import torch before tensorflow to ensure torch.utils.data.DataLoader can utilize
@@ -20,6 +21,9 @@ except ImportError:
         "ART 1.2 support is deprecated and will be removed in ARMORY 0.11. Use ART 1.3"
     )
     from art.classifiers import Classifier
+
+import copy
+
 from art.defences.postprocessor import Postprocessor
 from art.defences.preprocessor import Preprocessor
 from art.defences.trainer import Trainer
@@ -29,7 +33,6 @@ from armory.art_experimental.attacks.sweep import SweepAttack
 from armory.data.datasets import ArmoryDataGenerator, EvalGenerator
 from armory.data.utils import maybe_download_weights_from_s3
 from armory.utils import labels
-import copy
 
 
 def load(sub_config):

--- a/armory/utils/configuration.py
+++ b/armory/utils/configuration.py
@@ -8,7 +8,6 @@ import sys
 
 import jsonschema
 
-
 DEFAULT_SCHEMA = os.path.join(os.path.dirname(__file__), "config_schema.json")
 
 

--- a/armory/utils/external_repo.py
+++ b/armory/utils/external_repo.py
@@ -3,10 +3,10 @@ Utils to pull external repos for evaluation
 """
 import contextlib
 import os
-import tarfile
 import shutil
 import sys
-from typing import Union, List
+import tarfile
+from typing import List, Union
 
 import requests
 

--- a/armory/utils/labels.py
+++ b/armory/utils/labels.py
@@ -6,7 +6,6 @@ import importlib
 
 import numpy as np
 
-
 # Targeters assume a numpy 1D array as input to generate
 
 

--- a/armory/utils/typedef.py
+++ b/armory/utils/typedef.py
@@ -6,8 +6,7 @@ Documentation:
 
 """
 
-from typing import Dict, Any
-
+from typing import Any, Dict
 
 # Used for JSON-like configuration specification.
 Config = Dict[str, Any]

--- a/armory/utils/version.py
+++ b/armory/utils/version.py
@@ -13,9 +13,9 @@ which is a bit ungainly.
 
 import functools
 import os
+from pathlib import Path
 import re
 import site
-from pathlib import Path
 
 import setuptools_scm
 

--- a/armory/utils/version.py
+++ b/armory/utils/version.py
@@ -11,13 +11,13 @@ which also have a commit count and date in them like 1.0.1.dev2+g0c5ffd9.d202203
 which is a bit ungainly.
 """
 
+import functools
 import os
 import re
 import site
-import functools
-import setuptools_scm
-
 from pathlib import Path
+
+import setuptools_scm
 
 try:
     from importlib import metadata
@@ -26,7 +26,6 @@ except ImportError:
     import importlib_metadata as metadata  # noqa
 
 from armory.logs import log
-
 
 PYPI_PACKAGE_NAME = "armory-testbed"
 

--- a/armory/validation/test_config/test_model.py
+++ b/armory/validation/test_config/test_model.py
@@ -1,11 +1,12 @@
-import warnings
-import numpy as np
 import json
+import warnings
+
+import numpy as np
+from art.estimators.classification.classifier import ClassifierMixin
+from art.estimators.object_detection import ObjectDetectorMixin
+from art.estimators.speech_recognition import SpeechRecognizerMixin
 
 from armory.utils.config_loading import load_model
-from art.estimators.classification.classifier import ClassifierMixin
-from art.estimators.speech_recognition import SpeechRecognizerMixin
-from art.estimators.object_detection import ObjectDetectorMixin
 
 
 class TestModel:

--- a/armory/validation/test_config/test_model.py
+++ b/armory/validation/test_config/test_model.py
@@ -1,10 +1,10 @@
 import json
 import warnings
 
-import numpy as np
 from art.estimators.classification.classifier import ClassifierMixin
 from art.estimators.object_detection import ObjectDetectorMixin
 from art.estimators.speech_recognition import SpeechRecognizerMixin
+import numpy as np
 
 from armory.utils.config_loading import load_model
 

--- a/docker/build.py
+++ b/docker/build.py
@@ -1,9 +1,8 @@
 import argparse
-from pathlib import Path
 import shutil
 import subprocess
 import sys
-
+from pathlib import Path
 
 script_dir = Path(__file__).parent
 root_dir = script_dir.parent

--- a/docker/build.py
+++ b/docker/build.py
@@ -1,8 +1,8 @@
 import argparse
+from pathlib import Path
 import shutil
 import subprocess
 import sys
-from pathlib import Path
 
 script_dir = Path(__file__).parent
 root_dir = script_dir.parent

--- a/docs/style.md
+++ b/docs/style.md
@@ -36,6 +36,10 @@ yamllint --no-warnings
 
 Our repo-specific configuration for yamllint is found in `.yamllint`.
 
+We use [isort](https://pycqa.github.io/isort/) to sort Python imports.
+
+    isort --profile black *
+
 ### Pre-commit Hooks
 
 If you want those tools to run automatically before each commit, run:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -224,3 +224,4 @@ verbose           = true
 
 [tool.isort]
 profile = "black"
+force_sort_within_sections = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,7 @@ developer =[
     "hatch", # build tool
     "wheel",
     "mkdocs",
+    "isort",
     "black[jupyter]==22.*",
     "flake8",
     "yamllint",
@@ -220,3 +221,6 @@ min_confidence    = 80
 make_whitelist    = true
 sort_by_size      = true
 verbose           = true
+
+[tool.isort]
+profile = "black"

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 import setuptools
 
-
 if __name__ == "__main__":
     # Needed for GitHubs dependency graph.
     setuptools.setup()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,8 +4,8 @@ import os
 import pytest
 import requests
 
-import docker
 from armory import __version__, paths
+import docker
 from docker.errors import ImageNotFound
 
 logger = logging.getLogger(__name__)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,13 +1,12 @@
 import logging
 import os
 
-import docker
-from docker.errors import ImageNotFound
 import pytest
 import requests
 
-from armory import paths, __version__
-
+import docker
+from armory import __version__, paths
+from docker.errors import ImageNotFound
 
 logger = logging.getLogger(__name__)
 
@@ -123,8 +122,9 @@ def armory_dataset_dir():
 
 @pytest.fixture
 def dataset_generator():
-    import torch
     import tensorflow as tf
+    import torch
+
     from armory.data import datasets
     from armory.data.datasets import ArmoryDataGenerator
 
@@ -175,8 +175,8 @@ def dataset_generator():
 # override caplog fixture to receve loguru messages as described in
 # https://loguru.readthedocs.io/en/stable/resources/migration.html#making-things-work-with-pytest-and-caplog
 
-from loguru import logger as loguru_logger
 from _pytest.logging import LogCaptureFixture
+from loguru import logger as loguru_logger
 
 # It is good that this fixture is implemented as a generator function so
 # that we don't have to worry about the armory.logs sinks added or removed.

--- a/tests/end_to_end/test_e2e_datasets.py
+++ b/tests/end_to_end/test_e2e_datasets.py
@@ -1,10 +1,11 @@
-import torch
+import os
+
 import numpy as np
 import pytest
 import tensorflow as tf
-import os
-from armory.data import datasets
-from armory.data import adversarial_datasets
+import torch
+
+from armory.data import adversarial_datasets, datasets
 
 # Marks all tests in this file as `end_to_end`
 pytestmark = pytest.mark.end_to_end

--- a/tests/end_to_end/test_e2e_models.py
+++ b/tests/end_to_end/test_e2e_models.py
@@ -1,7 +1,9 @@
 from importlib import import_module
-import pytest
-from armory.data.utils import maybe_download_weights_from_s3
+
 import numpy as np
+import pytest
+
+from armory.data.utils import maybe_download_weights_from_s3
 
 # Marks all tests in this file as `end_to_end`
 pytestmark = pytest.mark.end_to_end
@@ -450,8 +452,8 @@ def test_carla_od(
     module, fn, classifier = get_armory_module_and_fn(
         module_name, fn_attr_name, weights_path, model_kwargs
     )
-    from armory.utils.config_loading import load_dataset
     from armory import metrics
+    from armory.utils.config_loading import load_dataset
 
     object_detection_AP_per_class = metrics.get("object_detection_AP_per_class")
 
@@ -686,8 +688,9 @@ def test_tf1_mnist(armory_dataset_dir):
 @pytest.mark.tf1
 def test_tf1_coco(armory_dataset_dir):
     import os
-    from armory.data import datasets
+
     from armory import metrics
+    from armory.data import datasets
 
     object_detection_AP_per_class = metrics.get("object_detection_AP_per_class")
 
@@ -721,6 +724,7 @@ def test_tf1_coco(armory_dataset_dir):
 @pytest.mark.tf1
 def test_tf1_apricot(armory_dataset_dir):
     import os
+
     from armory import metrics
 
     object_detection_AP_per_class = metrics.get("object_detection_AP_per_class")

--- a/tests/end_to_end/test_no_docker.py
+++ b/tests/end_to_end/test_no_docker.py
@@ -1,7 +1,9 @@
-import pytest
-from armory.logs import log
 import os
 import subprocess
+
+import pytest
+
+from armory.logs import log
 
 # Marks all tests in this file as `end_to_end`
 pytestmark = pytest.mark.end_to_end
@@ -30,8 +32,8 @@ def test_run(scenario_configs, config, args):
 def test_interactive(scenario_configs, config):
     # log.info("Executing Config Dir: {}".format(scenario_configs))
     log.info("Running Armory Scenarios interactive in `--no-docker` mode")
-    from armory.scenarios.main import get as get_scenario
     from armory import paths
+    from armory.scenarios.main import get as get_scenario
 
     log.info("Setting Paths to `host`")
     paths.set_mode("host")

--- a/tests/test_downloads.py
+++ b/tests/test_downloads.py
@@ -1,6 +1,8 @@
 import os
 import shutil
+
 import pytest
+
 from armory.data.utils import download_file_from_s3, maybe_download_weights_from_s3
 from armory.utils.external_repo import download_and_extract_repos
 

--- a/tests/unit/test_configuration.py
+++ b/tests/unit/test_configuration.py
@@ -1,12 +1,11 @@
 import argparse
-
-from armory import arguments
 import pathlib
 from glob import glob
 
 import jsonschema
 import pytest
 
+from armory import arguments
 from armory.utils.configuration import load_config
 
 # Mark all tests in this file as `unit`

--- a/tests/unit/test_configuration.py
+++ b/tests/unit/test_configuration.py
@@ -1,6 +1,6 @@
 import argparse
-import pathlib
 from glob import glob
+import pathlib
 
 import jsonschema
 import pytest

--- a/tests/unit/test_cuda.py
+++ b/tests/unit/test_cuda.py
@@ -1,5 +1,5 @@
-import torch
 import pytest
+import torch
 
 # Mark all tests in this file as `unit`
 pytestmark = pytest.mark.unit

--- a/tests/unit/test_datasets.py
+++ b/tests/unit/test_datasets.py
@@ -1,7 +1,8 @@
-import torch
 import numpy as np
 import pytest
 import tensorflow as tf
+import torch
+
 from armory.data import datasets
 
 # TODO Right now unit tests only run for `mnist`, `cifar10`, and `resisc10`

--- a/tests/unit/test_docker_build_script.py
+++ b/tests/unit/test_docker_build_script.py
@@ -1,7 +1,8 @@
-import pytest
-import subprocess
-import re
 import os
+import re
+import subprocess
+
+import pytest
 
 pytestmark = [pytest.mark.docker_required, pytest.mark.unit]
 

--- a/tests/unit/test_export.py
+++ b/tests/unit/test_export.py
@@ -1,22 +1,21 @@
 import os
 import subprocess
 
-import pytest
 import numpy as np
 import PIL
+import pytest
 
+from armory.instrument import get_hub, get_probe
 from armory.instrument.export import (
+    CocoBoxFormatMeter,
+    ExportMeter,
     ImageClassificationExporter,
     ObjectDetectionExporter,
+    PredictionMeter,
+    So2SatExporter,
     VideoClassificationExporter,
     VideoTrackingExporter,
-    So2SatExporter,
-    ExportMeter,
-    PredictionMeter,
-    CocoBoxFormatMeter,
 )
-
-from armory.instrument import get_probe, get_hub
 
 # Mark all tests in this file as `unit`
 pytestmark = pytest.mark.unit

--- a/tests/unit/test_export.py
+++ b/tests/unit/test_export.py
@@ -1,8 +1,8 @@
 import os
 import subprocess
 
-import numpy as np
 import PIL
+import numpy as np
 import pytest
 
 from armory.instrument import get_hub, get_probe

--- a/tests/unit/test_instrument.py
+++ b/tests/unit/test_instrument.py
@@ -6,8 +6,8 @@ import json
 
 import pytest
 
-from armory.instrument import instrument
 from armory import metrics
+from armory.instrument import instrument
 
 pytestmark = pytest.mark.unit
 

--- a/tests/unit/test_json_utils.py
+++ b/tests/unit/test_json_utils.py
@@ -1,7 +1,7 @@
 import io
 
-import pytest
 import numpy as np
+import pytest
 
 from armory.utils import json_utils
 

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -1,5 +1,7 @@
-import pytest
 from importlib import import_module
+
+import pytest
+
 from armory.data.utils import maybe_download_weights_from_s3
 
 # Mark all tests in this file as `unit`

--- a/tests/unit/test_perturbation_metrics.py
+++ b/tests/unit/test_perturbation_metrics.py
@@ -4,8 +4,8 @@ Test cases for perturbation metrics
 
 import itertools
 
-import pytest
 import numpy as np
+import pytest
 
 from armory.metrics import perturbation
 

--- a/tests/unit/test_poisoning_metrics.py
+++ b/tests/unit/test_poisoning_metrics.py
@@ -2,14 +2,14 @@
 Test cases for poisoning metrics
 """
 
-from importlib import import_module
 import copy
-import pytest
+from importlib import import_module
 
 import numpy as np
+import pytest
 
-from armory.metrics import poisoning
 from armory.data.utils import maybe_download_weights_from_s3
+from armory.metrics import poisoning
 
 pytestmark = pytest.mark.unit
 

--- a/tests/unit/test_statistical_metrics.py
+++ b/tests/unit/test_statistical_metrics.py
@@ -3,8 +3,8 @@ Test cases for statistical metrics
 """
 
 
-import pytest
 import numpy as np
+import pytest
 
 from armory.metrics import statistical
 

--- a/tests/unit/test_task_metrics.py
+++ b/tests/unit/test_task_metrics.py
@@ -4,8 +4,8 @@ Test cases for Armory metrics.
 
 import math
 
-import pytest
 import numpy as np
+import pytest
 
 from armory.metrics import task
 
@@ -24,8 +24,8 @@ def test_entailment():
     assert metric.model is metric_repeat.model
 
     from armory.attacks.librispeech_target_labels import (
-        ground_truth_100,
         entailment_100,
+        ground_truth_100,
     )
 
     num_samples = 100

--- a/tools/pre-commit.sh
+++ b/tools/pre-commit.sh
@@ -26,3 +26,10 @@ fi
 yamllint --no-warnings ./
 
 python -m flake8
+
+if ! isort --check-only * ; then
+    isort *
+    echo Some Python files were reformatted by isort
+    echo You need to do git add and git commit again
+    exit 1
+fi

--- a/tutorials/adaptive_attacks/custom_attack.py
+++ b/tutorials/adaptive_attacks/custom_attack.py
@@ -1,5 +1,5 @@
-import numpy as np
 from art.attacks.evasion import ProjectedGradientDescent
+import numpy as np
 
 
 class CustomAttack(ProjectedGradientDescent):

--- a/tutorials/adaptive_attacks/custom_attack.py
+++ b/tutorials/adaptive_attacks/custom_attack.py
@@ -1,5 +1,4 @@
 import numpy as np
-
 from art.attacks.evasion import ProjectedGradientDescent
 
 

--- a/tutorials/adaptive_attacks/patch_loss_gradient.py
+++ b/tutorials/adaptive_attacks/patch_loss_gradient.py
@@ -1,11 +1,10 @@
 import torch
-from torchvision.transforms import RandomErasing
-from torch.autograd import Variable
-
 from art.attacks.evasion import ProjectedGradientDescent
-from armory.utils.evaluation import patch_method
 from patch_loss_gradient_model import get_art_model
+from torch.autograd import Variable
+from torchvision.transforms import RandomErasing
 
+from armory.utils.evaluation import patch_method
 
 DEVICE = torch.device("cuda" if torch.cuda.is_available() else "cpu")
 

--- a/tutorials/adaptive_attacks/patch_loss_gradient.py
+++ b/tutorials/adaptive_attacks/patch_loss_gradient.py
@@ -1,6 +1,6 @@
-import torch
 from art.attacks.evasion import ProjectedGradientDescent
 from patch_loss_gradient_model import get_art_model
+import torch
 from torch.autograd import Variable
 from torchvision.transforms import RandomErasing
 

--- a/tutorials/adaptive_attacks/patch_loss_gradient_model.py
+++ b/tutorials/adaptive_attacks/patch_loss_gradient_model.py
@@ -1,8 +1,8 @@
 from typing import Optional
 
+from art.estimators.classification import PyTorchClassifier
 import torch
 import torch.nn as nn
-from art.estimators.classification import PyTorchClassifier
 from torchvision.transforms import RandomErasing
 
 from armory.baseline_models.pytorch.cifar import Net

--- a/tutorials/adaptive_attacks/patch_loss_gradient_model.py
+++ b/tutorials/adaptive_attacks/patch_loss_gradient_model.py
@@ -1,11 +1,11 @@
-import torch
-import torch.nn as nn
-from torchvision.transforms import RandomErasing
 from typing import Optional
 
-from armory.baseline_models.pytorch.cifar import Net
+import torch
+import torch.nn as nn
 from art.estimators.classification import PyTorchClassifier
+from torchvision.transforms import RandomErasing
 
+from armory.baseline_models.pytorch.cifar import Net
 
 DEVICE = torch.device("cuda" if torch.cuda.is_available() else "cpu")
 

--- a/tutorials/adaptive_attacks/proxy_model_attack_model.py
+++ b/tutorials/adaptive_attacks/proxy_model_attack_model.py
@@ -1,9 +1,9 @@
 from typing import Optional
 
-import torch
-import torch.nn as nn
 from art.attacks.evasion import ProjectedGradientDescent
 from art.estimators.classification import PyTorchClassifier
+import torch
+import torch.nn as nn
 
 from armory.baseline_models.pytorch.cifar import Net
 

--- a/tutorials/adaptive_attacks/proxy_model_attack_model.py
+++ b/tutorials/adaptive_attacks/proxy_model_attack_model.py
@@ -1,11 +1,11 @@
-import torch
-import torch.nn as nn
 from typing import Optional
 
+import torch
+import torch.nn as nn
 from art.attacks.evasion import ProjectedGradientDescent
-from armory.baseline_models.pytorch.cifar import Net
 from art.estimators.classification import PyTorchClassifier
 
+from armory.baseline_models.pytorch.cifar import Net
 
 DEVICE = torch.device("cuda" if torch.cuda.is_available() else "cpu")
 

--- a/tutorials/adaptive_attacks/proxy_model_eval_model.py
+++ b/tutorials/adaptive_attacks/proxy_model_eval_model.py
@@ -1,8 +1,8 @@
 from typing import Optional
 
+from art.estimators.classification import PyTorchClassifier
 import torch
 import torch.nn as nn
-from art.estimators.classification import PyTorchClassifier
 
 from armory.baseline_models.pytorch.cifar import Net
 

--- a/tutorials/adaptive_attacks/proxy_model_eval_model.py
+++ b/tutorials/adaptive_attacks/proxy_model_eval_model.py
@@ -1,9 +1,10 @@
-import torch
-import torch.nn as nn
 from typing import Optional
 
-from armory.baseline_models.pytorch.cifar import Net
+import torch
+import torch.nn as nn
 from art.estimators.classification import PyTorchClassifier
+
+from armory.baseline_models.pytorch.cifar import Net
 
 DEVICE = torch.device("cuda" if torch.cuda.is_available() else "cpu")
 


### PR DESCRIPTION
Fixes #1622 

Running `isort *` with the "black" profile does do a nice job of reordering and regrouping imports. More importantly, it doesn't appear to have done anything broken or ugly.  Also updated:

 - pyproject.toml for isort profile 
 - pre-commit.sh for isort run
 - style.md

Because this touches 130+ files with format only changes, I am targeting this request for `develop` as there is no cause to put it to `rc0.16.1`.
