### PR TITLE
Add sleeper agent resnet

### DIFF
--- a/armory/baseline_models/pytorch/resnet18.py
+++ b/armory/baseline_models/pytorch/resnet18.py
@@ -113,7 +113,7 @@ def get_art_model_sgd(
     return wrapped_model
 
 
-class SleeperAgentVersion(torch.nn.Module):
+class ResnetForCifarSleeperAgent(torch.nn.Module):
     def __init__(
         self,
         **model_kwargs,
@@ -146,9 +146,9 @@ class SleeperAgentVersion(torch.nn.Module):
 def get_art_model_cifar_sleeper_agent(
     model_kwargs: dict, wrapper_kwargs: dict, weights_path: Optional[str] = None
 ) -> PyTorchClassifier:
-    """Return Resnet version specific for sleeper agent poisoning on Cifar10"""
+    """Return ART-wrapped Resnet version specific for sleeper agent poisoning on Cifar10"""
 
-    model = SleeperAgentVersion(weights_path=weights_path, **model_kwargs)
+    model = ResnetForCifarSleeperAgent(weights_path=weights_path, **model_kwargs)
     lr = wrapper_kwargs.pop("learning_rate", 0.1)
     optimizer = torch.optim.SGD(
         model.parameters(), lr=lr, momentum=0.9, weight_decay=5e-4, nesterov=True

--- a/armory/baseline_models/pytorch/resnet18.py
+++ b/armory/baseline_models/pytorch/resnet18.py
@@ -121,7 +121,8 @@ class SleeperAgentVersion(torch.nn.Module):
         """This version of the Resnet imitates that found in the ART example notebook for the Sleeper Agent attack:
         https://github.com/Trusted-AI/adversarial-robustness-toolbox/blob/main/notebooks/poisoning_attack_sleeper_agent_pytorch.ipynb
 
-        This attack is somewhat brittle and is not successful against the above torchvision.models.resnet18 with the current attack parameters.
+        Sleeper Agent is somewhat brittle and is not successful against the above torchvision.models.resnet18 
+        with the current attack parameters; hence the inclusion of this version.
         """
 
         data_means = model_kwargs.pop("data_means", CIFAR10_MEANS)
@@ -145,7 +146,7 @@ class SleeperAgentVersion(torch.nn.Module):
 def get_art_model_cifar_sleeper_agent(
     model_kwargs: dict, wrapper_kwargs: dict, weights_path: Optional[str] = None
 ) -> PyTorchClassifier:
-    """Return model specific for sleeper agent poisoning on Cifar10"""
+    """Return Resnet version specific for sleeper agent poisoning on Cifar10"""
 
     model = SleeperAgentVersion(weights_path=weights_path, **model_kwargs)
     lr = wrapper_kwargs.pop("learning_rate", 0.1)

--- a/armory/baseline_models/pytorch/resnet18.py
+++ b/armory/baseline_models/pytorch/resnet18.py
@@ -121,7 +121,7 @@ class SleeperAgentVersion(torch.nn.Module):
         """This version of the Resnet imitates that found in the ART example notebook for the Sleeper Agent attack:
         https://github.com/Trusted-AI/adversarial-robustness-toolbox/blob/main/notebooks/poisoning_attack_sleeper_agent_pytorch.ipynb
 
-        Sleeper Agent is somewhat brittle and is not successful against the above torchvision.models.resnet18 
+        Sleeper Agent is somewhat brittle and is not successful against the above torchvision.models.resnet18
         with the current attack parameters; hence the inclusion of this version.
         """
 

--- a/armory/baseline_models/pytorch/resnet18.py
+++ b/armory/baseline_models/pytorch/resnet18.py
@@ -89,6 +89,10 @@ def get_art_model_sgd(
     model_kwargs: dict, wrapper_kwargs: dict, weights_path: Optional[str] = None
 ) -> PyTorchClassifier:
 
+    """Returns the same model as get_art_model, but with the SGD optimizer.
+    Some poisoning attacks were found to be brittle with regard to optimizer.
+    """
+
     model = OuterModel(weights_path=weights_path, **model_kwargs)
 
     lr = wrapper_kwargs.pop("learning_rate", 0.1)
@@ -99,6 +103,60 @@ def get_art_model_sgd(
         optimizer=torch.optim.SGD(
             model.parameters(), lr=lr, weight_decay=1e-6, momentum=0.9, nesterov=True
         ),
+        input_shape=wrapper_kwargs.pop(
+            "input_shape", (224, 224, 3)
+        ),  # default to imagenet shape
+        channels_first=False,
+        **wrapper_kwargs,
+        clip_values=(0.0, 1.0),
+    )
+    return wrapped_model
+
+
+class SleeperAgentVersion(torch.nn.Module):
+    def __init__(
+        self,
+        **model_kwargs,
+    ):
+        """This version of the Resnet imitates that found in the ART example notebook for the Sleeper Agent attack:
+        https://github.com/Trusted-AI/adversarial-robustness-toolbox/blob/main/notebooks/poisoning_attack_sleeper_agent_pytorch.ipynb
+
+        This attack is somewhat brittle and is not successful against the above torchvision.models.resnet18 with the current attack parameters.
+        """
+
+        data_means = model_kwargs.pop("data_means", CIFAR10_MEANS)
+        data_stds = model_kwargs.pop("data_stds", CIFAR10_STDS)
+
+        super().__init__()
+        self.inner_model = models.ResNet(
+            models.resnet.BasicBlock, [2, 2, 2, 2], num_classes=10
+        )
+
+        self.data_means = torch.tensor(data_means, dtype=torch.float32, device=DEVICE)
+        self.data_stdev = torch.tensor(data_stds, dtype=torch.float32, device=DEVICE)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        x_norm = ((x - self.data_means) / self.data_stdev).permute(0, 3, 1, 2)
+        output = self.inner_model(x_norm)
+
+        return output
+
+
+def get_art_model_cifar_sleeper_agent(
+    model_kwargs: dict, wrapper_kwargs: dict, weights_path: Optional[str] = None
+) -> PyTorchClassifier:
+    """Return model specific for sleeper agent poisoning on Cifar10"""
+
+    model = SleeperAgentVersion(weights_path=weights_path, **model_kwargs)
+    lr = wrapper_kwargs.pop("learning_rate", 0.1)
+    optimizer = torch.optim.SGD(
+        model.parameters(), lr=lr, momentum=0.9, weight_decay=5e-4, nesterov=True
+    )
+
+    wrapped_model = PyTorchClassifier(
+        model,
+        loss=torch.nn.CrossEntropyLoss(),
+        optimizer=optimizer,
         input_shape=wrapper_kwargs.pop(
             "input_shape", (224, 224, 3)
         ),  # default to imagenet shape

--- a/scenario_configs/eval6/poisoning/audio_dlbd/audio_p00_undefended.json
+++ b/scenario_configs/eval6/poisoning/audio_dlbd/audio_p00_undefended.json
@@ -1,5 +1,5 @@
 {
-    "_description": "Speech Commands DLBD poison audio classification",
+    "_description": "Speech Commands DLBD poison audio classification, undefended",
     "adhoc": {
         "compute_fairness_metrics": false,
         "experiment_id": 0,

--- a/scenario_configs/eval6/poisoning/audio_dlbd/audio_p01_undefended.json
+++ b/scenario_configs/eval6/poisoning/audio_dlbd/audio_p01_undefended.json
@@ -1,5 +1,5 @@
 {
-    "_description": "Speech Commands DLBD poison audio classification",
+    "_description": "Speech Commands DLBD poison audio classification, undefended",
     "adhoc": {
         "compute_fairness_metrics": false,
         "experiment_id": 0,

--- a/scenario_configs/eval6/poisoning/audio_dlbd/audio_p05_undefended.json
+++ b/scenario_configs/eval6/poisoning/audio_dlbd/audio_p05_undefended.json
@@ -1,5 +1,5 @@
 {
-    "_description": "Speech Commands DLBD poison audio classification",
+    "_description": "Speech Commands DLBD poison audio classification, undefended",
     "adhoc": {
         "compute_fairness_metrics": false,
         "experiment_id": 0,

--- a/scenario_configs/eval6/poisoning/audio_dlbd/audio_p10_undefended.json
+++ b/scenario_configs/eval6/poisoning/audio_dlbd/audio_p10_undefended.json
@@ -1,5 +1,5 @@
 {
-    "_description": "Speech Commands DLBD poison audio classification",
+    "_description": "Speech Commands DLBD poison audio classification, undefended",
     "adhoc": {
         "compute_fairness_metrics": false,
         "experiment_id": 0,

--- a/scenario_configs/eval6/poisoning/audio_dlbd/audio_p20_undefended.json
+++ b/scenario_configs/eval6/poisoning/audio_dlbd/audio_p20_undefended.json
@@ -1,5 +1,5 @@
 {
-    "_description": "Speech Commands DLBD poison audio classification",
+    "_description": "Speech Commands DLBD poison audio classification, undefended",
     "adhoc": {
         "compute_fairness_metrics": false,
         "experiment_id": 0,

--- a/scenario_configs/eval6/poisoning/audio_dlbd/audio_p30_undefended.json
+++ b/scenario_configs/eval6/poisoning/audio_dlbd/audio_p30_undefended.json
@@ -1,5 +1,5 @@
 {
-    "_description": "Speech Commands DLBD poison audio classification",
+    "_description": "Speech Commands DLBD poison audio classification, undefended",
     "adhoc": {
         "compute_fairness_metrics": false,
         "experiment_id": 0,

--- a/scenario_configs/eval6/poisoning/audio_dlbd/baseline_defenses/audio_p10_activation_defense.json
+++ b/scenario_configs/eval6/poisoning/audio_dlbd/baseline_defenses/audio_p10_activation_defense.json
@@ -1,5 +1,5 @@
 {
-    "_description": "Speech Commands DLBD poison audio classification",
+    "_description": "Speech Commands DLBD poison audio classification, activation defense",
     "adhoc": {
         "compute_fairness_metrics": false,
         "experiment_id": 0,

--- a/scenario_configs/eval6/poisoning/audio_dlbd/baseline_defenses/audio_p10_dpinstahide.json
+++ b/scenario_configs/eval6/poisoning/audio_dlbd/baseline_defenses/audio_p10_dpinstahide.json
@@ -1,5 +1,5 @@
 {
-    "_description": "Speech Commands DLBD poison audio classification",
+    "_description": "Speech Commands DLBD poison audio classification, DP Instahide defense",
     "adhoc": {
         "compute_fairness_metrics": false,
         "experiment_id": 0,

--- a/scenario_configs/eval6/poisoning/audio_dlbd/baseline_defenses/audio_p10_perfect_filter.json
+++ b/scenario_configs/eval6/poisoning/audio_dlbd/baseline_defenses/audio_p10_perfect_filter.json
@@ -1,5 +1,5 @@
 {
-    "_description": "Speech Commands DLBD poison audio classification",
+    "_description": "Speech Commands DLBD poison audio classification, perfect filter",
     "adhoc": {
         "compute_fairness_metrics": false,
         "experiment_id": 0,

--- a/scenario_configs/eval6/poisoning/audio_dlbd/baseline_defenses/audio_p10_random_filter.json
+++ b/scenario_configs/eval6/poisoning/audio_dlbd/baseline_defenses/audio_p10_random_filter.json
@@ -1,5 +1,5 @@
 {
-    "_description": "Speech Commands DLBD poison audio classification",
+    "_description": "Speech Commands DLBD poison audio classification, random filter",
     "adhoc": {
         "compute_fairness_metrics": false,
         "experiment_id": 0,

--- a/scenario_configs/eval6/poisoning/audio_dlbd/baseline_defenses/audio_p10_spectral_signature_defense.json
+++ b/scenario_configs/eval6/poisoning/audio_dlbd/baseline_defenses/audio_p10_spectral_signature_defense.json
@@ -1,5 +1,5 @@
 {
-    "_description": "Speech Commands DLBD poison audio classification",
+    "_description": "Speech Commands DLBD poison audio classification, spectral signatures defense",
     "adhoc": {
         "compute_fairness_metrics": false,
         "experiment_id": 0,

--- a/scenario_configs/eval6/poisoning/sleeper_agent/baseline_defenses/cifar10_sleeper_agent_p10_activation_defense.json
+++ b/scenario_configs/eval6/poisoning/sleeper_agent/baseline_defenses/cifar10_sleeper_agent_p10_activation_defense.json
@@ -1,5 +1,5 @@
 {
-    "_description": "CIFAR10 poison image classification, sleeper agent attack",
+    "_description": "CIFAR10 poison image classification, sleeper agent attack, activation defense",
     "adhoc": {
         "compute_fairness_metrics": false,
         "experiment_id": 0,
@@ -50,7 +50,7 @@
         "name": "SleeperAgentAttack"
     },
     "dataset": {
-        "batch_size": 512,
+        "batch_size": 128,
         "framework": "numpy",
         "module": "armory.data.datasets",
         "name": "cifar10"
@@ -72,7 +72,6 @@
         "fit": true,
         "fit_kwargs": {},
         "model_kwargs": {
-            "cifar_stem": true,
             "data_means": [
                 0.4914,
                 0.4822,
@@ -87,7 +86,7 @@
             "pretrained": false
         },
         "module": "armory.baseline_models.pytorch.resnet18",
-        "name": "get_art_model",
+        "name": "get_art_model_cifar_sleeper_agent",
         "weights_file": null,
         "wrapper_kwargs": {
             "input_shape": [
@@ -95,7 +94,7 @@
                 32,
                 3
             ],
-            "learning_rate": 0.001,
+            "learning_rate": 0.1,
             "nb_classes": 10
         }
     },

--- a/scenario_configs/eval6/poisoning/sleeper_agent/baseline_defenses/cifar10_sleeper_agent_p10_dpinstahide.json
+++ b/scenario_configs/eval6/poisoning/sleeper_agent/baseline_defenses/cifar10_sleeper_agent_p10_dpinstahide.json
@@ -1,5 +1,5 @@
 {
-    "_description": "CIFAR10 poison image classification, sleeper agent attack",
+    "_description": "CIFAR10 poison image classification, sleeper agent attack, DP Instahide defense",
     "adhoc": {
         "compute_fairness_metrics": false,
         "experiment_id": 0,
@@ -51,7 +51,7 @@
         "name": "SleeperAgentAttack"
     },
     "dataset": {
-        "batch_size": 512,
+        "batch_size": 128,
         "framework": "numpy",
         "module": "armory.data.datasets",
         "name": "cifar10"
@@ -83,7 +83,6 @@
         "fit": true,
         "fit_kwargs": {},
         "model_kwargs": {
-            "cifar_stem": true,
             "data_means": [
                 0.4914,
                 0.4822,
@@ -98,7 +97,7 @@
             "pretrained": false
         },
         "module": "armory.baseline_models.pytorch.resnet18",
-        "name": "get_art_model",
+        "name": "get_art_model_cifar_sleeper_agent",
         "weights_file": null,
         "wrapper_kwargs": {
             "input_shape": [
@@ -106,7 +105,7 @@
                 32,
                 3
             ],
-            "learning_rate": 0.001,
+            "learning_rate": 0.1,
             "nb_classes": 10
         }
     },

--- a/scenario_configs/eval6/poisoning/sleeper_agent/baseline_defenses/cifar10_sleeper_agent_p10_perfect_filter.json
+++ b/scenario_configs/eval6/poisoning/sleeper_agent/baseline_defenses/cifar10_sleeper_agent_p10_perfect_filter.json
@@ -1,5 +1,5 @@
 {
-    "_description": "CIFAR10 poison image classification, sleeper agent attack",
+    "_description": "CIFAR10 poison image classification, sleeper agent attack, perfect filter",
     "adhoc": {
         "compute_fairness_metrics": false,
         "experiment_id": 0,
@@ -50,7 +50,7 @@
         "name": "SleeperAgentAttack"
     },
     "dataset": {
-        "batch_size": 512,
+        "batch_size": 128,
         "framework": "numpy",
         "module": "armory.data.datasets",
         "name": "cifar10"
@@ -68,7 +68,6 @@
         "fit": true,
         "fit_kwargs": {},
         "model_kwargs": {
-            "cifar_stem": true,
             "data_means": [
                 0.4914,
                 0.4822,
@@ -83,7 +82,7 @@
             "pretrained": false
         },
         "module": "armory.baseline_models.pytorch.resnet18",
-        "name": "get_art_model",
+        "name": "get_art_model_cifar_sleeper_agent",
         "weights_file": null,
         "wrapper_kwargs": {
             "input_shape": [
@@ -91,7 +90,7 @@
                 32,
                 3
             ],
-            "learning_rate": 0.001,
+            "learning_rate": 0.1,
             "nb_classes": 10
         }
     },

--- a/scenario_configs/eval6/poisoning/sleeper_agent/baseline_defenses/cifar10_sleeper_agent_p10_random_filter.json
+++ b/scenario_configs/eval6/poisoning/sleeper_agent/baseline_defenses/cifar10_sleeper_agent_p10_random_filter.json
@@ -1,5 +1,5 @@
 {
-    "_description": "CIFAR10 poison image classification, sleeper agent attack",
+    "_description": "CIFAR10 poison image classification, sleeper agent attack, random filter",
     "adhoc": {
         "compute_fairness_metrics": false,
         "experiment_id": 0,
@@ -51,7 +51,7 @@
         "name": "SleeperAgentAttack"
     },
     "dataset": {
-        "batch_size": 512,
+        "batch_size": 128,
         "framework": "numpy",
         "module": "armory.data.datasets",
         "name": "cifar10"
@@ -69,7 +69,6 @@
         "fit": true,
         "fit_kwargs": {},
         "model_kwargs": {
-            "cifar_stem": true,
             "data_means": [
                 0.4914,
                 0.4822,
@@ -84,7 +83,7 @@
             "pretrained": false
         },
         "module": "armory.baseline_models.pytorch.resnet18",
-        "name": "get_art_model",
+        "name": "get_art_model_cifar_sleeper_agent",
         "weights_file": null,
         "wrapper_kwargs": {
             "input_shape": [
@@ -92,7 +91,7 @@
                 32,
                 3
             ],
-            "learning_rate": 0.001,
+            "learning_rate": 0.1,
             "nb_classes": 10
         }
     },

--- a/scenario_configs/eval6/poisoning/sleeper_agent/baseline_defenses/cifar10_sleeper_agent_p10_spectral_signatures_defense.json
+++ b/scenario_configs/eval6/poisoning/sleeper_agent/baseline_defenses/cifar10_sleeper_agent_p10_spectral_signatures_defense.json
@@ -1,5 +1,5 @@
 {
-    "_description": "CIFAR10 poison image classification, sleeper agent attack",
+    "_description": "CIFAR10 poison image classification, sleeper agent attack, spectral signatures defense",
     "adhoc": {
         "compute_fairness_metrics": false,
         "experiment_id": 0,
@@ -50,7 +50,7 @@
         "name": "SleeperAgentAttack"
     },
     "dataset": {
-        "batch_size": 512,
+        "batch_size": 128,
         "framework": "numpy",
         "module": "armory.data.datasets",
         "name": "cifar10"
@@ -68,7 +68,6 @@
         "fit": true,
         "fit_kwargs": {},
         "model_kwargs": {
-            "cifar_stem": true,
             "data_means": [
                 0.4914,
                 0.4822,
@@ -83,7 +82,7 @@
             "pretrained": false
         },
         "module": "armory.baseline_models.pytorch.resnet18",
-        "name": "get_art_model",
+        "name": "get_art_model_cifar_sleeper_agent",
         "weights_file": null,
         "wrapper_kwargs": {
             "input_shape": [
@@ -91,7 +90,7 @@
                 32,
                 3
             ],
-            "learning_rate": 0.001,
+            "learning_rate": 0.1,
             "nb_classes": 10
         }
     },

--- a/scenario_configs/eval6/poisoning/sleeper_agent/cifar10_sleeper_agent_p00_undefended.json
+++ b/scenario_configs/eval6/poisoning/sleeper_agent/cifar10_sleeper_agent_p00_undefended.json
@@ -1,5 +1,5 @@
 {
-    "_description": "CIFAR10 poison image classification, sleeper agent attack",
+    "_description": "CIFAR10 poison image classification, sleeper agent attack, undefended",
     "adhoc": {
         "compute_fairness_metrics": false,
         "experiment_id": 0,
@@ -50,7 +50,7 @@
         "name": "SleeperAgentAttack"
     },
     "dataset": {
-        "batch_size": 512,
+        "batch_size": 128,
         "framework": "numpy",
         "module": "armory.data.datasets",
         "name": "cifar10"
@@ -61,7 +61,6 @@
         "fit": true,
         "fit_kwargs": {},
         "model_kwargs": {
-            "cifar_stem": true,
             "data_means": [
                 0.4914,
                 0.4822,
@@ -76,7 +75,7 @@
             "pretrained": false
         },
         "module": "armory.baseline_models.pytorch.resnet18",
-        "name": "get_art_model",
+        "name": "get_art_model_cifar_sleeper_agent",
         "weights_file": null,
         "wrapper_kwargs": {
             "input_shape": [
@@ -84,7 +83,7 @@
                 32,
                 3
             ],
-            "learning_rate": 0.001,
+            "learning_rate": 0.1,
             "nb_classes": 10
         }
     },

--- a/scenario_configs/eval6/poisoning/sleeper_agent/cifar10_sleeper_agent_p01_undefended.json
+++ b/scenario_configs/eval6/poisoning/sleeper_agent/cifar10_sleeper_agent_p01_undefended.json
@@ -1,5 +1,5 @@
 {
-    "_description": "CIFAR10 poison image classification, sleeper agent attack",
+    "_description": "CIFAR10 poison image classification, sleeper agent attack, undefended",
     "adhoc": {
         "compute_fairness_metrics": false,
         "experiment_id": 0,
@@ -50,7 +50,7 @@
         "name": "SleeperAgentAttack"
     },
     "dataset": {
-        "batch_size": 512,
+        "batch_size": 128,
         "framework": "numpy",
         "module": "armory.data.datasets",
         "name": "cifar10"
@@ -61,7 +61,6 @@
         "fit": true,
         "fit_kwargs": {},
         "model_kwargs": {
-            "cifar_stem": true,
             "data_means": [
                 0.4914,
                 0.4822,
@@ -76,7 +75,7 @@
             "pretrained": false
         },
         "module": "armory.baseline_models.pytorch.resnet18",
-        "name": "get_art_model",
+        "name": "get_art_model_cifar_sleeper_agent",
         "weights_file": null,
         "wrapper_kwargs": {
             "input_shape": [
@@ -84,7 +83,7 @@
                 32,
                 3
             ],
-            "learning_rate": 0.001,
+            "learning_rate": 0.1,
             "nb_classes": 10
         }
     },

--- a/scenario_configs/eval6/poisoning/sleeper_agent/cifar10_sleeper_agent_p05_undefended.json
+++ b/scenario_configs/eval6/poisoning/sleeper_agent/cifar10_sleeper_agent_p05_undefended.json
@@ -1,5 +1,5 @@
 {
-    "_description": "CIFAR10 poison image classification, sleeper agent attack",
+    "_description": "CIFAR10 poison image classification, sleeper agent attack, undefended",
     "adhoc": {
         "compute_fairness_metrics": false,
         "experiment_id": 0,
@@ -50,7 +50,7 @@
         "name": "SleeperAgentAttack"
     },
     "dataset": {
-        "batch_size": 512,
+        "batch_size": 128,
         "framework": "numpy",
         "module": "armory.data.datasets",
         "name": "cifar10"
@@ -61,7 +61,6 @@
         "fit": true,
         "fit_kwargs": {},
         "model_kwargs": {
-            "cifar_stem": true,
             "data_means": [
                 0.4914,
                 0.4822,
@@ -76,7 +75,7 @@
             "pretrained": false
         },
         "module": "armory.baseline_models.pytorch.resnet18",
-        "name": "get_art_model",
+        "name": "get_art_model_cifar_sleeper_agent",
         "weights_file": null,
         "wrapper_kwargs": {
             "input_shape": [
@@ -84,7 +83,7 @@
                 32,
                 3
             ],
-            "learning_rate": 0.001,
+            "learning_rate": 0.1,
             "nb_classes": 10
         }
     },

--- a/scenario_configs/eval6/poisoning/sleeper_agent/cifar10_sleeper_agent_p10_undefended.json
+++ b/scenario_configs/eval6/poisoning/sleeper_agent/cifar10_sleeper_agent_p10_undefended.json
@@ -1,5 +1,5 @@
 {
-    "_description": "CIFAR10 poison image classification, sleeper agent attack",
+    "_description": "CIFAR10 poison image classification, sleeper agent attack, undefended",
     "adhoc": {
         "compute_fairness_metrics": false,
         "experiment_id": 0,
@@ -50,7 +50,7 @@
         "name": "SleeperAgentAttack"
     },
     "dataset": {
-        "batch_size": 512,
+        "batch_size": 128,
         "framework": "numpy",
         "module": "armory.data.datasets",
         "name": "cifar10"
@@ -61,7 +61,6 @@
         "fit": true,
         "fit_kwargs": {},
         "model_kwargs": {
-            "cifar_stem": true,
             "data_means": [
                 0.4914,
                 0.4822,
@@ -76,7 +75,7 @@
             "pretrained": false
         },
         "module": "armory.baseline_models.pytorch.resnet18",
-        "name": "get_art_model",
+        "name": "get_art_model_cifar_sleeper_agent",
         "weights_file": null,
         "wrapper_kwargs": {
             "input_shape": [
@@ -84,7 +83,7 @@
                 32,
                 3
             ],
-            "learning_rate": 0.001,
+            "learning_rate": 0.1,
             "nb_classes": 10
         }
     },

--- a/scenario_configs/eval6/poisoning/sleeper_agent/cifar10_sleeper_agent_p20_undefended.json
+++ b/scenario_configs/eval6/poisoning/sleeper_agent/cifar10_sleeper_agent_p20_undefended.json
@@ -1,5 +1,5 @@
 {
-    "_description": "CIFAR10 poison image classification, sleeper agent attack",
+    "_description": "CIFAR10 poison image classification, sleeper agent attack, undefended",
     "adhoc": {
         "compute_fairness_metrics": false,
         "experiment_id": 0,
@@ -50,7 +50,7 @@
         "name": "SleeperAgentAttack"
     },
     "dataset": {
-        "batch_size": 512,
+        "batch_size": 128,
         "framework": "numpy",
         "module": "armory.data.datasets",
         "name": "cifar10"
@@ -61,7 +61,6 @@
         "fit": true,
         "fit_kwargs": {},
         "model_kwargs": {
-            "cifar_stem": true,
             "data_means": [
                 0.4914,
                 0.4822,
@@ -76,7 +75,7 @@
             "pretrained": false
         },
         "module": "armory.baseline_models.pytorch.resnet18",
-        "name": "get_art_model",
+        "name": "get_art_model_cifar_sleeper_agent",
         "weights_file": null,
         "wrapper_kwargs": {
             "input_shape": [
@@ -84,7 +83,7 @@
                 32,
                 3
             ],
-            "learning_rate": 0.001,
+            "learning_rate": 0.1,
             "nb_classes": 10
         }
     },

--- a/scenario_configs/eval6/poisoning/sleeper_agent/cifar10_sleeper_agent_p30_undefended.json
+++ b/scenario_configs/eval6/poisoning/sleeper_agent/cifar10_sleeper_agent_p30_undefended.json
@@ -1,5 +1,5 @@
 {
-    "_description": "CIFAR10 poison image classification, sleeper agent attack",
+    "_description": "CIFAR10 poison image classification, sleeper agent attack, undefended",
     "adhoc": {
         "compute_fairness_metrics": false,
         "experiment_id": 0,
@@ -50,7 +50,7 @@
         "name": "SleeperAgentAttack"
     },
     "dataset": {
-        "batch_size": 512,
+        "batch_size": 128,
         "framework": "numpy",
         "module": "armory.data.datasets",
         "name": "cifar10"
@@ -61,7 +61,6 @@
         "fit": true,
         "fit_kwargs": {},
         "model_kwargs": {
-            "cifar_stem": true,
             "data_means": [
                 0.4914,
                 0.4822,
@@ -76,7 +75,7 @@
             "pretrained": false
         },
         "module": "armory.baseline_models.pytorch.resnet18",
-        "name": "get_art_model",
+        "name": "get_art_model_cifar_sleeper_agent",
         "weights_file": null,
         "wrapper_kwargs": {
             "input_shape": [
@@ -84,7 +83,7 @@
                 32,
                 3
             ],
-            "learning_rate": 0.001,
+            "learning_rate": 0.1,
             "nb_classes": 10
         }
     },

--- a/scenario_configs/eval6/poisoning/sleeper_agent/cifar10_sleeper_agent_p50_undefended.json
+++ b/scenario_configs/eval6/poisoning/sleeper_agent/cifar10_sleeper_agent_p50_undefended.json
@@ -1,5 +1,5 @@
 {
-    "_description": "CIFAR10 poison image classification, sleeper agent attack",
+    "_description": "CIFAR10 poison image classification, sleeper agent attack, undefended",
     "adhoc": {
         "compute_fairness_metrics": false,
         "experiment_id": 0,
@@ -50,7 +50,7 @@
         "name": "SleeperAgentAttack"
     },
     "dataset": {
-        "batch_size": 512,
+        "batch_size": 128,
         "framework": "numpy",
         "module": "armory.data.datasets",
         "name": "cifar10"
@@ -61,7 +61,6 @@
         "fit": true,
         "fit_kwargs": {},
         "model_kwargs": {
-            "cifar_stem": true,
             "data_means": [
                 0.4914,
                 0.4822,
@@ -76,7 +75,7 @@
             "pretrained": false
         },
         "module": "armory.baseline_models.pytorch.resnet18",
-        "name": "get_art_model",
+        "name": "get_art_model_cifar_sleeper_agent",
         "weights_file": null,
         "wrapper_kwargs": {
             "input_shape": [
@@ -84,7 +83,7 @@
                 32,
                 3
             ],
-            "learning_rate": 0.001,
+            "learning_rate": 0.1,
             "nb_classes": 10
         }
     },


### PR DESCRIPTION
Sleeper Agent doesn't work very well with the resnet18 already in armory.  Rather than attempt to tune hyperparameters, the poisoning group desired us to add this resnet version on which we know the attack succeeds.