### PR TITLE
Speech commands explanatory model

### DIFF
--- a/armory/art_experimental/attacks/poison_loader_audio.py
+++ b/armory/art_experimental/attacks/poison_loader_audio.py
@@ -60,6 +60,7 @@ class CacheTrigger:
             raise ValueError("Shift + Backdoor length is greater than audio's length.")
 
         audio[shift : shift + bd_length] += self.scaled_trigger
+        audio = np.clip(audio, -1.0, 1.0)
         return audio.astype(original_dtype)
 
 

--- a/armory/metrics/poisoning.py
+++ b/armory/metrics/poisoning.py
@@ -16,7 +16,6 @@ EXPLANATORY_MODEL_CONFIGS = explanatory_model_configs = {
         "model_framework": "tensorflow",
         "module": "armory.baseline_models.tf_graph.audio_resnet50",
         "name": "get_unwrapped_model",
-        "preprocess_kwargs": {},
         "weights_file": "speech_commands_explanatory_model_resnet50_bean.h5",
     },
     "cifar10_explanatory_model": {
@@ -27,14 +26,11 @@ EXPLANATORY_MODEL_CONFIGS = explanatory_model_configs = {
         },
         "module": "armory.baseline_models.pytorch.resnet18_bean_regularization",
         "name": "get_model",
-        "preprocess_kwargs": {},
         "weights_file": "cifar10_explanatory_model_resnet18_bean.pt",
     },
     "gtsrb_explanatory_model": {
-        "model_kwargs": {},
         "module": "armory.baseline_models.pytorch.micronnet_gtsrb_bean_regularization",
         "name": "get_model",
-        "preprocess_kwargs": {},
         "weights_file": "gtsrb_explanatory_model_micronnet_bean.pt",
     },
     "resisc10_explanatory_model": {
@@ -62,7 +58,7 @@ class ExplanatoryModel:
         data_modality="image",
         model_framework="pytorch",
         activation_layer=None,
-        preprocess_kwargs={},
+        preprocess_kwargs=None,
     ):
         """
         explanatory_model: A callable pytorch or tensorflow model used to produce
@@ -84,7 +80,7 @@ class ExplanatoryModel:
         self.data_modality = data_modality
         self.model_framework = model_framework
         self.activation_layer = activation_layer
-        self.preprocess_kwargs = preprocess_kwargs
+        self.preprocess_kwargs = preprocess_kwargs if preprocess_kwargs else {}
 
         if self.activation_layer is not None:
             if self.model_framework == "tensorflow":

--- a/armory/metrics/poisoning.py
+++ b/armory/metrics/poisoning.py
@@ -18,7 +18,7 @@ EXPLANATORY_MODEL_CONFIGS = explanatory_model_configs = {
         "model_framework": "tensorflow",
         "weights_file": "speech_commands_explanatory_model_resnet50_bean.h5",
     },
-    "cifar10_silhouette_model": {
+    "cifar10_explanatory_model": {
         "model_kwargs": {
             "data_means": [0.4914, 0.4822, 0.4465],
             "data_stds": [0.2471, 0.2435, 0.2616],
@@ -29,14 +29,14 @@ EXPLANATORY_MODEL_CONFIGS = explanatory_model_configs = {
         "resize_image": False,
         "weights_file": "cifar10_explanatory_model_resnet18_bean.pt",
     },
-    "gtsrb_silhouette_model": {
+    "gtsrb_explanatory_model": {
         "model_kwargs": {},
         "module": "armory.baseline_models.pytorch.micronnet_gtsrb_bean_regularization",
         "name": "get_model",
         "resize_image": False,
         "weights_file": "gtsrb_explanatory_model_micronnet_bean.pt",
     },
-    "resisc10_silhouette_model": {
+    "resisc10_explanatory_model": {
         "model_kwargs": {
             "data_means": [0.39382024, 0.4159701, 0.40887499],
             "data_stds": [0.18931773, 0.18901625, 0.19651154],

--- a/scenario_configs/eval1-4/poisoning/gtsrb_scenario_clbd.json
+++ b/scenario_configs/eval1-4/poisoning/gtsrb_scenario_clbd.json
@@ -3,7 +3,7 @@
     "adhoc": {
         "compute_fairness_metrics": true,
         "experiment_id": 0,
-        "explanatory_model": "gtsrb_silhouette_model",
+        "explanatory_model": "gtsrb_explanatory_model",
         "poison_dataset": true,
         "source_class": 1,
         "split_id": 0,

--- a/scenario_configs/eval1-4/poisoning/gtsrb_scenario_clbd_bullethole.json
+++ b/scenario_configs/eval1-4/poisoning/gtsrb_scenario_clbd_bullethole.json
@@ -3,7 +3,7 @@
     "adhoc": {
         "compute_fairness_metrics": true,
         "experiment_id": 0,
-        "explanatory_model": "gtsrb_silhouette_model",
+        "explanatory_model": "gtsrb_explanatory_model",
         "poison_dataset": true,
         "source_class": 1,
         "split_id": 0,

--- a/scenario_configs/eval1-4/poisoning/gtsrb_scenario_clbd_defended.json
+++ b/scenario_configs/eval1-4/poisoning/gtsrb_scenario_clbd_defended.json
@@ -3,7 +3,7 @@
     "adhoc": {
         "compute_fairness_metrics": true,
         "experiment_id": 0,
-        "explanatory_model": "gtsrb_silhouette_model",
+        "explanatory_model": "gtsrb_explanatory_model",
         "poison_dataset": true,
         "source_class": 1,
         "split_id": 0,

--- a/scenario_configs/eval1-4/poisoning/resisc10_poison_dlbd.json
+++ b/scenario_configs/eval1-4/poisoning/resisc10_poison_dlbd.json
@@ -3,7 +3,7 @@
     "adhoc": {
         "compute_fairness_metrics": true,
         "experiment_id": 0,
-        "explanatory_model": "resisc10_silhouette_model",
+        "explanatory_model": "resisc10_explanatory_model",
         "fraction_poisoned": 0.1,
         "poison_dataset": true,
         "source_class": 1,

--- a/scenario_configs/eval5/poisoning/baseline_defenses/cifar10/dlbd/copyright/cifar10_dlbd_copyright_activation_defense.json
+++ b/scenario_configs/eval5/poisoning/baseline_defenses/cifar10/dlbd/copyright/cifar10_dlbd_copyright_activation_defense.json
@@ -3,7 +3,7 @@
     "adhoc": {
         "compute_fairness_metrics": true,
         "experiment_id": 0,
-        "explanatory_model": "cifar10_silhouette_model",
+        "explanatory_model": "cifar10_explanatory_model",
         "fraction_poisoned": 0.1,
         "poison_dataset": true,
         "source_class": 0,

--- a/scenario_configs/eval5/poisoning/baseline_defenses/cifar10/dlbd/copyright/cifar10_dlbd_copyright_perfect_filter.json
+++ b/scenario_configs/eval5/poisoning/baseline_defenses/cifar10/dlbd/copyright/cifar10_dlbd_copyright_perfect_filter.json
@@ -3,7 +3,7 @@
     "adhoc": {
         "compute_fairness_metrics": true,
         "experiment_id": 0,
-        "explanatory_model": "cifar10_silhouette_model",
+        "explanatory_model": "cifar10_explanatory_model",
         "fraction_poisoned": 0.1,
         "poison_dataset": true,
         "source_class": 0,

--- a/scenario_configs/eval5/poisoning/baseline_defenses/cifar10/dlbd/copyright/cifar10_dlbd_copyright_random_filter.json
+++ b/scenario_configs/eval5/poisoning/baseline_defenses/cifar10/dlbd/copyright/cifar10_dlbd_copyright_random_filter.json
@@ -3,7 +3,7 @@
     "adhoc": {
         "compute_fairness_metrics": true,
         "experiment_id": 0,
-        "explanatory_model": "cifar10_silhouette_model",
+        "explanatory_model": "cifar10_explanatory_model",
         "fit_defense_classifier_outside_defense": false,
         "fraction_poisoned": 0.1,
         "poison_dataset": true,

--- a/scenario_configs/eval5/poisoning/baseline_defenses/cifar10/dlbd/copyright/cifar10_dlbd_copyright_spectral_signature_defense.json
+++ b/scenario_configs/eval5/poisoning/baseline_defenses/cifar10/dlbd/copyright/cifar10_dlbd_copyright_spectral_signature_defense.json
@@ -3,7 +3,7 @@
     "adhoc": {
         "compute_fairness_metrics": true,
         "experiment_id": 0,
-        "explanatory_model": "cifar10_silhouette_model",
+        "explanatory_model": "cifar10_explanatory_model",
         "fraction_poisoned": 0.1,
         "poison_dataset": true,
         "source_class": 0,

--- a/scenario_configs/eval5/poisoning/baseline_defenses/cifar10/dlbd/copyright/cifar10_dlbd_copyright_undefended.json
+++ b/scenario_configs/eval5/poisoning/baseline_defenses/cifar10/dlbd/copyright/cifar10_dlbd_copyright_undefended.json
@@ -3,7 +3,7 @@
     "adhoc": {
         "compute_fairness_metrics": true,
         "experiment_id": 0,
-        "explanatory_model": "cifar10_silhouette_model",
+        "explanatory_model": "cifar10_explanatory_model",
         "fraction_poisoned": 0.1,
         "poison_dataset": true,
         "source_class": 0,

--- a/scenario_configs/eval5/poisoning/baseline_defenses/cifar10/dlbd/watermark/cifar10_dlbd_watermark_activation_defense.json
+++ b/scenario_configs/eval5/poisoning/baseline_defenses/cifar10/dlbd/watermark/cifar10_dlbd_watermark_activation_defense.json
@@ -3,7 +3,7 @@
     "adhoc": {
         "compute_fairness_metrics": true,
         "experiment_id": 0,
-        "explanatory_model": "cifar10_silhouette_model",
+        "explanatory_model": "cifar10_explanatory_model",
         "fraction_poisoned": 0.1,
         "poison_dataset": true,
         "source_class": 0,

--- a/scenario_configs/eval5/poisoning/baseline_defenses/cifar10/dlbd/watermark/cifar10_dlbd_watermark_perfect_filter.json
+++ b/scenario_configs/eval5/poisoning/baseline_defenses/cifar10/dlbd/watermark/cifar10_dlbd_watermark_perfect_filter.json
@@ -3,7 +3,7 @@
     "adhoc": {
         "compute_fairness_metrics": true,
         "experiment_id": 0,
-        "explanatory_model": "cifar10_silhouette_model",
+        "explanatory_model": "cifar10_explanatory_model",
         "fraction_poisoned": 0.1,
         "poison_dataset": true,
         "source_class": 0,

--- a/scenario_configs/eval5/poisoning/baseline_defenses/cifar10/dlbd/watermark/cifar10_dlbd_watermark_random_filter.json
+++ b/scenario_configs/eval5/poisoning/baseline_defenses/cifar10/dlbd/watermark/cifar10_dlbd_watermark_random_filter.json
@@ -3,7 +3,7 @@
     "adhoc": {
         "compute_fairness_metrics": true,
         "experiment_id": 0,
-        "explanatory_model": "cifar10_silhouette_model",
+        "explanatory_model": "cifar10_explanatory_model",
         "fit_defense_classifier_outside_defense": false,
         "fraction_poisoned": 0.1,
         "poison_dataset": true,

--- a/scenario_configs/eval5/poisoning/baseline_defenses/cifar10/dlbd/watermark/cifar10_dlbd_watermark_spectral_signature_defense.json
+++ b/scenario_configs/eval5/poisoning/baseline_defenses/cifar10/dlbd/watermark/cifar10_dlbd_watermark_spectral_signature_defense.json
@@ -3,7 +3,7 @@
     "adhoc": {
         "compute_fairness_metrics": true,
         "experiment_id": 0,
-        "explanatory_model": "cifar10_silhouette_model",
+        "explanatory_model": "cifar10_explanatory_model",
         "fraction_poisoned": 0.1,
         "poison_dataset": true,
         "source_class": 0,

--- a/scenario_configs/eval5/poisoning/baseline_defenses/cifar10/dlbd/watermark/cifar10_dlbd_watermark_undefended.json
+++ b/scenario_configs/eval5/poisoning/baseline_defenses/cifar10/dlbd/watermark/cifar10_dlbd_watermark_undefended.json
@@ -3,7 +3,7 @@
     "adhoc": {
         "compute_fairness_metrics": true,
         "experiment_id": 0,
-        "explanatory_model": "cifar10_silhouette_model",
+        "explanatory_model": "cifar10_explanatory_model",
         "fraction_poisoned": 0.1,
         "poison_dataset": true,
         "source_class": 0,

--- a/scenario_configs/eval5/poisoning/baseline_defenses/cifar10/witches_brew/cifar10_witches_brew_activation_defense.json
+++ b/scenario_configs/eval5/poisoning/baseline_defenses/cifar10/witches_brew/cifar10_witches_brew_activation_defense.json
@@ -3,7 +3,7 @@
     "adhoc": {
         "compute_fairness_metrics": true,
         "experiment_id": 0,
-        "explanatory_model": "cifar10_silhouette_model",
+        "explanatory_model": "cifar10_explanatory_model",
         "fraction_poisoned": 0.1,
         "poison_dataset": true,
         "source_class": [

--- a/scenario_configs/eval5/poisoning/baseline_defenses/cifar10/witches_brew/cifar10_witches_brew_perfect_filter.json
+++ b/scenario_configs/eval5/poisoning/baseline_defenses/cifar10/witches_brew/cifar10_witches_brew_perfect_filter.json
@@ -3,7 +3,7 @@
     "adhoc": {
         "compute_fairness_metrics": true,
         "experiment_id": 0,
-        "explanatory_model": "cifar10_silhouette_model",
+        "explanatory_model": "cifar10_explanatory_model",
         "fraction_poisoned": 0.1,
         "poison_dataset": true,
         "source_class": [

--- a/scenario_configs/eval5/poisoning/baseline_defenses/cifar10/witches_brew/cifar10_witches_brew_random_filter.json
+++ b/scenario_configs/eval5/poisoning/baseline_defenses/cifar10/witches_brew/cifar10_witches_brew_random_filter.json
@@ -3,7 +3,7 @@
     "adhoc": {
         "compute_fairness_metrics": true,
         "experiment_id": 0,
-        "explanatory_model": "cifar10_silhouette_model",
+        "explanatory_model": "cifar10_explanatory_model",
         "fit_defense_classifier_outside_defense": false,
         "fraction_poisoned": 0.1,
         "poison_dataset": true,

--- a/scenario_configs/eval5/poisoning/baseline_defenses/cifar10/witches_brew/cifar10_witches_brew_spectral_signature_defense.json
+++ b/scenario_configs/eval5/poisoning/baseline_defenses/cifar10/witches_brew/cifar10_witches_brew_spectral_signature_defense.json
@@ -3,7 +3,7 @@
     "adhoc": {
         "compute_fairness_metrics": true,
         "experiment_id": 0,
-        "explanatory_model": "cifar10_silhouette_model",
+        "explanatory_model": "cifar10_explanatory_model",
         "fraction_poisoned": 0.1,
         "poison_dataset": true,
         "source_class": [

--- a/scenario_configs/eval5/poisoning/baseline_defenses/cifar10/witches_brew/cifar10_witches_brew_undefended.json
+++ b/scenario_configs/eval5/poisoning/baseline_defenses/cifar10/witches_brew/cifar10_witches_brew_undefended.json
@@ -3,7 +3,7 @@
     "adhoc": {
         "compute_fairness_metrics": true,
         "experiment_id": 0,
-        "explanatory_model": "cifar10_silhouette_model",
+        "explanatory_model": "cifar10_explanatory_model",
         "fraction_poisoned": 0.1,
         "poison_dataset": true,
         "source_class": [

--- a/scenario_configs/eval5/poisoning/baseline_defenses/gtsrb/clbd/bullet_holes/gtsrb_clbd_bullet_holes_activation_defense.json
+++ b/scenario_configs/eval5/poisoning/baseline_defenses/gtsrb/clbd/bullet_holes/gtsrb_clbd_bullet_holes_activation_defense.json
@@ -3,7 +3,7 @@
     "adhoc": {
         "compute_fairness_metrics": true,
         "experiment_id": 0,
-        "explanatory_model": "gtsrb_silhouette_model",
+        "explanatory_model": "gtsrb_explanatory_model",
         "poison_dataset": true,
         "source_class": 1,
         "split_id": 0,

--- a/scenario_configs/eval5/poisoning/baseline_defenses/gtsrb/clbd/bullet_holes/gtsrb_clbd_bullet_holes_perfect_filter.json
+++ b/scenario_configs/eval5/poisoning/baseline_defenses/gtsrb/clbd/bullet_holes/gtsrb_clbd_bullet_holes_perfect_filter.json
@@ -3,7 +3,7 @@
     "adhoc": {
         "compute_fairness_metrics": true,
         "experiment_id": 0,
-        "explanatory_model": "gtsrb_silhouette_model",
+        "explanatory_model": "gtsrb_explanatory_model",
         "poison_dataset": true,
         "source_class": 1,
         "split_id": 0,

--- a/scenario_configs/eval5/poisoning/baseline_defenses/gtsrb/clbd/bullet_holes/gtsrb_clbd_bullet_holes_random_filter.json
+++ b/scenario_configs/eval5/poisoning/baseline_defenses/gtsrb/clbd/bullet_holes/gtsrb_clbd_bullet_holes_random_filter.json
@@ -3,7 +3,7 @@
     "adhoc": {
         "compute_fairness_metrics": true,
         "experiment_id": 0,
-        "explanatory_model": "gtsrb_silhouette_model",
+        "explanatory_model": "gtsrb_explanatory_model",
         "fit_defense_classifier_outside_defense": false,
         "poison_dataset": true,
         "source_class": 1,

--- a/scenario_configs/eval5/poisoning/baseline_defenses/gtsrb/clbd/bullet_holes/gtsrb_clbd_bullet_holes_spectral_signature_defense.json
+++ b/scenario_configs/eval5/poisoning/baseline_defenses/gtsrb/clbd/bullet_holes/gtsrb_clbd_bullet_holes_spectral_signature_defense.json
@@ -3,7 +3,7 @@
     "adhoc": {
         "compute_fairness_metrics": true,
         "experiment_id": 0,
-        "explanatory_model": "gtsrb_silhouette_model",
+        "explanatory_model": "gtsrb_explanatory_model",
         "poison_dataset": true,
         "source_class": 1,
         "split_id": 0,

--- a/scenario_configs/eval5/poisoning/baseline_defenses/gtsrb/clbd/bullet_holes/gtsrb_clbd_bullet_holes_undefended.json
+++ b/scenario_configs/eval5/poisoning/baseline_defenses/gtsrb/clbd/bullet_holes/gtsrb_clbd_bullet_holes_undefended.json
@@ -3,7 +3,7 @@
     "adhoc": {
         "compute_fairness_metrics": true,
         "experiment_id": 0,
-        "explanatory_model": "gtsrb_silhouette_model",
+        "explanatory_model": "gtsrb_explanatory_model",
         "poison_dataset": true,
         "source_class": 1,
         "split_id": 0,

--- a/scenario_configs/eval5/poisoning/baseline_defenses/gtsrb/clbd/peace_sign/gtsrb_clbd_peace_sign_activation_defense.json
+++ b/scenario_configs/eval5/poisoning/baseline_defenses/gtsrb/clbd/peace_sign/gtsrb_clbd_peace_sign_activation_defense.json
@@ -3,7 +3,7 @@
     "adhoc": {
         "compute_fairness_metrics": true,
         "experiment_id": 0,
-        "explanatory_model": "gtsrb_silhouette_model",
+        "explanatory_model": "gtsrb_explanatory_model",
         "poison_dataset": true,
         "source_class": 1,
         "split_id": 0,

--- a/scenario_configs/eval5/poisoning/baseline_defenses/gtsrb/clbd/peace_sign/gtsrb_clbd_peace_sign_perfect_filter.json
+++ b/scenario_configs/eval5/poisoning/baseline_defenses/gtsrb/clbd/peace_sign/gtsrb_clbd_peace_sign_perfect_filter.json
@@ -3,7 +3,7 @@
     "adhoc": {
         "compute_fairness_metrics": true,
         "experiment_id": 0,
-        "explanatory_model": "gtsrb_silhouette_model",
+        "explanatory_model": "gtsrb_explanatory_model",
         "poison_dataset": true,
         "source_class": 1,
         "split_id": 0,

--- a/scenario_configs/eval5/poisoning/baseline_defenses/gtsrb/clbd/peace_sign/gtsrb_clbd_peace_sign_random_filter.json
+++ b/scenario_configs/eval5/poisoning/baseline_defenses/gtsrb/clbd/peace_sign/gtsrb_clbd_peace_sign_random_filter.json
@@ -3,7 +3,7 @@
     "adhoc": {
         "compute_fairness_metrics": true,
         "experiment_id": 0,
-        "explanatory_model": "gtsrb_silhouette_model",
+        "explanatory_model": "gtsrb_explanatory_model",
         "fit_defense_classifier_outside_defense": false,
         "poison_dataset": true,
         "source_class": 1,

--- a/scenario_configs/eval5/poisoning/baseline_defenses/gtsrb/clbd/peace_sign/gtsrb_clbd_peace_sign_spectral_signature_defense.json
+++ b/scenario_configs/eval5/poisoning/baseline_defenses/gtsrb/clbd/peace_sign/gtsrb_clbd_peace_sign_spectral_signature_defense.json
@@ -3,7 +3,7 @@
     "adhoc": {
         "compute_fairness_metrics": true,
         "experiment_id": 0,
-        "explanatory_model": "gtsrb_silhouette_model",
+        "explanatory_model": "gtsrb_explanatory_model",
         "poison_dataset": true,
         "source_class": 1,
         "split_id": 0,

--- a/scenario_configs/eval5/poisoning/baseline_defenses/gtsrb/clbd/peace_sign/gtsrb_clbd_peace_sign_undefended.json
+++ b/scenario_configs/eval5/poisoning/baseline_defenses/gtsrb/clbd/peace_sign/gtsrb_clbd_peace_sign_undefended.json
@@ -3,7 +3,7 @@
     "adhoc": {
         "compute_fairness_metrics": true,
         "experiment_id": 0,
-        "explanatory_model": "gtsrb_silhouette_model",
+        "explanatory_model": "gtsrb_explanatory_model",
         "poison_dataset": true,
         "source_class": 1,
         "split_id": 0,

--- a/scenario_configs/eval5/poisoning/baseline_defenses/gtsrb/dlbd/bullet_holes/gtsrb_dlbd_bullet_holes_activation_defense.json
+++ b/scenario_configs/eval5/poisoning/baseline_defenses/gtsrb/dlbd/bullet_holes/gtsrb_dlbd_bullet_holes_activation_defense.json
@@ -3,7 +3,7 @@
     "adhoc": {
         "compute_fairness_metrics": true,
         "experiment_id": 0,
-        "explanatory_model": "gtsrb_silhouette_model",
+        "explanatory_model": "gtsrb_explanatory_model",
         "fraction_poisoned": 0.1,
         "poison_dataset": true,
         "source_class": 1,

--- a/scenario_configs/eval5/poisoning/baseline_defenses/gtsrb/dlbd/bullet_holes/gtsrb_dlbd_bullet_holes_perfect_filter.json
+++ b/scenario_configs/eval5/poisoning/baseline_defenses/gtsrb/dlbd/bullet_holes/gtsrb_dlbd_bullet_holes_perfect_filter.json
@@ -3,7 +3,7 @@
     "adhoc": {
         "compute_fairness_metrics": true,
         "experiment_id": 0,
-        "explanatory_model": "gtsrb_silhouette_model",
+        "explanatory_model": "gtsrb_explanatory_model",
         "fraction_poisoned": 0.1,
         "poison_dataset": true,
         "source_class": 1,

--- a/scenario_configs/eval5/poisoning/baseline_defenses/gtsrb/dlbd/bullet_holes/gtsrb_dlbd_bullet_holes_random_filter.json
+++ b/scenario_configs/eval5/poisoning/baseline_defenses/gtsrb/dlbd/bullet_holes/gtsrb_dlbd_bullet_holes_random_filter.json
@@ -3,7 +3,7 @@
     "adhoc": {
         "compute_fairness_metrics": true,
         "experiment_id": 0,
-        "explanatory_model": "gtsrb_silhouette_model",
+        "explanatory_model": "gtsrb_explanatory_model",
         "fit_defense_classifier_outside_defense": false,
         "fraction_poisoned": 0.1,
         "poison_dataset": true,

--- a/scenario_configs/eval5/poisoning/baseline_defenses/gtsrb/dlbd/bullet_holes/gtsrb_dlbd_bullet_holes_spectral_signature_defense.json
+++ b/scenario_configs/eval5/poisoning/baseline_defenses/gtsrb/dlbd/bullet_holes/gtsrb_dlbd_bullet_holes_spectral_signature_defense.json
@@ -3,7 +3,7 @@
     "adhoc": {
         "compute_fairness_metrics": true,
         "experiment_id": 0,
-        "explanatory_model": "gtsrb_silhouette_model",
+        "explanatory_model": "gtsrb_explanatory_model",
         "fraction_poisoned": 0.1,
         "poison_dataset": true,
         "source_class": 1,

--- a/scenario_configs/eval5/poisoning/baseline_defenses/gtsrb/dlbd/bullet_holes/gtsrb_dlbd_bullet_holes_undefended.json
+++ b/scenario_configs/eval5/poisoning/baseline_defenses/gtsrb/dlbd/bullet_holes/gtsrb_dlbd_bullet_holes_undefended.json
@@ -3,7 +3,7 @@
     "adhoc": {
         "compute_fairness_metrics": true,
         "experiment_id": 0,
-        "explanatory_model": "gtsrb_silhouette_model",
+        "explanatory_model": "gtsrb_explanatory_model",
         "fraction_poisoned": 0.1,
         "poison_dataset": true,
         "source_class": 1,

--- a/scenario_configs/eval5/poisoning/baseline_defenses/gtsrb/dlbd/peace_sign/gtsrb_dlbd_peace_sign_activation_defense.json
+++ b/scenario_configs/eval5/poisoning/baseline_defenses/gtsrb/dlbd/peace_sign/gtsrb_dlbd_peace_sign_activation_defense.json
@@ -3,7 +3,7 @@
     "adhoc": {
         "compute_fairness_metrics": true,
         "experiment_id": 0,
-        "explanatory_model": "gtsrb_silhouette_model",
+        "explanatory_model": "gtsrb_explanatory_model",
         "fraction_poisoned": 0.1,
         "poison_dataset": true,
         "source_class": 1,

--- a/scenario_configs/eval5/poisoning/baseline_defenses/gtsrb/dlbd/peace_sign/gtsrb_dlbd_peace_sign_perfect_filter.json
+++ b/scenario_configs/eval5/poisoning/baseline_defenses/gtsrb/dlbd/peace_sign/gtsrb_dlbd_peace_sign_perfect_filter.json
@@ -3,7 +3,7 @@
     "adhoc": {
         "compute_fairness_metrics": true,
         "experiment_id": 0,
-        "explanatory_model": "gtsrb_silhouette_model",
+        "explanatory_model": "gtsrb_explanatory_model",
         "fraction_poisoned": 0.1,
         "poison_dataset": true,
         "source_class": 1,

--- a/scenario_configs/eval5/poisoning/baseline_defenses/gtsrb/dlbd/peace_sign/gtsrb_dlbd_peace_sign_random_filter.json
+++ b/scenario_configs/eval5/poisoning/baseline_defenses/gtsrb/dlbd/peace_sign/gtsrb_dlbd_peace_sign_random_filter.json
@@ -3,7 +3,7 @@
     "adhoc": {
         "compute_fairness_metrics": true,
         "experiment_id": 0,
-        "explanatory_model": "gtsrb_silhouette_model",
+        "explanatory_model": "gtsrb_explanatory_model",
         "fit_defense_classifier_outside_defense": false,
         "fraction_poisoned": 0.1,
         "poison_dataset": true,

--- a/scenario_configs/eval5/poisoning/baseline_defenses/gtsrb/dlbd/peace_sign/gtsrb_dlbd_peace_sign_spectral_signature_defense.json
+++ b/scenario_configs/eval5/poisoning/baseline_defenses/gtsrb/dlbd/peace_sign/gtsrb_dlbd_peace_sign_spectral_signature_defense.json
@@ -3,7 +3,7 @@
     "adhoc": {
         "compute_fairness_metrics": true,
         "experiment_id": 0,
-        "explanatory_model": "gtsrb_silhouette_model",
+        "explanatory_model": "gtsrb_explanatory_model",
         "fraction_poisoned": 0.1,
         "poison_dataset": true,
         "source_class": 1,

--- a/scenario_configs/eval5/poisoning/baseline_defenses/gtsrb/dlbd/peace_sign/gtsrb_dlbd_peace_sign_undefended.json
+++ b/scenario_configs/eval5/poisoning/baseline_defenses/gtsrb/dlbd/peace_sign/gtsrb_dlbd_peace_sign_undefended.json
@@ -3,7 +3,7 @@
     "adhoc": {
         "compute_fairness_metrics": true,
         "experiment_id": 0,
-        "explanatory_model": "gtsrb_silhouette_model",
+        "explanatory_model": "gtsrb_explanatory_model",
         "fraction_poisoned": 0.1,
         "poison_dataset": true,
         "source_class": 1,

--- a/scenario_configs/eval5/poisoning/baseline_defenses/gtsrb/witches_brew/gtsrb_witches_brew_activation_defense.json
+++ b/scenario_configs/eval5/poisoning/baseline_defenses/gtsrb/witches_brew/gtsrb_witches_brew_activation_defense.json
@@ -3,7 +3,7 @@
     "adhoc": {
         "compute_fairness_metrics": true,
         "experiment_id": 0,
-        "explanatory_model": "gtsrb_silhouette_model",
+        "explanatory_model": "gtsrb_explanatory_model",
         "fraction_poisoned": 0.01,
         "poison_dataset": true,
         "source_class": 1,

--- a/scenario_configs/eval5/poisoning/baseline_defenses/gtsrb/witches_brew/gtsrb_witches_brew_perfect_filter.json
+++ b/scenario_configs/eval5/poisoning/baseline_defenses/gtsrb/witches_brew/gtsrb_witches_brew_perfect_filter.json
@@ -3,7 +3,7 @@
     "adhoc": {
         "compute_fairness_metrics": true,
         "experiment_id": 0,
-        "explanatory_model": "gtsrb_silhouette_model",
+        "explanatory_model": "gtsrb_explanatory_model",
         "fraction_poisoned": 0.01,
         "poison_dataset": true,
         "source_class": 1,

--- a/scenario_configs/eval5/poisoning/baseline_defenses/gtsrb/witches_brew/gtsrb_witches_brew_random_filter.json
+++ b/scenario_configs/eval5/poisoning/baseline_defenses/gtsrb/witches_brew/gtsrb_witches_brew_random_filter.json
@@ -3,7 +3,7 @@
     "adhoc": {
         "compute_fairness_metrics": true,
         "experiment_id": 0,
-        "explanatory_model": "gtsrb_silhouette_model",
+        "explanatory_model": "gtsrb_explanatory_model",
         "fit_defense_classifier_outside_defense": false,
         "fraction_poisoned": 0.01,
         "poison_dataset": true,

--- a/scenario_configs/eval5/poisoning/baseline_defenses/gtsrb/witches_brew/gtsrb_witches_brew_spectral_signature_defense.json
+++ b/scenario_configs/eval5/poisoning/baseline_defenses/gtsrb/witches_brew/gtsrb_witches_brew_spectral_signature_defense.json
@@ -3,7 +3,7 @@
     "adhoc": {
         "compute_fairness_metrics": true,
         "experiment_id": 0,
-        "explanatory_model": "gtsrb_silhouette_model",
+        "explanatory_model": "gtsrb_explanatory_model",
         "fraction_poisoned": 0.01,
         "poison_dataset": true,
         "source_class": 1,

--- a/scenario_configs/eval5/poisoning/baseline_defenses/gtsrb/witches_brew/gtsrb_witches_brew_undefended.json
+++ b/scenario_configs/eval5/poisoning/baseline_defenses/gtsrb/witches_brew/gtsrb_witches_brew_undefended.json
@@ -3,7 +3,7 @@
     "adhoc": {
         "compute_fairness_metrics": true,
         "experiment_id": 0,
-        "explanatory_model": "gtsrb_silhouette_model",
+        "explanatory_model": "gtsrb_explanatory_model",
         "fraction_poisoned": 0.01,
         "poison_dataset": true,
         "source_class": 1,

--- a/scenario_configs/eval5/poisoning/cifar10_poison_dlbd.json
+++ b/scenario_configs/eval5/poisoning/cifar10_poison_dlbd.json
@@ -3,7 +3,7 @@
     "adhoc": {
         "compute_fairness_metrics": true,
         "experiment_id": 0,
-        "explanatory_model": "cifar10_silhouette_model",
+        "explanatory_model": "cifar10_explanatory_model",
         "fraction_poisoned": 0.1,
         "poison_dataset": true,
         "source_class": 0,

--- a/scenario_configs/eval5/poisoning/cifar10_witches_brew.json
+++ b/scenario_configs/eval5/poisoning/cifar10_witches_brew.json
@@ -3,7 +3,7 @@
     "adhoc": {
         "compute_fairness_metrics": true,
         "experiment_id": 0,
-        "explanatory_model": "cifar10_silhouette_model",
+        "explanatory_model": "cifar10_explanatory_model",
         "fraction_poisoned": 0.1,
         "poison_dataset": true,
         "source_class": [

--- a/scenario_configs/eval5/poisoning/gtsrb_dlbd_baseline_keras.json
+++ b/scenario_configs/eval5/poisoning/gtsrb_dlbd_baseline_keras.json
@@ -3,7 +3,7 @@
     "adhoc": {
         "compute_fairness_metrics": true,
         "experiment_id": 0,
-        "explanatory_model": "gtsrb_silhouette_model",
+        "explanatory_model": "gtsrb_explanatory_model",
         "fraction_poisoned": 0.1,
         "poison_dataset": true,
         "source_class": 1,

--- a/scenario_configs/eval5/poisoning/gtsrb_dlbd_baseline_pytorch.json
+++ b/scenario_configs/eval5/poisoning/gtsrb_dlbd_baseline_pytorch.json
@@ -3,7 +3,7 @@
     "adhoc": {
         "compute_fairness_metrics": true,
         "experiment_id": 0,
-        "explanatory_model": "gtsrb_silhouette_model",
+        "explanatory_model": "gtsrb_explanatory_model",
         "fraction_poisoned": 0.1,
         "poison_dataset": true,
         "source_class": 1,

--- a/scenario_configs/eval5/poisoning/gtsrb_witches_brew.json
+++ b/scenario_configs/eval5/poisoning/gtsrb_witches_brew.json
@@ -3,7 +3,7 @@
     "adhoc": {
         "compute_fairness_metrics": true,
         "experiment_id": 0,
-        "explanatory_model": "gtsrb_silhouette_model",
+        "explanatory_model": "gtsrb_explanatory_model",
         "fraction_poisoned": 0.01,
         "poison_dataset": true,
         "source_class": 1,

--- a/scenario_configs/eval6/poisoning/audio_dlbd/audio_p00_undefended.json
+++ b/scenario_configs/eval6/poisoning/audio_dlbd/audio_p00_undefended.json
@@ -3,7 +3,7 @@
     "adhoc": {
         "compute_fairness_metrics": false,
         "experiment_id": 0,
-        "explanatory_model": null,
+        "explanatory_model": "speech_commands_explanatory_model",
         "fraction_poisoned": 0,
         "poison_dataset": false,
         "source_class": 11,

--- a/scenario_configs/eval6/poisoning/audio_dlbd/audio_p01_undefended.json
+++ b/scenario_configs/eval6/poisoning/audio_dlbd/audio_p01_undefended.json
@@ -3,7 +3,7 @@
     "adhoc": {
         "compute_fairness_metrics": false,
         "experiment_id": 0,
-        "explanatory_model": null,
+        "explanatory_model": "speech_commands_explanatory_model",
         "fraction_poisoned": 0.01,
         "poison_dataset": true,
         "source_class": 11,
@@ -46,9 +46,7 @@
         "wrapper_kwargs": {}
     },
     "scenario": {
-        "kwargs": {
-            "fit_generator": false
-        },
+        "kwargs": {},
         "module": "armory.scenarios.poison",
         "name": "Poison"
     },

--- a/scenario_configs/eval6/poisoning/audio_dlbd/audio_p05_undefended.json
+++ b/scenario_configs/eval6/poisoning/audio_dlbd/audio_p05_undefended.json
@@ -3,7 +3,7 @@
     "adhoc": {
         "compute_fairness_metrics": false,
         "experiment_id": 0,
-        "explanatory_model": null,
+        "explanatory_model": "speech_commands_explanatory_model",
         "fraction_poisoned": 0.05,
         "poison_dataset": true,
         "source_class": 11,

--- a/scenario_configs/eval6/poisoning/audio_dlbd/audio_p10_undefended.json
+++ b/scenario_configs/eval6/poisoning/audio_dlbd/audio_p10_undefended.json
@@ -3,7 +3,7 @@
     "adhoc": {
         "compute_fairness_metrics": false,
         "experiment_id": 0,
-        "explanatory_model": null,
+        "explanatory_model": "speech_commands_explanatory_model",
         "fraction_poisoned": 0.1,
         "poison_dataset": true,
         "source_class": 11,

--- a/scenario_configs/eval6/poisoning/audio_dlbd/audio_p20_undefended.json
+++ b/scenario_configs/eval6/poisoning/audio_dlbd/audio_p20_undefended.json
@@ -3,7 +3,7 @@
     "adhoc": {
         "compute_fairness_metrics": false,
         "experiment_id": 0,
-        "explanatory_model": null,
+        "explanatory_model": "speech_commands_explanatory_model",
         "fraction_poisoned": 0.2,
         "poison_dataset": true,
         "source_class": 11,

--- a/scenario_configs/eval6/poisoning/audio_dlbd/audio_p30_undefended.json
+++ b/scenario_configs/eval6/poisoning/audio_dlbd/audio_p30_undefended.json
@@ -3,7 +3,7 @@
     "adhoc": {
         "compute_fairness_metrics": false,
         "experiment_id": 0,
-        "explanatory_model": null,
+        "explanatory_model": "speech_commands_explanatory_model",
         "fraction_poisoned": 0.3,
         "poison_dataset": true,
         "source_class": 11,

--- a/scenario_configs/eval6/poisoning/sleeper_agent/baseline_defenses/cifar10_sleeper_agent_p10_activation_defense.json
+++ b/scenario_configs/eval6/poisoning/sleeper_agent/baseline_defenses/cifar10_sleeper_agent_p10_activation_defense.json
@@ -3,7 +3,7 @@
     "adhoc": {
         "compute_fairness_metrics": false,
         "experiment_id": 0,
-        "explanatory_model": "cifar10_silhouette_model",
+        "explanatory_model": "cifar10_explanatory_model",
         "fraction_poisoned": 0.1,
         "poison_dataset": true,
         "source_class": 0,

--- a/scenario_configs/eval6/poisoning/sleeper_agent/baseline_defenses/cifar10_sleeper_agent_p10_dpinstahide.json
+++ b/scenario_configs/eval6/poisoning/sleeper_agent/baseline_defenses/cifar10_sleeper_agent_p10_dpinstahide.json
@@ -3,7 +3,7 @@
     "adhoc": {
         "compute_fairness_metrics": false,
         "experiment_id": 0,
-        "explanatory_model": "cifar10_silhouette_model",
+        "explanatory_model": "cifar10_explanatory_model",
         "fit_defense_classifier_outside_defense": false,
         "fraction_poisoned": 0.1,
         "poison_dataset": true,

--- a/scenario_configs/eval6/poisoning/sleeper_agent/baseline_defenses/cifar10_sleeper_agent_p10_perfect_filter.json
+++ b/scenario_configs/eval6/poisoning/sleeper_agent/baseline_defenses/cifar10_sleeper_agent_p10_perfect_filter.json
@@ -3,7 +3,7 @@
     "adhoc": {
         "compute_fairness_metrics": false,
         "experiment_id": 0,
-        "explanatory_model": "cifar10_silhouette_model",
+        "explanatory_model": "cifar10_explanatory_model",
         "fraction_poisoned": 0.1,
         "poison_dataset": true,
         "source_class": 0,

--- a/scenario_configs/eval6/poisoning/sleeper_agent/baseline_defenses/cifar10_sleeper_agent_p10_random_filter.json
+++ b/scenario_configs/eval6/poisoning/sleeper_agent/baseline_defenses/cifar10_sleeper_agent_p10_random_filter.json
@@ -3,7 +3,7 @@
     "adhoc": {
         "compute_fairness_metrics": false,
         "experiment_id": 0,
-        "explanatory_model": "cifar10_silhouette_model",
+        "explanatory_model": "cifar10_explanatory_model",
         "fit_defense_classifier_outside_defense": false,
         "fraction_poisoned": 0.1,
         "poison_dataset": true,

--- a/scenario_configs/eval6/poisoning/sleeper_agent/baseline_defenses/cifar10_sleeper_agent_p10_spectral_signatures_defense.json
+++ b/scenario_configs/eval6/poisoning/sleeper_agent/baseline_defenses/cifar10_sleeper_agent_p10_spectral_signatures_defense.json
@@ -3,7 +3,7 @@
     "adhoc": {
         "compute_fairness_metrics": false,
         "experiment_id": 0,
-        "explanatory_model": "cifar10_silhouette_model",
+        "explanatory_model": "cifar10_explanatory_model",
         "fraction_poisoned": 0.1,
         "poison_dataset": true,
         "source_class": 0,

--- a/scenario_configs/eval6/poisoning/sleeper_agent/cifar10_sleeper_agent_p00_undefended.json
+++ b/scenario_configs/eval6/poisoning/sleeper_agent/cifar10_sleeper_agent_p00_undefended.json
@@ -3,7 +3,7 @@
     "adhoc": {
         "compute_fairness_metrics": false,
         "experiment_id": 0,
-        "explanatory_model": "cifar10_silhouette_model",
+        "explanatory_model": "cifar10_explanatory_model",
         "fraction_poisoned": 0,
         "poison_dataset": false,
         "source_class": 0,

--- a/scenario_configs/eval6/poisoning/sleeper_agent/cifar10_sleeper_agent_p01_undefended.json
+++ b/scenario_configs/eval6/poisoning/sleeper_agent/cifar10_sleeper_agent_p01_undefended.json
@@ -3,7 +3,7 @@
     "adhoc": {
         "compute_fairness_metrics": false,
         "experiment_id": 0,
-        "explanatory_model": "cifar10_silhouette_model",
+        "explanatory_model": "cifar10_explanatory_model",
         "fraction_poisoned": 0.01,
         "poison_dataset": true,
         "source_class": 0,

--- a/scenario_configs/eval6/poisoning/sleeper_agent/cifar10_sleeper_agent_p05_undefended.json
+++ b/scenario_configs/eval6/poisoning/sleeper_agent/cifar10_sleeper_agent_p05_undefended.json
@@ -3,7 +3,7 @@
     "adhoc": {
         "compute_fairness_metrics": false,
         "experiment_id": 0,
-        "explanatory_model": "cifar10_silhouette_model",
+        "explanatory_model": "cifar10_explanatory_model",
         "fraction_poisoned": 0.05,
         "poison_dataset": true,
         "source_class": 0,

--- a/scenario_configs/eval6/poisoning/sleeper_agent/cifar10_sleeper_agent_p10_undefended.json
+++ b/scenario_configs/eval6/poisoning/sleeper_agent/cifar10_sleeper_agent_p10_undefended.json
@@ -3,7 +3,7 @@
     "adhoc": {
         "compute_fairness_metrics": false,
         "experiment_id": 0,
-        "explanatory_model": "cifar10_silhouette_model",
+        "explanatory_model": "cifar10_explanatory_model",
         "fraction_poisoned": 0.1,
         "poison_dataset": true,
         "source_class": 0,

--- a/scenario_configs/eval6/poisoning/sleeper_agent/cifar10_sleeper_agent_p20_undefended.json
+++ b/scenario_configs/eval6/poisoning/sleeper_agent/cifar10_sleeper_agent_p20_undefended.json
@@ -3,7 +3,7 @@
     "adhoc": {
         "compute_fairness_metrics": false,
         "experiment_id": 0,
-        "explanatory_model": "cifar10_silhouette_model",
+        "explanatory_model": "cifar10_explanatory_model",
         "fraction_poisoned": 0.2,
         "poison_dataset": true,
         "source_class": 0,

--- a/scenario_configs/eval6/poisoning/sleeper_agent/cifar10_sleeper_agent_p30_undefended.json
+++ b/scenario_configs/eval6/poisoning/sleeper_agent/cifar10_sleeper_agent_p30_undefended.json
@@ -3,7 +3,7 @@
     "adhoc": {
         "compute_fairness_metrics": false,
         "experiment_id": 0,
-        "explanatory_model": "cifar10_silhouette_model",
+        "explanatory_model": "cifar10_explanatory_model",
         "fraction_poisoned": 0.3,
         "poison_dataset": true,
         "source_class": 0,

--- a/scenario_configs/eval6/poisoning/sleeper_agent/cifar10_sleeper_agent_p50_undefended.json
+++ b/scenario_configs/eval6/poisoning/sleeper_agent/cifar10_sleeper_agent_p50_undefended.json
@@ -3,7 +3,7 @@
     "adhoc": {
         "compute_fairness_metrics": false,
         "experiment_id": 0,
-        "explanatory_model": "cifar10_silhouette_model",
+        "explanatory_model": "cifar10_explanatory_model",
         "fraction_poisoned": 0.5,
         "poison_dataset": true,
         "source_class": 0,

--- a/tests/unit/test_poisoning_metrics.py
+++ b/tests/unit/test_poisoning_metrics.py
@@ -68,7 +68,7 @@ def test_explanatory_model():
 def test_preprocess():
 
     x = np.random.rand(10, 32, 32, 3).astype(np.float32)
-    x_ = poisoning.ExplanatoryModel._preprocess(x)
+    x_ = poisoning.ExplanatoryModel._preprocess_image(x)
     assert x_.shape == (10, 224, 224, 3)
     assert x_.max() <= 1
     assert x_.min() >= 0

--- a/tests/unit/test_poisoning_metrics.py
+++ b/tests/unit/test_poisoning_metrics.py
@@ -71,7 +71,7 @@ def test_explanatory_model():
 def test_preprocess():
 
     x = np.random.rand(10, 32, 32, 3).astype(np.float32)
-    x_ = poisoning.ExplanatoryModel._preprocess_image(x)
+    x_ = poisoning.ExplanatoryModel._preprocess_image(x, resize_image=True)
     assert x_.shape == (10, 224, 224, 3)
     assert x_.max() <= 1
     assert x_.min() >= 0

--- a/tests/unit/test_poisoning_metrics.py
+++ b/tests/unit/test_poisoning_metrics.py
@@ -18,9 +18,9 @@ pytestmark = pytest.mark.unit
 def test_explanatory_model():
 
     config_keys = [
-        "cifar10_silhouette_model",
-        "gtsrb_silhouette_model",
-        "resisc10_silhouette_model",
+        "cifar10_explanatory_model",
+        "gtsrb_explanatory_model",
+        "resisc10_explanatory_model",
         "speech_commands_explanatory_model",
     ]
     data_sizes = [

--- a/tests/unit/test_poisoning_metrics.py
+++ b/tests/unit/test_poisoning_metrics.py
@@ -21,16 +21,19 @@ def test_explanatory_model():
         "cifar10_silhouette_model",
         "gtsrb_silhouette_model",
         "resisc10_silhouette_model",
+        "speech_commands_explanatory_model",
     ]
     data_sizes = [
         (10, 32, 32, 3),
         (10, 48, 48, 3),
         (10, 256, 256, 3),
+        (10, 16000),
     ]
     activation_shapes = [
         (10, 512),
         (10, 1184),
         (10, 512),
+        (10, 2048),
     ]
 
     for config_key, data_size, activation_shape in zip(


### PR DESCRIPTION
Adds explanatory model for poisoning fairness metrics.

Also corrects for an ART bug where triggered audio samples go out of range.