### PR TITLE
offload scenario-runner to self-hosted

### DIFF
--- a/.github/workflows/scenario-runner.yml
+++ b/.github/workflows/scenario-runner.yml
@@ -27,7 +27,7 @@ on:
 jobs:
   matrix_generator:
     name: Matrix Generator
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted]
     outputs:
       matrix: ${{ steps.generate-matrix.outputs.matrix }}
     steps:


### PR DESCRIPTION
The scenario-runner test exhausts resources on Github-hosted action runners. This causes them to use our self hosted runner.
