### PR TITLE
update dataset config schema

### DIFF
--- a/armory/utils/config_schema.json
+++ b/armory/utils/config_schema.json
@@ -36,20 +36,6 @@
             "type": "object"
         },
         "dataset": {
-            "$comment": "Must include at least one of 'test' or 'train'",
-            "additionalProperties": false,
-            "anyOf": [
-                {
-                    "required": [
-                        "test"
-                    ]
-                },
-                {
-                    "required": [
-                        "train"
-                    ]
-                }
-            ],
             "properties": {
                 "test": {
                     "$comment": "See load_dataset() kwargs in armory/datasets/config_load.py",
@@ -86,6 +72,10 @@
                     "type": "object"
                 }
             },
+            "required": [
+                "test"
+            ],
+            "additionalProperties": false,
             "type": "object"
         },
         "defense": {

--- a/armory/utils/config_schema.json
+++ b/armory/utils/config_schema.json
@@ -73,8 +73,8 @@
                 }
             },
             "required": [
-                "test"
             ],
+            "additionalProperties": false,
             "type": "object"
         },
         "defense": {

--- a/armory/utils/config_schema.json
+++ b/armory/utils/config_schema.json
@@ -36,6 +36,45 @@
             "type": "object"
         },
         "dataset": {
+            "properties": {
+                "test": {
+                    "$comment": "See load_dataset() kwargs in armory/datasets/config_load.py",
+                    "properties": {
+                        "batch_size": {
+                            "minimum": 1,
+                            "type": "integer"
+                        },
+                        "name": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "name",
+                        "batch_size"
+                    ],
+                    "type": "object"
+                },
+                "train": {
+                    "$comment": "See load_dataset() kwargs in armory/datasets/config_load.py",
+                    "properties": {
+                        "batch_size": {
+                            "minimum": 1,
+                            "type": "integer"
+                        },
+                        "name": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "name",
+                        "batch_size"
+                    ],
+                    "type": "object"
+                }
+            },
+            "required": [
+                "test"
+            ],
             "type": "object"
         },
         "defense": {

--- a/armory/utils/config_schema.json
+++ b/armory/utils/config_schema.json
@@ -73,6 +73,7 @@
                 }
             },
             "required": [
+                "test"
             ],
             "additionalProperties": false,
             "type": "object"

--- a/armory/utils/config_schema.json
+++ b/armory/utils/config_schema.json
@@ -36,6 +36,20 @@
             "type": "object"
         },
         "dataset": {
+            "$comment": "Must include at least one of 'test' or 'train'",
+            "additionalProperties": false,
+            "anyOf": [
+                {
+                    "required": [
+                        "test"
+                    ]
+                },
+                {
+                    "required": [
+                        "train"
+                    ]
+                }
+            ],
             "properties": {
                 "test": {
                     "$comment": "See load_dataset() kwargs in armory/datasets/config_load.py",
@@ -72,10 +86,6 @@
                     "type": "object"
                 }
             },
-            "required": [
-                "test"
-            ],
-            "additionalProperties": false,
             "type": "object"
         },
         "defense": {


### PR DESCRIPTION
This PR adds structure to the dataset config schema. A couple decisions that were made:

1. it requires that ~~at least one of `"test"` and `"train"` is present underneath `"dataset"`~~
edit: I had it this way, then went back to requiring `"test"`, since there is no "train-only" mode in Armory
2. It allows _only_ the keys `"test"` and `"train"` to go underneath `"dataset"` (via `"additionalProperties": false`) . So if you use a config from current master branch, it will fail with `Could not validate config: Additional properties are not allowed ('module', 'name', 'batch_size', 'framework' were unexpected) @ dataset`
3. for the objects that `"test"` and `"train"` map to, it requires the following two keys: `"batch_size"` and `"name"` 