### PR TITLE
fixing cifar config to comply with recent changes to tfdsv4 branch

### DIFF
--- a/armory/scenarios/scenario.py
+++ b/armory/scenarios/scenario.py
@@ -47,7 +47,7 @@ class Scenario:
             num_eval_batches = 1
             # Modify dataset entries
             if config["model"]["fit"]:
-                config["model"]["fit_kwargs"]["nb_epochs"] = 1
+                config["dataset"]["train"]["epochs"] = 1
             if config.get("attack", {}).get("type") == "preloaded":
                 config["attack"]["check_run"] = True
             # For poisoning scenario

--- a/scenario_configs/eval1-4/cifar/cifar10_baseline.json
+++ b/scenario_configs/eval1-4/cifar/cifar10_baseline.json
@@ -24,6 +24,7 @@
         },
         "train": {
             "batch_size": 64,
+            "epochs": 20,
             "name": "cifar10"
         }
     },
@@ -38,9 +39,7 @@
     },
     "model": {
         "fit": true,
-        "fit_kwargs": {
-            "nb_epochs": 20
-        },
+        "fit_kwargs": {},
         "model_kwargs": {},
         "module": "armory.baseline_models.pytorch.cifar",
         "name": "get_art_model",

--- a/scenario_configs/eval1-4/mnist/mnist_baseline.json
+++ b/scenario_configs/eval1-4/mnist/mnist_baseline.json
@@ -23,6 +23,7 @@
         },
         "train": {
             "batch_size": 128,
+            "epochs": 20,
             "name": "mnist",
             "split": "train"
         }
@@ -38,9 +39,7 @@
     },
     "model": {
         "fit": true,
-        "fit_kwargs": {
-            "nb_epochs": 20
-        },
+        "fit_kwargs": {},
         "model_kwargs": {},
         "module": "armory.baseline_models.keras.mnist",
         "name": "get_art_model",


### PR DESCRIPTION
1. This fix gets rid of the `TypeError: art.estimators.classification.pytorch.PyTorchClassifier.fit_generator() got multiple values for keyword argument 'nb_epochs'` when running the cifar config, since `epochs` is now specified in dataset config rather than model config

2. This PR also fixes a bug where the error above occurs when `--check` is set, since the `scenario.py` logic needed to be updated to modify the _dataset_ config rather than model config when `--check` is set.

3. Same as (1) but for mnist config 