### PR TITLE
Updated imagenette

### DIFF
--- a/armory/datasets/build.py
+++ b/armory/datasets/build.py
@@ -127,9 +127,6 @@ def build_info(name: str, version: str = None, data_dir: str = None):
     """
     if data_dir is None:
         data_dir = common.get_root()
-    # including version as an argument will return True for tfds.core.load._try_load_from_files_first,
-    # which will return a tensorflow_datasets.core.read_only_builder.ReadOnlyBuilder object with an empty BUILDER_CONFIGS
-    # builder = tfds.builder(name, version=version, data_dir=data_dir)
     builder = tfds.builder(name, data_dir=data_dir)
     version = str(builder.info.version)
     built_data_dir = builder.info.data_dir

--- a/armory/datasets/build.py
+++ b/armory/datasets/build.py
@@ -127,11 +127,18 @@ def build_info(name: str, version: str = None, data_dir: str = None):
     """
     if data_dir is None:
         data_dir = common.get_root()
-    builder = tfds.builder(name, version=version, data_dir=data_dir)
+    # including version as an argument will return True for tfds.core.load._try_load_from_files_first,
+    # which will return a tensorflow_datasets.core.read_only_builder.ReadOnlyBuilder object with an empty BUILDER_CONFIGS
+    # builder = tfds.builder(name, version=version, data_dir=data_dir)
+    builder = tfds.builder(name, data_dir=data_dir)
+    # print(builder)
     version = str(builder.info.version)
     built_data_dir = builder.info.data_dir
     subdir = Path(built_data_dir).relative_to(data_dir)
-    return version, data_dir, built_data_dir, subdir
+    builder_configs = builder.BUILDER_CONFIGS
+    # print(builder.BUILDER_CONFIGS)
+    # print(builder_configs)
+    return version, data_dir, built_data_dir, subdir, builder_configs
 
 
 if __name__ == "__main__":

--- a/armory/datasets/build.py
+++ b/armory/datasets/build.py
@@ -131,13 +131,11 @@ def build_info(name: str, version: str = None, data_dir: str = None):
     # which will return a tensorflow_datasets.core.read_only_builder.ReadOnlyBuilder object with an empty BUILDER_CONFIGS
     # builder = tfds.builder(name, version=version, data_dir=data_dir)
     builder = tfds.builder(name, data_dir=data_dir)
-    # print(builder)
     version = str(builder.info.version)
     built_data_dir = builder.info.data_dir
     subdir = Path(built_data_dir).relative_to(data_dir)
     builder_configs = builder.BUILDER_CONFIGS
-    # print(builder.BUILDER_CONFIGS)
-    # print(builder_configs)
+
     return version, data_dir, built_data_dir, subdir, builder_configs
 
 

--- a/armory/datasets/cached_datasets.json
+++ b/armory/datasets/cached_datasets.json
@@ -27,6 +27,20 @@
         "url": null,
         "version": "1.0.8"
     },
+    "imagenette": {
+        "sha256": "ca79a0f077d95dcd8510ec0755b8c80b3c169095bc1cedcb32e7022513f68124",
+        "size": 3990756717,
+        "subdir": [
+            "imagenette/full-size-v2/1.0.0",
+            "imagenette/320px-v2/1.0.0",
+            "imagenette/160px-v2/1.0.0",
+            "imagenette/full-size/1.0.0",
+            "imagenette/320px/1.0.0",
+            "imagenette/160px/1.0.0"
+        ],
+        "url": null,
+        "version": "1.0.0"
+    },
     "mnist": {
         "sha256": "fdc3408e29580367145e95ac7cb1d51e807105b174314cd52c16d27a13b98979",
         "size": 16920751,

--- a/armory/datasets/cached_datasets.json
+++ b/armory/datasets/cached_datasets.json
@@ -36,7 +36,8 @@
             "imagenette/160px-v2/1.0.0",
             "imagenette/full-size/1.0.0",
             "imagenette/320px/1.0.0",
-            "imagenette/160px/1.0.0"
+            "imagenette/160px/1.0.0",
+            "imagenette/.config"
         ],
         "url": null,
         "version": "1.0.0"

