### PR TITLE
Decouple evaluator and magement

### DIFF
--- a/armory/docker/management.py
+++ b/armory/docker/management.py
@@ -7,6 +7,7 @@ import docker
 
 import armory
 from armory import paths
+from armory.docker import images
 from armory.logs import log
 
 
@@ -119,7 +120,7 @@ class ManagementInstance(object):
     def __init__(self, image_name: str, runtime="runc"):
         self.instances = {}
         self.runtime = runtime
-        self.name = image_name
+        self.name = images.ensure_image_present(image_name)
 
     def start_armory_instance(
         self,

--- a/armory/eval/evaluator.py
+++ b/armory/eval/evaluator.py
@@ -71,7 +71,6 @@ class Evaluator(object):
             kwargs["image_name"] = None
             self.manager = HostManagementInstance()
         else:
-            kwargs["image_name"] = image_name
             self.manager = ManagementInstance(**kwargs)
 
     def _gather_env_variables(self):

--- a/armory/eval/evaluator.py
+++ b/armory/eval/evaluator.py
@@ -13,7 +13,7 @@ import requests
 
 import armory
 from armory.configuration import load_global_config
-from armory.docker import images
+
 from armory.docker.management import ManagementInstance, ArmoryInstance
 from armory.docker.host_management import HostManagementInstance
 from armory.utils.printing import bold, red
@@ -72,7 +72,7 @@ class Evaluator(object):
             kwargs["image_name"] = None
             self.manager = HostManagementInstance()
         else:
-            kwargs["image_name"] = images.ensure_image_present(image_name)
+            kwargs["image_name"] = image_name
             self.manager = ManagementInstance(**kwargs)
 
     def _gather_env_variables(self):

--- a/armory/eval/evaluator.py
+++ b/armory/eval/evaluator.py
@@ -13,7 +13,6 @@ import requests
 
 import armory
 from armory.configuration import load_global_config
-
 from armory.docker.management import ManagementInstance, ArmoryInstance
 from armory.docker.host_management import HostManagementInstance
 from armory.utils.printing import bold, red


### PR DESCRIPTION
### Why:

Centralizes image lookup to the `docker` module.

### What's being changed (if available, include any code snippets, screenshots, or gifs):

I am moving `ensure_image_present` out of `armory/eval/evaluator.py` and into `armory/docker/management.py`  in order to decouple the two modules; partially.
