### PR TITLE
Retain data type for arrays passed into "relable" function

### DIFF
--- a/armory/metrics/task.py
+++ b/armory/metrics/task.py
@@ -1592,7 +1592,10 @@ class HOTA_metrics:
         unique_ids = sorted(set(unique_ids))
         new_unique_ids = list(range(len(unique_ids)))
         id_map = {k: v for k, v in zip(unique_ids, new_unique_ids)}
-        new_list = [np.array([id_map[x] for x in array], dtype=array.dtype) for array in list_of_id_arrays]
+        new_list = [
+            np.array([id_map[x] for x in array], dtype=array.dtype)
+            for array in list_of_id_arrays
+        ]
         return new_unique_ids, new_list
 
     def preprocess(self, gt_data, tracker_data, tracked_class):

--- a/armory/metrics/task.py
+++ b/armory/metrics/task.py
@@ -1592,7 +1592,7 @@ class HOTA_metrics:
         unique_ids = sorted(set(unique_ids))
         new_unique_ids = list(range(len(unique_ids)))
         id_map = {k: v for k, v in zip(unique_ids, new_unique_ids)}
-        new_list = [np.array([id_map[x] for x in array]) for array in list_of_id_arrays]
+        new_list = [np.array([id_map[x] for x in array], dtype=array.dtype) for array in list_of_id_arrays]
         return new_unique_ids, new_list
 
     def preprocess(self, gt_data, tracker_data, tracked_class):


### PR DESCRIPTION
Addresses https://github.com/twosixlabs/armory/issues/1769
Relable function would return subarrays of type `float64` if they are empty which caused issues when passed into the HOTA function which expected it to be of type `int`. Change utilizes the empty array's dtype for consistency.