### PR TITLE
runs scenario checks on self-hosted runner

### DIFF
--- a/.github/workflows/scenario-runner.yml
+++ b/.github/workflows/scenario-runner.yml
@@ -27,7 +27,7 @@ on:
 jobs:
   matrix_generator:
     name: Matrix Generator
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted]
     outputs:
       matrix: ${{ steps.generate-matrix.outputs.matrix }}
     steps:
@@ -43,7 +43,7 @@ jobs:
 
 
   matrix_job:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted]
     needs: matrix_generator
     strategy:
       fail-fast: false


### PR DESCRIPTION
This repoints the scenario-runner CI to execute on our self-hosted runner because the Github hosted runners are too small for those tests.