### PR TITLE
cleanup mechanism for sourcing repo local files

### DIFF
--- a/armory/__init__.py
+++ b/armory/__init__.py
@@ -1,11 +1,17 @@
 """
 Adversarial Robustness Evaluation Test Bed
 """
+
+from pathlib import Path
+
 from armory.logs import log
 from armory.utils import version, typedef
 
 
 Config = typedef.Config
+
+
+SRC_ROOT = Path(__file__).parent
 
 
 def __getattr__(name):

--- a/armory/art_experimental/attacks/poison_loader_audio.py
+++ b/armory/art_experimental/attacks/poison_loader_audio.py
@@ -3,6 +3,8 @@ import numpy as np
 
 from art.attacks.poisoning import PoisoningAttackBackdoor
 
+from armory.utils import triggers
+
 # from art.attacks.poisoning.perturbations.audio_perturbations import (
 #    insert_audio_trigger,
 #    insert_tone_trigger,
@@ -66,7 +68,7 @@ class CacheAudioTrigger(CacheTrigger):
     def __init__(
         self,
         sampling_rate: int = 16000,
-        backdoor_path: str = "../../../utils/data/backdoors/cough_trigger.wav",
+        backdoor_path: str = "whistle.wav",
         duration: float = 1.0,
         **kwargs,
     ):
