### PR TITLE
Sleeper agent fix

### DIFF
--- a/armory/scenarios/poisoning_sleeper_agent.py
+++ b/armory/scenarios/poisoning_sleeper_agent.py
@@ -167,4 +167,19 @@ class SleeperAgentScenario(Poison):
                 np.array([]),
             )
 
+        # poison_index returned by attack is the index within the target class, not the whole dataset.
+        # In addition, it may contain images that aren't actually perturbed.
+        # Find the true poison indices
+        true_poison_inds = np.array(
+            [
+                i
+                for i in range(len(self.x_clean))
+                if (self.x_clean[i] != self.x_poison[i]).all()
+            ]
+        )
+        n_target = (self.y_clean == self.target_class).sum()
+        log.info(
+            f"Actual amount of poison returned by attack: {len(true_poison_inds)} samples or {len(true_poison_inds)/n_target} percent"
+        )
+        self.poison_index = true_poison_inds
         self.record_poison_and_data_info()

--- a/armory/scenarios/poisoning_sleeper_agent.py
+++ b/armory/scenarios/poisoning_sleeper_agent.py
@@ -170,7 +170,7 @@ class SleeperAgentScenario(Poison):
         # poison_index returned by attack is the index within the target class, not the whole dataset.
         # In addition, it may contain images that aren't actually perturbed.
         # Find the true poison indices
-        true_poison_inds = np.array(
+        poison_index = np.array(
             [
                 i
                 for i in range(len(self.x_clean))
@@ -179,7 +179,7 @@ class SleeperAgentScenario(Poison):
         )
         n_target = (self.y_clean == self.target_class).sum()
         log.info(
-            f"Actual amount of poison returned by attack: {len(true_poison_inds)} samples or {len(true_poison_inds)/n_target} percent"
+            f"Actual amount of poison returned by attack: {len(poison_index)} samples or {len(poison_index)/n_target} percent"
         )
-        self.poison_index = true_poison_inds
+        self.poison_index = poison_index
         self.record_poison_and_data_info()

--- a/armory/scenarios/poisoning_sleeper_agent.py
+++ b/armory/scenarios/poisoning_sleeper_agent.py
@@ -154,14 +154,14 @@ class SleeperAgentScenario(Poison):
             (
                 self.x_poison,
                 self.y_poison,
-                self.poison_index,
+                poison_index,
             ) = self.poisoner.poison_dataset(
                 self.x_clean,
                 self.label_function(self.y_clean),
                 return_index=True,
             )
         else:
-            self.x_poison, self.y_poison, self.poison_index = (
+            self.x_poison, self.y_poison, poison_index = (
                 self.x_clean,
                 self.y_clean,
                 np.array([]),

--- a/armory/scenarios/poisoning_sleeper_agent.py
+++ b/armory/scenarios/poisoning_sleeper_agent.py
@@ -97,7 +97,13 @@ class SleeperAgentScenario(Poison):
             kwargs = attack_config["kwargs"]
             patch_size = kwargs.pop("patch_size")
             patch = Image.open(triggers.get_path(kwargs["patch"]))
-            patch = np.asarray(patch.resize((patch_size, patch_size)))
+            patch = np.asarray(patch.resize((patch_size, patch_size))).astype(
+                np.float64
+            )
+            if np.max(patch) > 1:
+                # scale patch if needed
+                patch /= 255.0
+
             device_name = kwargs.pop("device_name", None)
             if device_name is None:
                 try:


### PR DESCRIPTION
Corrections: scale the patch to [0,1], and find the correct poison indices.

Note: running the current configs will return low attack success because the attack parameters are tuned for a slightly different resnet version.