### PR TITLE
Fix for Issue 1620 - remove references to getenv("ARMORY_VERSION")

### DIFF
--- a/armory/docker/management.py
+++ b/armory/docker/management.py
@@ -27,11 +27,11 @@ class ArmoryInstance(object):
     ):
         self.docker_client = docker.from_env(version="auto")
 
-        host_paths = paths.HostPaths()
-        docker_paths = paths.DockerPaths()
-
         envs = envs if envs else {}
         envs["ARMORY_VERSION"] = armory.__version__
+
+        host_paths = paths.HostPaths()
+        docker_paths = paths.DockerPaths()
 
         mounts = [
             docker.types.Mount(
@@ -40,7 +40,7 @@ class ArmoryInstance(object):
                 type="bind",
                 read_only=False,
             )
-            for dir in "cwd dataset_dir local_git_dir output_dir saved_model_dir tmp_dir".split()
+            for dir in ("cwd", "dataset_dir", "local_git_dir", "output_dir", "saved_model_dir", "tmp_dir")
         ]
 
         container_args = {

--- a/armory/docker/management.py
+++ b/armory/docker/management.py
@@ -20,7 +20,7 @@ class ArmoryInstance(object):
         self,
         image_name,
         runtime: str = "runc",
-        envs: dict = {},
+        envs: dict = None,
         ports: dict = None,
         command: str = "tail -f /dev/null",
         user: str = "",
@@ -30,6 +30,7 @@ class ArmoryInstance(object):
         host_paths = paths.HostPaths()
         docker_paths = paths.DockerPaths()
 
+        envs = envs if envs not None else {}
         envs["ARMORY_VERSION"] = armory.__version__
 
         mounts = [

--- a/armory/docker/management.py
+++ b/armory/docker/management.py
@@ -40,7 +40,14 @@ class ArmoryInstance(object):
                 type="bind",
                 read_only=False,
             )
-            for dir in ("cwd", "dataset_dir", "local_git_dir", "output_dir", "saved_model_dir", "tmp_dir")
+            for dir in (
+                "cwd",
+                "dataset_dir",
+                "local_git_dir",
+                "output_dir",
+                "saved_model_dir",
+                "tmp_dir",
+            )
         ]
 
         container_args = {

--- a/armory/docker/management.py
+++ b/armory/docker/management.py
@@ -30,7 +30,7 @@ class ArmoryInstance(object):
         host_paths = paths.HostPaths()
         docker_paths = paths.DockerPaths()
 
-        envs = envs if envs not None else {}
+        envs = envs if envs else {}
         envs["ARMORY_VERSION"] = armory.__version__
 
         mounts = [

--- a/armory/docker/management.py
+++ b/armory/docker/management.py
@@ -20,7 +20,7 @@ class ArmoryInstance(object):
         self,
         image_name,
         runtime: str = "runc",
-        envs: dict = None,
+        envs: dict = {},
         ports: dict = None,
         command: str = "tail -f /dev/null",
         user: str = "",
@@ -29,6 +29,8 @@ class ArmoryInstance(object):
 
         host_paths = paths.HostPaths()
         docker_paths = paths.DockerPaths()
+
+        envs["ARMORY_VERSION"] = armory.__version__
 
         mounts = [
             docker.types.Mount(

--- a/armory/environment.py
+++ b/armory/environment.py
@@ -1,5 +1,0 @@
-"""
-Environment parameter names
-"""
-
-ARMORY_VERSION = "ARMORY_VERSION"

--- a/armory/eval/evaluator.py
+++ b/armory/eval/evaluator.py
@@ -11,7 +11,6 @@ import sys
 
 import requests
 
-import armory
 from armory.configuration import load_global_config
 from armory.docker.management import ManagementInstance, ArmoryInstance
 from armory.docker.host_management import HostManagementInstance

--- a/armory/eval/evaluator.py
+++ b/armory/eval/evaluator.py
@@ -110,8 +110,6 @@ class Evaluator(object):
             torch_home = paths.DockerPaths().pytorch_dir
         self.extra_env_vars["TORCH_HOME"] = torch_home
 
-        self.extra_env_vars["ARMORY_VERSION"] = armory.__version__
-
     def _cleanup(self):
         log.info(f"deleting tmp_dir {self.tmp_dir}")
         try:

--- a/armory/eval/evaluator.py
+++ b/armory/eval/evaluator.py
@@ -17,7 +17,6 @@ from armory.docker.management import ManagementInstance, ArmoryInstance
 from armory.docker.host_management import HostManagementInstance
 from armory.utils.printing import bold, red
 from armory import paths
-from armory import environment
 from armory.logs import log, is_debug, added_filters
 
 
@@ -111,7 +110,7 @@ class Evaluator(object):
             torch_home = paths.DockerPaths().pytorch_dir
         self.extra_env_vars["TORCH_HOME"] = torch_home
 
-        self.extra_env_vars[environment.ARMORY_VERSION] = armory.__version__
+        self.extra_env_vars["ARMORY_VERSION"] = armory.__version__
 
     def _cleanup(self):
         log.info(f"deleting tmp_dir {self.tmp_dir}")

--- a/armory/scenarios/main.py
+++ b/armory/scenarios/main.py
@@ -21,7 +21,7 @@ import pytest
 import time
 
 import armory
-from armory import environment, paths, validation, Config
+from armory import paths, validation, Config
 from armory.utils import config_loading, external_repo
 from armory.utils.configuration import load_config
 from armory.logs import log, update_filters, make_logfiles
@@ -208,7 +208,7 @@ if __name__ == "__main__":
     args = parser.parse_args()
     update_filters(args.log_level, args.debug)
     log.trace(f"main.py called update_filters({args.log_level} debug: {args.debug})")
-    calling_version = os.getenv(environment.ARMORY_VERSION, "UNKNOWN")
+    calling_version = os.environ.get("ARMORY_VERSION", "UNKNOWN")
     if calling_version != armory.__version__:
         log.warning(
             f"armory calling version {calling_version} != "

--- a/armory/scenarios/main.py
+++ b/armory/scenarios/main.py
@@ -27,6 +27,9 @@ from armory.utils.configuration import load_config
 from armory.logs import log, update_filters, make_logfiles
 
 
+CLIENT_ARMORY_VERSION = "ARMORY_VERSION"
+
+
 def _scenario_setup(config: Config) -> None:
     """
     Creates scenario specific tmp and output directiories.
@@ -208,7 +211,7 @@ if __name__ == "__main__":
     args = parser.parse_args()
     update_filters(args.log_level, args.debug)
     log.trace(f"main.py called update_filters({args.log_level} debug: {args.debug})")
-    calling_version = os.environ.get("ARMORY_VERSION", "UNKNOWN")
+    calling_version = os.environ.get(CLIENT_ARMORY_VERSION, "UNKNOWN")
     if calling_version != armory.__version__:
         log.warning(
             f"armory calling version {calling_version} != "

--- a/tools/pre-commit.sh
+++ b/tools/pre-commit.sh
@@ -53,8 +53,11 @@ pushd $PROJECT_ROOT > /dev/null || exit 1
         echo "⚫ Executing 'black' formatter..."
         python -m black --check ${TARGET_FILES} > /dev/null 2>&1
         if [ $? -ne 0 ]; then
-            python -m black $TARGET_FILES
             echo "⚫ some files were formatted."
+            if [ "${ARMORY_CI_TEST}" -ne 0 ]; then
+                python -m black --diff $TARGET_FILES
+            fi
+            python -m black $TARGET_FILES
             CHECK_EXIT_STATUS 1
         fi
 


### PR DESCRIPTION
Removes references to `getenv("ARMORY_VERSION")`.

see Issue #1620 