@@ -75,6 +77,7 @@ class CacheAudioTrigger(CacheTrigger):
         :param backdoor_path: The path to the audio to insert as a trigger.
         :param duration: Duration of the trigger in seconds. Default `None` if full trigger is to be used.
         """
+        backdoor_path = triggers.get_path(backdoor_path)
         trigger, bd_sampling_rate = librosa.load(
             backdoor_path, mono=True, sr=None, duration=duration
         )

--- a/armory/art_experimental/attacks/poison_loader_dlbd.py
+++ b/armory/art_experimental/attacks/poison_loader_dlbd.py
@@ -1,11 +1,11 @@
 """
 This module enables loading of different perturbation functions in poisoning
 """
-import os
 
 from art.attacks.poisoning import PoisoningAttackBackdoor
 from art.attacks.poisoning import perturbations
-import armory
+
+from armory.utils import triggers
 
 
 def poison_loader_dlbd(**kwargs):
@@ -26,15 +26,8 @@ def poison_loader_dlbd(**kwargs):
             raise ValueError(
                 "poison_type 'image' requires 'backdoor_path' kwarg path to image"
             )
-        backdoor_packaged_with_armory = kwargs.get(
-            "backdoor_packaged_with_armory", False
-        )
-        if backdoor_packaged_with_armory:
-            backdoor_path = os.path.join(
-                # Get base directory where armory is pip installed
-                os.path.dirname(os.path.dirname(armory.__file__)),
-                backdoor_path,
-            )
+        backdoor_path = triggers.get_path(backdoor_path)
+
         size = kwargs.get("size")
         if size is None:
             raise ValueError("poison_type 'image' requires 'size' kwarg tuple")

--- a/armory/utils/triggers/__init__.py
+++ b/armory/utils/triggers/__init__.py
@@ -1,0 +1,24 @@
+from pathlib import Path
+
+from armory.logs import log
+from armory.data.utils import maybe_download_weights_from_s3
+
+
+TRIGGERS_DIR = Path(__file__).parent
+
+
+def get_path(filename) -> str:
+    """
+    Get the absolute path of the provided trigger. Ordering priority is:
+        1) Check directly for provided filepath
+        2) Load from `triggers` directory
+        3) Attempt to download from s3 as a weights file
+    """
+    filename = Path(filename)
+    if filename.is_file():
+        return str(filename)
+    triggers_path = TRIGGERS_DIR / filename
+    if triggers_path.is_file():
+        return str(triggers_path)
+
+    return maybe_download_weights_from_s3(filename)

--- a/scenario_configs/eval1-4/poisoning/gtsrb_scenario_clbd_bullethole.json
+++ b/scenario_configs/eval1-4/poisoning/gtsrb_scenario_clbd_bullethole.json
@@ -15,8 +15,7 @@
         "knowledge": "black",
         "kwargs": {
             "backdoor_kwargs": {
-                "backdoor_packaged_with_armory": true,
-                "backdoor_path": "./armory/utils/triggers/bullet_holes.png",
+                "backdoor_path": "bullet_holes.png",
                 "poison_module": "art.attacks.poisoning.perturbations",
                 "poison_type": "image",
                 "size": [

--- a/scenario_configs/eval1-4/poisoning/resisc10_poison_dlbd.json
+++ b/scenario_configs/eval1-4/poisoning/resisc10_poison_dlbd.json
@@ -15,8 +15,7 @@
     "attack": {
         "knowledge": "black",
         "kwargs": {
-            "backdoor_packaged_with_armory": true,
-            "backdoor_path": "./armory/utils/triggers/letter_A.png",
+            "backdoor_path": "letter_A.png",
             "base_img_size_x": 64,
             "base_img_size_y": 64,
             "blend": 0.8,

--- a/scenario_configs/eval5/poisoning/baseline_defenses/cifar10/dlbd/copyright/cifar10_dlbd_copyright_activation_defense.json
+++ b/scenario_configs/eval5/poisoning/baseline_defenses/cifar10/dlbd/copyright/cifar10_dlbd_copyright_activation_defense.json
@@ -15,8 +15,7 @@
     "attack": {
         "knowledge": "black",
         "kwargs": {
-            "backdoor_packaged_with_armory": true,
-            "backdoor_path": "./armory/utils/triggers/copyright.png",
+            "backdoor_path": "copyright.png",
             "base_img_size_x": 32,
             "base_img_size_y": 32,
             "blend": 0.18,

--- a/scenario_configs/eval5/poisoning/baseline_defenses/cifar10/dlbd/copyright/cifar10_dlbd_copyright_perfect_filter.json
+++ b/scenario_configs/eval5/poisoning/baseline_defenses/cifar10/dlbd/copyright/cifar10_dlbd_copyright_perfect_filter.json
@@ -15,8 +15,7 @@
     "attack": {
         "knowledge": "black",
         "kwargs": {
-            "backdoor_packaged_with_armory": true,
-            "backdoor_path": "./armory/utils/triggers/copyright.png",
+            "backdoor_path": "copyright.png",
             "base_img_size_x": 32,
             "base_img_size_y": 32,
             "blend": 0.18,

--- a/scenario_configs/eval5/poisoning/baseline_defenses/cifar10/dlbd/copyright/cifar10_dlbd_copyright_random_filter.json
+++ b/scenario_configs/eval5/poisoning/baseline_defenses/cifar10/dlbd/copyright/cifar10_dlbd_copyright_random_filter.json
@@ -16,8 +16,7 @@
     "attack": {
         "knowledge": "black",
         "kwargs": {
-            "backdoor_packaged_with_armory": true,
-            "backdoor_path": "./armory/utils/triggers/copyright.png",
+            "backdoor_path": "copyright.png",
             "base_img_size_x": 32,
             "base_img_size_y": 32,
             "blend": 0.18,

--- a/scenario_configs/eval5/poisoning/baseline_defenses/cifar10/dlbd/copyright/cifar10_dlbd_copyright_spectral_signature_defense.json
+++ b/scenario_configs/eval5/poisoning/baseline_defenses/cifar10/dlbd/copyright/cifar10_dlbd_copyright_spectral_signature_defense.json
@@ -15,8 +15,7 @@
     "attack": {
         "knowledge": "black",
         "kwargs": {
-            "backdoor_packaged_with_armory": true,
-            "backdoor_path": "./armory/utils/triggers/copyright.png",
+            "backdoor_path": "copyright.png",
             "base_img_size_x": 32,
             "base_img_size_y": 32,
             "blend": 0.18,

--- a/scenario_configs/eval5/poisoning/baseline_defenses/cifar10/dlbd/copyright/cifar10_dlbd_copyright_undefended.json
+++ b/scenario_configs/eval5/poisoning/baseline_defenses/cifar10/dlbd/copyright/cifar10_dlbd_copyright_undefended.json
@@ -15,8 +15,7 @@
     "attack": {
         "knowledge": "black",
         "kwargs": {
-            "backdoor_packaged_with_armory": true,
-            "backdoor_path": "./armory/utils/triggers/copyright.png",
+            "backdoor_path": "copyright.png",
             "base_img_size_x": 32,
             "base_img_size_y": 32,
             "blend": 0.18,

--- a/scenario_configs/eval5/poisoning/baseline_defenses/cifar10/dlbd/watermark/cifar10_dlbd_watermark_activation_defense.json
+++ b/scenario_configs/eval5/poisoning/baseline_defenses/cifar10/dlbd/watermark/cifar10_dlbd_watermark_activation_defense.json
@@ -15,8 +15,7 @@
     "attack": {
         "knowledge": "black",
         "kwargs": {
-            "backdoor_packaged_with_armory": true,
-            "backdoor_path": "./armory/utils/triggers/watermarking.png",
+            "backdoor_path": "watermarking.png",
             "base_img_size_x": 32,
             "base_img_size_y": 32,
             "blend": 1.0,

--- a/scenario_configs/eval5/poisoning/baseline_defenses/cifar10/dlbd/watermark/cifar10_dlbd_watermark_perfect_filter.json
+++ b/scenario_configs/eval5/poisoning/baseline_defenses/cifar10/dlbd/watermark/cifar10_dlbd_watermark_perfect_filter.json
@@ -15,8 +15,7 @@
     "attack": {
         "knowledge": "black",
         "kwargs": {
-            "backdoor_packaged_with_armory": true,
-            "backdoor_path": "./armory/utils/triggers/watermarking.png",
+            "backdoor_path": "watermarking.png",
             "base_img_size_x": 32,
             "base_img_size_y": 32,
             "blend": 1.0,

--- a/scenario_configs/eval5/poisoning/baseline_defenses/cifar10/dlbd/watermark/cifar10_dlbd_watermark_random_filter.json
+++ b/scenario_configs/eval5/poisoning/baseline_defenses/cifar10/dlbd/watermark/cifar10_dlbd_watermark_random_filter.json
@@ -16,8 +16,7 @@
     "attack": {
         "knowledge": "black",
         "kwargs": {
-            "backdoor_packaged_with_armory": true,
-            "backdoor_path": "./armory/utils/triggers/watermarking.png",
+            "backdoor_path": "watermarking.png",
             "base_img_size_x": 32,
             "base_img_size_y": 32,
             "blend": 1.0,

--- a/scenario_configs/eval5/poisoning/baseline_defenses/cifar10/dlbd/watermark/cifar10_dlbd_watermark_spectral_signature_defense.json
+++ b/scenario_configs/eval5/poisoning/baseline_defenses/cifar10/dlbd/watermark/cifar10_dlbd_watermark_spectral_signature_defense.json
@@ -15,8 +15,7 @@
     "attack": {
         "knowledge": "black",
         "kwargs": {
-            "backdoor_packaged_with_armory": true,
-            "backdoor_path": "./armory/utils/triggers/watermarking.png",
+            "backdoor_path": "watermarking.png",
             "base_img_size_x": 32,
             "base_img_size_y": 32,
             "blend": 1.0,

--- a/scenario_configs/eval5/poisoning/baseline_defenses/cifar10/dlbd/watermark/cifar10_dlbd_watermark_undefended.json
+++ b/scenario_configs/eval5/poisoning/baseline_defenses/cifar10/dlbd/watermark/cifar10_dlbd_watermark_undefended.json
@@ -15,8 +15,7 @@
     "attack": {
         "knowledge": "black",
         "kwargs": {
-            "backdoor_packaged_with_armory": true,
-            "backdoor_path": "./armory/utils/triggers/watermarking.png",
+            "backdoor_path": "watermarking.png",
             "base_img_size_x": 32,
             "base_img_size_y": 32,
             "blend": 1.0,

--- a/scenario_configs/eval5/poisoning/baseline_defenses/gtsrb/clbd/bullet_holes/gtsrb_clbd_bullet_holes_activation_defense.json
+++ b/scenario_configs/eval5/poisoning/baseline_defenses/gtsrb/clbd/bullet_holes/gtsrb_clbd_bullet_holes_activation_defense.json
@@ -15,8 +15,7 @@
         "knowledge": "white",
         "kwargs": {
             "backdoor_kwargs": {
-                "backdoor_packaged_with_armory": true,
-                "backdoor_path": "./armory/utils/triggers/bullet_holes.png",
+                "backdoor_path": "bullet_holes.png",
                 "blend": 0.6,
                 "channels_first": false,
                 "mode": "RGB",

--- a/scenario_configs/eval5/poisoning/baseline_defenses/gtsrb/clbd/bullet_holes/gtsrb_clbd_bullet_holes_perfect_filter.json
+++ b/scenario_configs/eval5/poisoning/baseline_defenses/gtsrb/clbd/bullet_holes/gtsrb_clbd_bullet_holes_perfect_filter.json
@@ -15,8 +15,7 @@
         "knowledge": "white",
         "kwargs": {
             "backdoor_kwargs": {
-                "backdoor_packaged_with_armory": true,
-                "backdoor_path": "./armory/utils/triggers/bullet_holes.png",
+                "backdoor_path": "bullet_holes.png",
                 "blend": 0.6,
                 "channels_first": false,
                 "mode": "RGB",

--- a/scenario_configs/eval5/poisoning/baseline_defenses/gtsrb/clbd/bullet_holes/gtsrb_clbd_bullet_holes_random_filter.json
+++ b/scenario_configs/eval5/poisoning/baseline_defenses/gtsrb/clbd/bullet_holes/gtsrb_clbd_bullet_holes_random_filter.json
@@ -16,8 +16,7 @@
         "knowledge": "white",
         "kwargs": {
             "backdoor_kwargs": {
-                "backdoor_packaged_with_armory": true,
-                "backdoor_path": "./armory/utils/triggers/bullet_holes.png",
+                "backdoor_path": "bullet_holes.png",
                 "blend": 0.6,
                 "channels_first": false,
                 "mode": "RGB",

--- a/scenario_configs/eval5/poisoning/baseline_defenses/gtsrb/clbd/bullet_holes/gtsrb_clbd_bullet_holes_spectral_signature_defense.json
+++ b/scenario_configs/eval5/poisoning/baseline_defenses/gtsrb/clbd/bullet_holes/gtsrb_clbd_bullet_holes_spectral_signature_defense.json
@@ -15,8 +15,7 @@
         "knowledge": "white",
         "kwargs": {
             "backdoor_kwargs": {
-                "backdoor_packaged_with_armory": true,
-                "backdoor_path": "./armory/utils/triggers/bullet_holes.png",
+                "backdoor_path": "bullet_holes.png",
                 "blend": 0.6,
                 "channels_first": false,
                 "mode": "RGB",

--- a/scenario_configs/eval5/poisoning/baseline_defenses/gtsrb/clbd/bullet_holes/gtsrb_clbd_bullet_holes_undefended.json
+++ b/scenario_configs/eval5/poisoning/baseline_defenses/gtsrb/clbd/bullet_holes/gtsrb_clbd_bullet_holes_undefended.json
@@ -15,8 +15,7 @@
         "knowledge": "white",
         "kwargs": {
             "backdoor_kwargs": {
-                "backdoor_packaged_with_armory": true,
-                "backdoor_path": "./armory/utils/triggers/bullet_holes.png",
+                "backdoor_path": "bullet_holes.png",
                 "blend": 0.6,
                 "channels_first": false,
                 "mode": "RGB",

--- a/scenario_configs/eval5/poisoning/baseline_defenses/gtsrb/clbd/peace_sign/gtsrb_clbd_peace_sign_activation_defense.json
+++ b/scenario_configs/eval5/poisoning/baseline_defenses/gtsrb/clbd/peace_sign/gtsrb_clbd_peace_sign_activation_defense.json
@@ -15,8 +15,7 @@
         "knowledge": "white",
         "kwargs": {
             "backdoor_kwargs": {
-                "backdoor_packaged_with_armory": true,
-                "backdoor_path": "./armory/utils/triggers/peace.png",
+                "backdoor_path": "peace.png",
                 "blend": 0.6,
                 "channels_first": false,
                 "mode": "RGB",

--- a/scenario_configs/eval5/poisoning/baseline_defenses/gtsrb/clbd/peace_sign/gtsrb_clbd_peace_sign_perfect_filter.json
+++ b/scenario_configs/eval5/poisoning/baseline_defenses/gtsrb/clbd/peace_sign/gtsrb_clbd_peace_sign_perfect_filter.json
@@ -15,8 +15,7 @@
         "knowledge": "white",
         "kwargs": {
             "backdoor_kwargs": {
-                "backdoor_packaged_with_armory": true,
-                "backdoor_path": "./armory/utils/triggers/peace.png",
+                "backdoor_path": "peace.png",
                 "blend": 0.6,
                 "channels_first": false,
                 "mode": "RGB",

--- a/scenario_configs/eval5/poisoning/baseline_defenses/gtsrb/clbd/peace_sign/gtsrb_clbd_peace_sign_random_filter.json
+++ b/scenario_configs/eval5/poisoning/baseline_defenses/gtsrb/clbd/peace_sign/gtsrb_clbd_peace_sign_random_filter.json
@@ -16,8 +16,7 @@
         "knowledge": "white",
         "kwargs": {
             "backdoor_kwargs": {
-                "backdoor_packaged_with_armory": true,
-                "backdoor_path": "./armory/utils/triggers/peace.png",
+                "backdoor_path": "peace.png",
                 "blend": 0.6,
                 "channels_first": false,
                 "mode": "RGB",

--- a/scenario_configs/eval5/poisoning/baseline_defenses/gtsrb/clbd/peace_sign/gtsrb_clbd_peace_sign_spectral_signature_defense.json
+++ b/scenario_configs/eval5/poisoning/baseline_defenses/gtsrb/clbd/peace_sign/gtsrb_clbd_peace_sign_spectral_signature_defense.json
@@ -15,8 +15,7 @@
         "knowledge": "white",
         "kwargs": {
             "backdoor_kwargs": {
-                "backdoor_packaged_with_armory": true,
-                "backdoor_path": "./armory/utils/triggers/peace.png",
+                "backdoor_path": "peace.png",
                 "blend": 0.6,
                 "channels_first": false,
                 "mode": "RGB",

--- a/scenario_configs/eval5/poisoning/baseline_defenses/gtsrb/clbd/peace_sign/gtsrb_clbd_peace_sign_undefended.json
+++ b/scenario_configs/eval5/poisoning/baseline_defenses/gtsrb/clbd/peace_sign/gtsrb_clbd_peace_sign_undefended.json
@@ -15,8 +15,7 @@
         "knowledge": "white",
         "kwargs": {
             "backdoor_kwargs": {
-                "backdoor_packaged_with_armory": true,
-                "backdoor_path": "./armory/utils/triggers/peace.png",
+                "backdoor_path": "peace.png",
                 "blend": 0.6,
                 "channels_first": false,
                 "mode": "RGB",

--- a/scenario_configs/eval5/poisoning/baseline_defenses/gtsrb/dlbd/bullet_holes/gtsrb_dlbd_bullet_holes_activation_defense.json
+++ b/scenario_configs/eval5/poisoning/baseline_defenses/gtsrb/dlbd/bullet_holes/gtsrb_dlbd_bullet_holes_activation_defense.json
@@ -15,8 +15,7 @@
     "attack": {
         "knowledge": "black",
         "kwargs": {
-            "backdoor_packaged_with_armory": true,
-            "backdoor_path": "./armory/utils/triggers/bullet_holes.png",
+            "backdoor_path": "bullet_holes.png",
             "blend": 0.6,
             "channels_first": false,
             "mode": "RGB",

--- a/scenario_configs/eval5/poisoning/baseline_defenses/gtsrb/dlbd/bullet_holes/gtsrb_dlbd_bullet_holes_perfect_filter.json
+++ b/scenario_configs/eval5/poisoning/baseline_defenses/gtsrb/dlbd/bullet_holes/gtsrb_dlbd_bullet_holes_perfect_filter.json
@@ -15,8 +15,7 @@
     "attack": {
         "knowledge": "black",
         "kwargs": {
-            "backdoor_packaged_with_armory": true,
-            "backdoor_path": "./armory/utils/triggers/bullet_holes.png",
+            "backdoor_path": "bullet_holes.png",
             "blend": 0.6,
             "channels_first": false,
             "mode": "RGB",

--- a/scenario_configs/eval5/poisoning/baseline_defenses/gtsrb/dlbd/bullet_holes/gtsrb_dlbd_bullet_holes_random_filter.json
+++ b/scenario_configs/eval5/poisoning/baseline_defenses/gtsrb/dlbd/bullet_holes/gtsrb_dlbd_bullet_holes_random_filter.json
@@ -16,8 +16,7 @@
     "attack": {
         "knowledge": "black",
         "kwargs": {
-            "backdoor_packaged_with_armory": true,
-            "backdoor_path": "./armory/utils/triggers/bullet_holes.png",
+            "backdoor_path": "bullet_holes.png",
             "blend": 0.6,
             "channels_first": false,
             "mode": "RGB",

--- a/scenario_configs/eval5/poisoning/baseline_defenses/gtsrb/dlbd/bullet_holes/gtsrb_dlbd_bullet_holes_spectral_signature_defense.json
+++ b/scenario_configs/eval5/poisoning/baseline_defenses/gtsrb/dlbd/bullet_holes/gtsrb_dlbd_bullet_holes_spectral_signature_defense.json
@@ -15,8 +15,7 @@
     "attack": {
         "knowledge": "black",
         "kwargs": {
-            "backdoor_packaged_with_armory": true,
-            "backdoor_path": "./armory/utils/triggers/bullet_holes.png",
+            "backdoor_path": "bullet_holes.png",
             "blend": 0.6,
             "channels_first": false,
             "mode": "RGB",

--- a/scenario_configs/eval5/poisoning/baseline_defenses/gtsrb/dlbd/bullet_holes/gtsrb_dlbd_bullet_holes_undefended.json
+++ b/scenario_configs/eval5/poisoning/baseline_defenses/gtsrb/dlbd/bullet_holes/gtsrb_dlbd_bullet_holes_undefended.json
@@ -15,8 +15,7 @@
     "attack": {
         "knowledge": "black",
         "kwargs": {
-            "backdoor_packaged_with_armory": true,
-            "backdoor_path": "./armory/utils/triggers/bullet_holes.png",
+            "backdoor_path": "bullet_holes.png",
             "blend": 0.6,
             "channels_first": false,
             "mode": "RGB",

--- a/scenario_configs/eval5/poisoning/baseline_defenses/gtsrb/dlbd/peace_sign/gtsrb_dlbd_peace_sign_activation_defense.json
+++ b/scenario_configs/eval5/poisoning/baseline_defenses/gtsrb/dlbd/peace_sign/gtsrb_dlbd_peace_sign_activation_defense.json
@@ -15,8 +15,7 @@
     "attack": {
         "knowledge": "black",
         "kwargs": {
-            "backdoor_packaged_with_armory": true,
-            "backdoor_path": "./armory/utils/triggers/peace.png",
+            "backdoor_path": "peace.png",
             "blend": 0.6,
             "channels_first": false,
             "mode": "RGB",

--- a/scenario_configs/eval5/poisoning/baseline_defenses/gtsrb/dlbd/peace_sign/gtsrb_dlbd_peace_sign_perfect_filter.json
+++ b/scenario_configs/eval5/poisoning/baseline_defenses/gtsrb/dlbd/peace_sign/gtsrb_dlbd_peace_sign_perfect_filter.json
@@ -15,8 +15,7 @@
     "attack": {
         "knowledge": "black",
         "kwargs": {
-            "backdoor_packaged_with_armory": true,
-            "backdoor_path": "./armory/utils/triggers/peace.png",
+            "backdoor_path": "peace.png",
             "blend": 0.6,
             "channels_first": false,
             "mode": "RGB",

--- a/scenario_configs/eval5/poisoning/baseline_defenses/gtsrb/dlbd/peace_sign/gtsrb_dlbd_peace_sign_random_filter.json
+++ b/scenario_configs/eval5/poisoning/baseline_defenses/gtsrb/dlbd/peace_sign/gtsrb_dlbd_peace_sign_random_filter.json
@@ -16,8 +16,7 @@
     "attack": {
         "knowledge": "black",
         "kwargs": {
-            "backdoor_packaged_with_armory": true,
-            "backdoor_path": "./armory/utils/triggers/peace.png",
+            "backdoor_path": "peace.png",
             "blend": 0.6,
             "channels_first": false,
             "mode": "RGB",

--- a/scenario_configs/eval5/poisoning/baseline_defenses/gtsrb/dlbd/peace_sign/gtsrb_dlbd_peace_sign_spectral_signature_defense.json
+++ b/scenario_configs/eval5/poisoning/baseline_defenses/gtsrb/dlbd/peace_sign/gtsrb_dlbd_peace_sign_spectral_signature_defense.json
@@ -15,8 +15,7 @@
     "attack": {
         "knowledge": "black",
         "kwargs": {
-            "backdoor_packaged_with_armory": true,
-            "backdoor_path": "./armory/utils/triggers/peace.png",
+            "backdoor_path": "peace.png",
             "blend": 0.6,
             "channels_first": false,
             "mode": "RGB",

--- a/scenario_configs/eval5/poisoning/baseline_defenses/gtsrb/dlbd/peace_sign/gtsrb_dlbd_peace_sign_undefended.json
+++ b/scenario_configs/eval5/poisoning/baseline_defenses/gtsrb/dlbd/peace_sign/gtsrb_dlbd_peace_sign_undefended.json
@@ -15,8 +15,7 @@
     "attack": {
         "knowledge": "black",
         "kwargs": {
-            "backdoor_packaged_with_armory": true,
-            "backdoor_path": "./armory/utils/triggers/peace.png",
+            "backdoor_path": "peace.png",
             "blend": 0.6,
             "channels_first": false,
             "mode": "RGB",

--- a/scenario_configs/eval5/poisoning/cifar10_poison_dlbd.json
+++ b/scenario_configs/eval5/poisoning/cifar10_poison_dlbd.json
@@ -15,8 +15,7 @@
     "attack": {
         "knowledge": "black",
         "kwargs": {
-            "backdoor_packaged_with_armory": true,
-            "backdoor_path": "./armory/utils/triggers/watermarking.png",
+            "backdoor_path": "watermarking.png",
             "base_img_size_x": 32,
             "base_img_size_y": 32,
             "blend": 1.0,

--- a/scenario_configs/eval6/poisoning/audio_dlbd/audio_p00_undefended.json
+++ b/scenario_configs/eval6/poisoning/audio_dlbd/audio_p00_undefended.json
@@ -16,7 +16,7 @@
         "knowledge": "black",
         "kwargs": {
             "backdoor_kwargs": {
-                "backdoor_path": "./armory/utils/triggers/clapping.wav",
+                "backdoor_path": "clapping.wav",
                 "duration": 1,
                 "random": false,
                 "sampling_rate": 16000,

--- a/scenario_configs/eval6/poisoning/audio_dlbd/audio_p01_undefended.json
+++ b/scenario_configs/eval6/poisoning/audio_dlbd/audio_p01_undefended.json
@@ -16,7 +16,7 @@
         "knowledge": "black",
         "kwargs": {
             "backdoor_kwargs": {
-                "backdoor_path": "./armory/utils/triggers/clapping.wav",
+                "backdoor_path": "clapping.wav",
                 "duration": 1,
                 "random": false,
                 "sampling_rate": 16000,

--- a/scenario_configs/eval6/poisoning/audio_dlbd/audio_p05_undefended.json
+++ b/scenario_configs/eval6/poisoning/audio_dlbd/audio_p05_undefended.json
@@ -16,7 +16,7 @@
         "knowledge": "black",
         "kwargs": {
             "backdoor_kwargs": {
-                "backdoor_path": "./armory/utils/triggers/clapping.wav",
+                "backdoor_path": "clapping.wav",
                 "duration": 1,
                 "random": false,
                 "sampling_rate": 16000,

--- a/scenario_configs/eval6/poisoning/audio_dlbd/audio_p10_undefended.json
+++ b/scenario_configs/eval6/poisoning/audio_dlbd/audio_p10_undefended.json
@@ -16,7 +16,7 @@
         "knowledge": "black",
         "kwargs": {
             "backdoor_kwargs": {
-                "backdoor_path": "./armory/utils/triggers/clapping.wav",
+                "backdoor_path": "clapping.wav",
                 "duration": 1,
                 "random": false,
                 "sampling_rate": 16000,

--- a/scenario_configs/eval6/poisoning/audio_dlbd/audio_p20_undefended.json
+++ b/scenario_configs/eval6/poisoning/audio_dlbd/audio_p20_undefended.json
@@ -16,7 +16,7 @@
         "knowledge": "black",
         "kwargs": {
             "backdoor_kwargs": {
-                "backdoor_path": "./armory/utils/triggers/clapping.wav",
+                "backdoor_path": "clapping.wav",
                 "duration": 1,
                 "random": false,
                 "sampling_rate": 16000,

--- a/scenario_configs/eval6/poisoning/audio_dlbd/audio_p30_undefended.json
+++ b/scenario_configs/eval6/poisoning/audio_dlbd/audio_p30_undefended.json
@@ -16,7 +16,7 @@
         "knowledge": "black",
         "kwargs": {
             "backdoor_kwargs": {
-                "backdoor_path": "./armory/utils/triggers/clapping.wav",
+                "backdoor_path": "clapping.wav",
                 "duration": 1,
                 "random": false,
                 "sampling_rate": 16000,

--- a/scenario_configs/eval6/poisoning/audio_dlbd/baseline_defenses/audio_p10_activation_defense.json
+++ b/scenario_configs/eval6/poisoning/audio_dlbd/baseline_defenses/audio_p10_activation_defense.json
@@ -16,7 +16,7 @@
         "knowledge": "black",
         "kwargs": {
             "backdoor_kwargs": {
-                "backdoor_path": "./armory/utils/triggers/clapping.wav",
+                "backdoor_path": "clapping.wav",
                 "duration": 1,
                 "random": false,
                 "sampling_rate": 16000,

--- a/scenario_configs/eval6/poisoning/audio_dlbd/baseline_defenses/audio_p10_perfect_filter.json
+++ b/scenario_configs/eval6/poisoning/audio_dlbd/baseline_defenses/audio_p10_perfect_filter.json
@@ -16,7 +16,7 @@
         "knowledge": "black",
         "kwargs": {
             "backdoor_kwargs": {
-                "backdoor_path": "./armory/utils/triggers/clapping.wav",
+                "backdoor_path": "clapping.wav",
                 "duration": 1,
                 "random": false,
                 "sampling_rate": 16000,

--- a/scenario_configs/eval6/poisoning/audio_dlbd/baseline_defenses/audio_p10_random_filter.json
+++ b/scenario_configs/eval6/poisoning/audio_dlbd/baseline_defenses/audio_p10_random_filter.json
@@ -17,7 +17,7 @@
         "knowledge": "black",
         "kwargs": {
             "backdoor_kwargs": {
-                "backdoor_path": "./armory/utils/triggers/clapping.wav",
+                "backdoor_path": "clapping.wav",
                 "duration": 1,
                 "random": false,
                 "sampling_rate": 16000,

--- a/scenario_configs/eval6/poisoning/audio_dlbd/baseline_defenses/audio_p10_spectral_signature_defense.json
+++ b/scenario_configs/eval6/poisoning/audio_dlbd/baseline_defenses/audio_p10_spectral_signature_defense.json
@@ -16,7 +16,7 @@
         "knowledge": "black",
         "kwargs": {
             "backdoor_kwargs": {
-                "backdoor_path": "./armory/utils/triggers/clapping.wav",
+                "backdoor_path": "clapping.wav",
                 "duration": 1,
                 "random": false,
                 "sampling_rate": 16000,


### PR DESCRIPTION
This is a collection of three related commits 0451b347 3f809552 ee0e1abf that were made to branch develop but that we'd like in rc0.16.1. I have cherry-picked them into this work branch for separate review.

The changes create an `armory.SRC_ROOT` variable that is of general utility to code that wants to make root-relative references. It also adds a `armory.utils.triggers.TRIGGERS_DIR` pathlib.Path which contains binary files used mostly by poisoning scenarios. These replace hardcoded paths containing confusing `../../..` style paths.