--- a/armory/datasets/config_load.py
+++ b/armory/datasets/config_load.py
@@ -8,6 +8,7 @@ from armory.datasets import load, preprocessing, generator, filtering
 def load_dataset(
     name=None,
     version=None,
+    config=None,
     batch_size=1,
     num_batches=None,
     epochs=1,
@@ -24,7 +25,9 @@ def load_dataset(
     # All are keyword elements by design
     if name is None:
         raise ValueError("name must be specified, not None")
-    info, ds_dict = load.load(name, version=version, shuffle_files=shuffle_files)
+    info, ds_dict = load.load(
+        name, version=version, config=config, shuffle_files=shuffle_files
+    )
 
     if class_ids is None:
         element_filter = None

--- a/armory/datasets/download.py
+++ b/armory/datasets/download.py
@@ -64,7 +64,9 @@ def download(
         if overwrite:
             filepath.unlink()
         else:
-            raise ValueError("set overwrite=True to overwrite existing file")
+            raise ValueError(
+                f"set overwrite=True to overwrite cached dataset tarfile at {filepath}"
+            )
 
     key = common.get_cache_key(name, version)
     download_file_from_s3(str(key), str(filepath), public=public)

--- a/armory/datasets/load.py
+++ b/armory/datasets/load.py
@@ -40,6 +40,7 @@ def ensure_download_extract(
 def load(
     name: str,
     version: str = None,
+    config: str = None,
     data_dir: str = None,
     download_cached: bool = True,
     verify: bool = True,
@@ -64,7 +65,7 @@ def load(
         data_dir = common.get_root()
 
     try:
-        builder = tfds.builder(name, version=version, data_dir=data_dir)
+        builder = tfds.builder(name, version=version, data_dir=data_dir, config=config)
         ds = builder.as_dataset(**as_dataset_kwargs)
         return builder.info, ds
     except (tfds.core.registered.DatasetNotFoundError, AssertionError):
@@ -85,7 +86,7 @@ def load(
         else:
             raise ValueError(f"dataset {name} not recognized")
 
-    builder = tfds.builder(name, version=version, data_dir=data_dir)
+    builder = tfds.builder(name, version=version, data_dir=data_dir, config=config)
     ds = builder.as_dataset(**as_dataset_kwargs)
     return builder.info, ds
 

--- a/armory/datasets/package.py
+++ b/armory/datasets/package.py
@@ -29,9 +29,6 @@ def package(
     else:
         # including .config, which contains metadata.json that tfds refers to for default_config_name of a given dataset
         # .config and metadata.json are hardcoded values for tfds v4.6.0
-        # should subdirectories exist in a dataset, user has the option to choose a subdirectory
-        # if the user does not make a selection via a scenario json file, armory will pick one via
-        # tfds, which will get default_config_name from .config/metadata.json to make a subdirectory selection
         tar_list = [
             str(Path(name) / config.name / version) for config in builder_configs
         ] + [str(Path(name) / ".config")]
@@ -177,7 +174,9 @@ def extract(name, data_dir: str = None, overwrite: bool = False):
     for expected_subdir in expected_subdir_list:
         source_data_dir = tmp_dir / expected_subdir
         if any(child.is_dir() for child in source_data_dir.iterdir()):
-            raise ValueError("Data directory should not have subdirectories")
+            raise ValueError(
+                f"{source_data_dir} directory should not have subdirectories"
+            )
 
         target_data_dir = data_dir / expected_subdir
         if target_data_dir.exists() and overwrite:

--- a/armory/datasets/package.py
+++ b/armory/datasets/package.py
@@ -69,10 +69,13 @@ def update(name, version: str = None, data_dir: str = None, url=None):
         raise FileNotFoundError(f"filepath '{filepath}' not found.")
     assert (name, version) == common.parse_cache_filename(filepath.name)
 
+    # we will rely on subdir to check what gets extracted from a cached file in package.extract
     if not builder_configs:
         subdir = str(Path(name) / version)
     else:
-        subdir = [str(Path(name) / config.name / version) for config in builder_configs]
+        subdir = [
+            str(Path(name) / config.name / version) for config in builder_configs
+        ] + [str(Path(name) / ".config")]
     file_size, file_sha256 = common.hash_file(filepath)
 
     common.update_cached_datasets(name, version, subdir, file_size, file_sha256, url)
@@ -102,10 +105,16 @@ def extract(name, data_dir: str = None, overwrite: bool = False):
     filepath = common.get_cache_dataset_path(name, version)
     if not filepath.is_file():
         raise FileNotFoundError(f"filepath '{filepath}' for dataset {name} not found.")
+    subdir_list = common.cached_datasets()[name]["subdir"]
+    if isinstance(subdir_list, str):
+        subdir_list = [subdir_list]
 
-    target_data_dir = data_dir / name / version
-    if target_data_dir.exists() and not overwrite:
-        raise ValueError("Target directory exists. Set overwrite=True to overwrite")
+    for subdir in subdir_list:
+        target_data_dir = data_dir / subdir
+        if target_data_dir.exists() and not overwrite:
+            raise ValueError(
+                f"Target directory {target_data_dir} exists. Set overwrite=True to overwrite"
+            )
 
     # Extract to tmp directory
     tmp_dir = Path(cache_dir) / (
@@ -117,21 +126,43 @@ def extract(name, data_dir: str = None, overwrite: bool = False):
     completed_process = subprocess.run(cmd)
     completed_process.check_returncode()
 
-    # should have directory structure <tmp_dir>/<name>/<version>/<data>
-    if len(os.listdir(tmp_dir)) != 1:
+    tmp_dir_listdir = os.listdir(tmp_dir)
+    # should have directory structure <tmp_dir>/<name>/*
+    if len(tmp_dir_listdir) != 1:
         raise ValueError(f"{tmp_dir} has more than 1 directory inside")
-    if name not in os.listdir(tmp_dir):
+    if name not in tmp_dir_listdir:
         raise ValueError(f"{name} does not match directory in {tmp_dir}")
     tmp_dir_name = tmp_dir / name
 
-    if len(os.listdir(tmp_dir_name)) != 1:
-        raise ValueError(f"{tmp_dir_name} has more than 1 directory inside")
-    if version not in os.listdir(tmp_dir_name):
-        raise ValueError(f"{version} does not match directory in {tmp_dir_name}")
-    source_data_dir = tmp_dir_name / version
+    tmp_dir_name_listdir = os.listdir(tmp_dir_name)
+    subdir_parsed_list = [subdir.split("/")[1] for subdir in subdir_list]
+    if set(tmp_dir_name_listdir) != set(subdir_parsed_list):
+        raise ValueError(
+            f"Directories in {tmp_dir_name_listdir} do not match {subdir_parsed_list}"
+        )
+    if len(tmp_dir_name_listdir) > 1:
+        for tmp_subdir in tmp_dir_name_listdir:
+            if tmp_subdir == ".config":
+                # should have directory structure <tmp_dir>/<name>/.config/metadata.json
+                if "metadata.json" not in os.listdir(tmp_dir_name / tmp_subdir):
+                    raise ValueError(
+                        f"metadata.json not in directory {tmp_dir_name / tmp_subdir}"
+                    )
+            else:
+                # should have directory structure <tmp_dir>/<name>/<tmp_subdir>/<version>
+                if version not in os.listdir(tmp_dir_name / tmp_subdir):
+                    raise ValueError(
+                        f"{version} does not match directory in {tmp_dir_name / tmp_subdir}"
+                    )
+    else:
+        # should have directory structure <tmp_dir>/<name>/<version>
+        if version not in tmp_dir_name_listdir:
+            raise ValueError(f"{version} does not match directory in {tmp_dir_name}")
 
-    if any(child.is_dir() for child in source_data_dir.iterdir()):
-        raise ValueError("Data directory should not have subdirectories")
+    for subdir in subdir_list:
+        source_data_dir = tmp_dir / subdir
+        if any(child.is_dir() for child in source_data_dir.iterdir()):
+            raise ValueError("Data directory should not have subdirectories")
 
     if target_data_dir.exists() and overwrite:
         shutil.rmtree(target_data_dir)

--- a/armory/datasets/package.py
+++ b/armory/datasets/package.py
@@ -22,13 +22,16 @@ def package(
         name, version=version, data_dir=data_dir
     )
 
-    # print(builder_configs)
     data_dir = Path(data_dir)
 
     if not builder_configs:
         tar_list = [str(Path(name) / version)]
     else:
-        # metadata.json contains default_config_name for the given dataset
+        # including .config, which contains metadata.json that tfds refers to for default_config_name of a given dataset
+        # .config and metadata.json are hardcoded values for tfds v4.6.0
+        # should subdirectories exist in a dataset, user has the option to choose a subdirectory
+        # if the user does not make a selection via a scenario json file, armory will pick one via
+        # tfds, which will get default_config_name from .config/metadata.json to make a subdirectory selection
         tar_list = [
             str(Path(name) / config.name / version) for config in builder_configs
         ] + [str(Path(name) / ".config")]
@@ -36,7 +39,6 @@ def package(
     for tar_path in tar_list:
         expected_dir = data_dir / tar_path
         if not expected_dir.is_dir():
-            # raise FileNotFoundError(f"Dataset {name} not found at {expected_dir}")
             raise FileNotFoundError(f"Dataset {tar_path} not found at {expected_dir}")
 
     tar_full_filepath = common.get_cache_dataset_path(name, version)

--- a/armory/datasets/package.py
+++ b/armory/datasets/package.py
@@ -8,6 +8,11 @@ import subprocess
 from armory.logs import log
 from armory.datasets import build, common, upload
 
+# .config and metadata.json are hardcoded values for tfds v4.6.0
+# https://github.com/tensorflow/datasets/blob/v4.6.0/tensorflow_datasets/core/dataset_builder.py#L1257-L1286
+DEFAULT_CONFIG_DIR = ".config"
+DEFAULT_CONFIG_FILE = "metadata.json"
+
 
 def package(
     name,
@@ -27,11 +32,10 @@ def package(
     if not builder_configs:
         tar_list = [str(Path(name) / version)]
     else:
-        # including .config, which contains metadata.json that tfds refers to for default_config_name of a given dataset
-        # .config and metadata.json are hardcoded values for tfds v4.6.0
+        # including DEFAULT_CONFIG_DIR, which contains DEFAULT_CONFIG_FILE that tfds refers to for default_config_name of a given dataset
         tar_list = [
             str(Path(name) / config.name / version) for config in builder_configs
-        ] + [str(Path(name) / ".config")]
+        ] + [str(Path(name) / DEFAULT_CONFIG_DIR)]
 
     for tar_path in tar_list:
         expected_dir = data_dir / tar_path
@@ -74,7 +78,7 @@ def update(name, version: str = None, data_dir: str = None, url=None):
     else:
         subdir = [
             str(Path(name) / config.name / version) for config in builder_configs
-        ] + [str(Path(name) / ".config")]
+        ] + [str(Path(name) / DEFAULT_CONFIG_DIR)]
     file_size, file_sha256 = common.hash_file(filepath)
 
     common.update_cached_datasets(name, version, subdir, file_size, file_sha256, url)
@@ -111,7 +115,7 @@ def extract(name, data_dir: str = None, overwrite: bool = False):
     # expected_subdir format is one of three formats:
     # <name>/<version>
     # <name>/<config>/<version>
-    # <name>/.config
+    # <name>/DEFAULT_CONFIG_DIR
     for expected_subdir in expected_subdir_list:
         target_data_dir = data_dir / expected_subdir
         if target_data_dir.exists() and not overwrite:
@@ -137,9 +141,9 @@ def extract(name, data_dir: str = None, overwrite: bool = False):
         raise ValueError(f"{name} does not match directory in {tmp_dir}")
     tmp_dir_name = tmp_dir / name
 
-    # elements in tmp_dir_name_listdir should be one of three values: <version>, <config>, .config
+    # elements in tmp_dir_name_listdir should be one of three values: <version>, <config>, DEFAULT_CONFIG_DIR
     tmp_dir_name_listdir = os.listdir(tmp_dir_name)
-    # elements in expected_subdir_parsed_list is one of three values: <version>, <config>, .config
+    # elements in expected_subdir_parsed_list is one of three values: <version>, <config>, DEFAULT_CONFIG_DIR
     expected_subdir_parsed_list = [
         expected_subdir.split("/")[1] for expected_subdir in expected_subdir_list
     ]
@@ -150,15 +154,15 @@ def extract(name, data_dir: str = None, overwrite: bool = False):
         )
 
     # len(tmp_dir_name_listdir) > 1 means that subdirectories exist in a dataset
-    # and tmp_subdir should be <config> or .config
+    # and tmp_subdir should be <config> or DEFAULT_CONFIG_DIR
     # else, tmp_subdir should be <version>
     if len(tmp_dir_name_listdir) > 1:
         for tmp_subdir in tmp_dir_name_listdir:
-            if tmp_subdir == ".config":
-                # should have directory structure <tmp_dir>/<name>/.config/metadata.json
-                if "metadata.json" not in os.listdir(tmp_dir_name / tmp_subdir):
+            if tmp_subdir == DEFAULT_CONFIG_DIR:
+                # should have directory structure <tmp_dir>/<name>/DEFAULT_CONFIG_DIR/DEFAULT_CONFIG_FILE
+                if DEFAULT_CONFIG_FILE not in os.listdir(tmp_dir_name / tmp_subdir):
                     raise ValueError(
-                        f"metadata.json not in directory {tmp_dir_name / tmp_subdir}"
+                        f"{DEFAULT_CONFIG_DIR} not in directory {tmp_dir_name / tmp_subdir}"
                     )
             else:
                 # should have directory structure <tmp_dir>/<name>/<tmp_subdir>/<version>

--- a/armory/datasets/preprocessing.py
+++ b/armory/datasets/preprocessing.py
@@ -42,6 +42,7 @@ def supervised_image_classification(element):
 mnist = register(supervised_image_classification, "mnist")
 cifar10 = register(supervised_image_classification, "cifar10")
 cifar100 = register(supervised_image_classification, "cifar100")
+imagenette = register(supervised_image_classification, "imagenette")
 resisc45 = register(supervised_image_classification, "resisc45")
 
 


### PR DESCRIPTION
Updated code for packaging, uploading, and loading datasets for armory run to account for cases where datasets have subdirectories. User can specify the desired subdirectory with optional `config` as kwarg for `test` or `train` of `dataset` in config json file. `config` value must match the name of one of the subdirectories - if `config` is not specified, `tfds.builder` seems to refer to `imagenette/.config/metadata.json` for the `config` value. This update assumes that all `tfds` datasets have `.config/metadata.json` if the dataset has subdirectories. We are working off of `v4.6.0` of `tfds` - code may need to be updated should `tfds` version change.

Note: When testing `imagenette`, I could tell that a different subdirectory was being used by the number of samples from `armory` logs