### PR TITLE
Carla metrics bug fix

### DIFF
--- a/armory/metrics/task.py
+++ b/armory/metrics/task.py
@@ -1225,74 +1225,98 @@ def object_detection_hallucinations_per_image(
 
 @populationwise
 def carla_od_hallucinations_per_image(
-    y_list, y_pred_list, iou_threshold=0.5, score_threshold=0.5
+    y_list, y_pred_list, iou_threshold=0.5, score_threshold=0.5, mean=True, per_image=True
 ):
     """
     CARLA object detection datasets contains class labels 1-4, with class 4 representing
     the green screen/patch itself, which should not be treated as an object class.
     """
     class_list = [1, 2, 3]
-    return object_detection_hallucinations_per_image(
+    result = object_detection_hallucinations_per_image(
         y_list,
         y_pred_list,
         iou_threshold=iou_threshold,
         score_threshold=score_threshold,
         class_list=class_list,
     )
+    if not mean and not per_image:
+        raise ValueError("At least one of 'mean' and 'per_image' must be true")
+    if mean and per_image:
+        return {"mean":np.mean(np.array(result)), "per_image":result}
+
+    return np.mean(np.array(result)) if mean else result
 
 
 @populationwise
 def carla_od_disappearance_rate(
-    y_list, y_pred_list, iou_threshold=0.5, score_threshold=0.5
+    y_list, y_pred_list, iou_threshold=0.5, score_threshold=0.5, mean=True, per_image=True
 ):
     """
     CARLA object detection datasets contains class labels 1-4, with class 4 representing
     the green screen/patch itself, which should not be treated as an object class.
     """
     class_list = [1, 2, 3]
-    return object_detection_disappearance_rate(
+    result = object_detection_disappearance_rate(
         y_list,
         y_pred_list,
         iou_threshold=iou_threshold,
         score_threshold=score_threshold,
         class_list=class_list,
     )
+    if not mean and not per_image:
+        raise ValueError("At least one of 'mean' and 'per_image' must be true")
+    if mean and per_image:
+        return {"mean":np.mean(np.array(result)), "per_image":result}
+
+    return np.mean(np.array(result)) if mean else result
 
 
 @populationwise
 def carla_od_true_positive_rate(
-    y_list, y_pred_list, iou_threshold=0.5, score_threshold=0.5
+    y_list, y_pred_list, iou_threshold=0.5, score_threshold=0.5, mean=True, per_image=True
 ):
     """
     CARLA object detection datasets contains class labels 1-4, with class 4 representing
     the green screen/patch itself, which should not be treated as an object class.
     """
     class_list = [1, 2, 3]
-    return object_detection_true_positive_rate(
+    result = object_detection_true_positive_rate(
         y_list,
         y_pred_list,
         iou_threshold=iou_threshold,
         score_threshold=score_threshold,
         class_list=class_list,
     )
+    if not mean and not per_image:
+        raise ValueError("At least one of 'mean' and 'per_image' must be true")
+    if mean and per_image:
+        return {"mean":np.mean(np.array(result)), "per_image":result}
+
+    return np.mean(np.array(result)) if mean else result
 
 
 @populationwise
 def carla_od_misclassification_rate(
-    y_list, y_pred_list, iou_threshold=0.5, score_threshold=0.5
+    y_list, y_pred_list, iou_threshold=0.5, score_threshold=0.5, mean=True, per_image=True
 ):
     """
     CARLA object detection datasets contains class labels 1-4, with class 4 representing
     the green screen/patch itself, which should not be treated as an object class.
     """
     class_list = [1, 2, 3]
-    return object_detection_misclassification_rate(
+    result = object_detection_misclassification_rate(
         y_list,
         y_pred_list,
         iou_threshold=iou_threshold,
         score_threshold=score_threshold,
         class_list=class_list,
     )
+    if not mean and not per_image:
+        raise ValueError("At least one of 'mean' and 'per_image' must be true")
+    if mean and per_image:
+        return {"mean":np.mean(np.array(result)), "per_image":result}
+
+    return np.mean(np.array(result)) if mean else result
 
 
 @populationwise

--- a/armory/metrics/task.py
+++ b/armory/metrics/task.py
@@ -1223,7 +1223,7 @@ def object_detection_hallucinations_per_image(
     return hallucinations_per_image
 
 
-@populationwise
+@batchwise
 def carla_od_hallucinations_per_image(
     y_list, y_pred_list, iou_threshold=0.5, score_threshold=0.5
 ):
@@ -1241,7 +1241,7 @@ def carla_od_hallucinations_per_image(
     )
 
 
-@populationwise
+@batchwise
 def carla_od_disappearance_rate(
     y_list, y_pred_list, iou_threshold=0.5, score_threshold=0.5
 ):
@@ -1259,7 +1259,7 @@ def carla_od_disappearance_rate(
     )
 
 
-@populationwise
+@batchwise
 def carla_od_true_positive_rate(
     y_list, y_pred_list, iou_threshold=0.5, score_threshold=0.5
 ):
@@ -1277,7 +1277,7 @@ def carla_od_true_positive_rate(
     )
 
 
-@populationwise
+@batchwise
 def carla_od_misclassification_rate(
     y_list, y_pred_list, iou_threshold=0.5, score_threshold=0.5
 ):

--- a/armory/metrics/task.py
+++ b/armory/metrics/task.py
@@ -1225,7 +1225,12 @@ def object_detection_hallucinations_per_image(
 
 @populationwise
 def carla_od_hallucinations_per_image(
-    y_list, y_pred_list, iou_threshold=0.5, score_threshold=0.5, mean=True, per_image=True
+    y_list,
+    y_pred_list,
+    iou_threshold=0.5,
+    score_threshold=0.5,
+    mean=True,
+    per_image=True,
 ):
     """
     CARLA object detection datasets contains class labels 1-4, with class 4 representing
@@ -1242,14 +1247,19 @@ def carla_od_hallucinations_per_image(
     if not mean and not per_image:
         raise ValueError("At least one of 'mean' and 'per_image' must be true")
     if mean and per_image:
-        return {"mean":np.mean(np.array(result)), "per_image":result}
+        return {"mean": np.mean(np.array(result)), "per_image": result}
 
     return np.mean(np.array(result)) if mean else result
 
 
 @populationwise
 def carla_od_disappearance_rate(
-    y_list, y_pred_list, iou_threshold=0.5, score_threshold=0.5, mean=True, per_image=True
+    y_list,
+    y_pred_list,
+    iou_threshold=0.5,
+    score_threshold=0.5,
+    mean=True,
+    per_image=True,
 ):
     """
     CARLA object detection datasets contains class labels 1-4, with class 4 representing
@@ -1266,14 +1276,19 @@ def carla_od_disappearance_rate(
     if not mean and not per_image:
         raise ValueError("At least one of 'mean' and 'per_image' must be true")
     if mean and per_image:
-        return {"mean":np.mean(np.array(result)), "per_image":result}
+        return {"mean": np.mean(np.array(result)), "per_image": result}
 
     return np.mean(np.array(result)) if mean else result
 
 
 @populationwise
 def carla_od_true_positive_rate(
-    y_list, y_pred_list, iou_threshold=0.5, score_threshold=0.5, mean=True, per_image=True
+    y_list,
+    y_pred_list,
+    iou_threshold=0.5,
+    score_threshold=0.5,
+    mean=True,
+    per_image=True,
 ):
     """
     CARLA object detection datasets contains class labels 1-4, with class 4 representing
@@ -1290,14 +1305,19 @@ def carla_od_true_positive_rate(
     if not mean and not per_image:
         raise ValueError("At least one of 'mean' and 'per_image' must be true")
     if mean and per_image:
-        return {"mean":np.mean(np.array(result)), "per_image":result}
+        return {"mean": np.mean(np.array(result)), "per_image": result}
 
     return np.mean(np.array(result)) if mean else result
 
 
 @populationwise
 def carla_od_misclassification_rate(
-    y_list, y_pred_list, iou_threshold=0.5, score_threshold=0.5, mean=True, per_image=True
+    y_list,
+    y_pred_list,
+    iou_threshold=0.5,
+    score_threshold=0.5,
+    mean=True,
+    per_image=True,
 ):
     """
     CARLA object detection datasets contains class labels 1-4, with class 4 representing
@@ -1314,7 +1334,7 @@ def carla_od_misclassification_rate(
     if not mean and not per_image:
         raise ValueError("At least one of 'mean' and 'per_image' must be true")
     if mean and per_image:
-        return {"mean":np.mean(np.array(result)), "per_image":result}
+        return {"mean": np.mean(np.array(result)), "per_image": result}
 
     return np.mean(np.array(result)) if mean else result
 

--- a/armory/metrics/task.py
+++ b/armory/metrics/task.py
@@ -1100,7 +1100,13 @@ def _object_detection_get_tpr_mr_dr_hr(
 
 @populationwise
 def object_detection_true_positive_rate(
-    y_list, y_pred_list, iou_threshold=0.5, score_threshold=0.5, class_list=None
+    y_list,
+    y_pred_list,
+    iou_threshold=0.5,
+    score_threshold=0.5,
+    class_list=None,
+    mean=True,
+    per_image=True,
 ):
     """
     Computes object detection true positive rate: the percent of ground-truth boxes which
@@ -1126,12 +1132,30 @@ def object_detection_true_positive_rate(
         score_threshold=score_threshold,
         class_list=class_list,
     )
-    return true_positive_rate_per_img
+    if not mean and not per_image:
+        raise ValueError("At least one of 'mean' and 'per_image' must be true")
+    if mean and per_image:
+        return {
+            "mean": np.mean(np.array(true_positive_rate_per_img)),
+            "per_image": true_positive_rate_per_img,
+        }
+
+    return (
+        np.mean(np.array(true_positive_rate_per_img))
+        if mean
+        else true_positive_rate_per_img
+    )
 
 
 @populationwise
 def object_detection_misclassification_rate(
-    y_list, y_pred_list, iou_threshold=0.5, score_threshold=0.5, class_list=None
+    y_list,
+    y_pred_list,
+    iou_threshold=0.5,
+    score_threshold=0.5,
+    class_list=None,
+    mean=True,
+    per_image=True,
 ):
     """
     Computes object detection misclassification rate: the percent of ground-truth boxes which
@@ -1157,12 +1181,30 @@ def object_detection_misclassification_rate(
         score_threshold=score_threshold,
         class_list=class_list,
     )
-    return misclassification_rate_per_image
+    if not mean and not per_image:
+        raise ValueError("At least one of 'mean' and 'per_image' must be true")
+    if mean and per_image:
+        return {
+            "mean": np.mean(np.array(misclassification_rate_per_image)),
+            "per_image": misclassification_rate_per_image,
+        }
+
+    return (
+        np.mean(np.array(misclassification_rate_per_image))
+        if mean
+        else misclassification_rate_per_image
+    )
 
 
 @populationwise
 def object_detection_disappearance_rate(
-    y_list, y_pred_list, iou_threshold=0.5, score_threshold=0.5, class_list=None
+    y_list,
+    y_pred_list,
+    iou_threshold=0.5,
+    score_threshold=0.5,
+    class_list=None,
+    mean=True,
+    per_image=True,
 ):
     """
     Computes object detection disappearance rate: the percent of ground-truth boxes for which
@@ -1189,12 +1231,30 @@ def object_detection_disappearance_rate(
         score_threshold=score_threshold,
         class_list=class_list,
     )
-    return disappearance_rate_per_img
+    if not mean and not per_image:
+        raise ValueError("At least one of 'mean' and 'per_image' must be true")
+    if mean and per_image:
+        return {
+            "mean": np.mean(np.array(disappearance_rate_per_img)),
+            "per_image": disappearance_rate_per_img,
+        }
+
+    return (
+        np.mean(np.array(disappearance_rate_per_img))
+        if mean
+        else disappearance_rate_per_img
+    )
 
 
 @populationwise
 def object_detection_hallucinations_per_image(
-    y_list, y_pred_list, iou_threshold=0.5, score_threshold=0.5, class_list=None
+    y_list,
+    y_pred_list,
+    iou_threshold=0.5,
+    score_threshold=0.5,
+    class_list=None,
+    mean=True,
+    per_image=True,
 ):
     """
     Computes object detection hallucinations per image: the number of predicted boxes per image
@@ -1220,7 +1280,19 @@ def object_detection_hallucinations_per_image(
         score_threshold=score_threshold,
         class_list=class_list,
     )
-    return hallucinations_per_image
+    if not mean and not per_image:
+        raise ValueError("At least one of 'mean' and 'per_image' must be true")
+    if mean and per_image:
+        return {
+            "mean": np.mean(np.array(hallucinations_per_image)),
+            "per_image": hallucinations_per_image,
+        }
+
+    return (
+        np.mean(np.array(hallucinations_per_image))
+        if mean
+        else hallucinations_per_image
+    )
 
 
 @populationwise
@@ -1237,19 +1309,15 @@ def carla_od_hallucinations_per_image(
     the green screen/patch itself, which should not be treated as an object class.
     """
     class_list = [1, 2, 3]
-    result = object_detection_hallucinations_per_image(
+    return object_detection_hallucinations_per_image(
         y_list,
         y_pred_list,
         iou_threshold=iou_threshold,
         score_threshold=score_threshold,
         class_list=class_list,
+        mean=mean,
+        per_image=per_image,
     )
-    if not mean and not per_image:
-        raise ValueError("At least one of 'mean' and 'per_image' must be true")
-    if mean and per_image:
-        return {"mean": np.mean(np.array(result)), "per_image": result}
-
-    return np.mean(np.array(result)) if mean else result
 
 
 @populationwise
@@ -1266,19 +1334,15 @@ def carla_od_disappearance_rate(
     the green screen/patch itself, which should not be treated as an object class.
     """
     class_list = [1, 2, 3]
-    result = object_detection_disappearance_rate(
+    return object_detection_disappearance_rate(
         y_list,
         y_pred_list,
         iou_threshold=iou_threshold,
         score_threshold=score_threshold,
         class_list=class_list,
+        mean=mean,
+        per_image=per_image,
     )
-    if not mean and not per_image:
-        raise ValueError("At least one of 'mean' and 'per_image' must be true")
-    if mean and per_image:
-        return {"mean": np.mean(np.array(result)), "per_image": result}
-
-    return np.mean(np.array(result)) if mean else result
 
 
 @populationwise
@@ -1295,19 +1359,15 @@ def carla_od_true_positive_rate(
     the green screen/patch itself, which should not be treated as an object class.
     """
     class_list = [1, 2, 3]
-    result = object_detection_true_positive_rate(
+    return object_detection_true_positive_rate(
         y_list,
         y_pred_list,
         iou_threshold=iou_threshold,
         score_threshold=score_threshold,
         class_list=class_list,
+        mean=mean,
+        per_image=per_image,
     )
-    if not mean and not per_image:
-        raise ValueError("At least one of 'mean' and 'per_image' must be true")
-    if mean and per_image:
-        return {"mean": np.mean(np.array(result)), "per_image": result}
-
-    return np.mean(np.array(result)) if mean else result
 
 
 @populationwise
@@ -1324,19 +1384,15 @@ def carla_od_misclassification_rate(
     the green screen/patch itself, which should not be treated as an object class.
     """
     class_list = [1, 2, 3]
-    result = object_detection_misclassification_rate(
+    return object_detection_misclassification_rate(
         y_list,
         y_pred_list,
         iou_threshold=iou_threshold,
         score_threshold=score_threshold,
         class_list=class_list,
+        mean=mean,
+        per_image=per_image,
     )
-    if not mean and not per_image:
-        raise ValueError("At least one of 'mean' and 'per_image' must be true")
-    if mean and per_image:
-        return {"mean": np.mean(np.array(result)), "per_image": result}
-
-    return np.mean(np.array(result)) if mean else result
 
 
 @populationwise

--- a/armory/metrics/task.py
+++ b/armory/metrics/task.py
@@ -1100,13 +1100,7 @@ def _object_detection_get_tpr_mr_dr_hr(
 
 @populationwise
 def object_detection_true_positive_rate(
-    y_list,
-    y_pred_list,
-    iou_threshold=0.5,
-    score_threshold=0.5,
-    class_list=None,
-    mean=True,
-    per_image=True,
+    y_list, y_pred_list, iou_threshold=0.5, score_threshold=0.5, class_list=None
 ):
     """
     Computes object detection true positive rate: the percent of ground-truth boxes which
@@ -1132,30 +1126,12 @@ def object_detection_true_positive_rate(
         score_threshold=score_threshold,
         class_list=class_list,
     )
-    if not mean and not per_image:
-        raise ValueError("At least one of 'mean' and 'per_image' must be true")
-    if mean and per_image:
-        return {
-            "mean": np.mean(np.array(true_positive_rate_per_img)),
-            "per_image": true_positive_rate_per_img,
-        }
-
-    return (
-        np.mean(np.array(true_positive_rate_per_img))
-        if mean
-        else true_positive_rate_per_img
-    )
+    return true_positive_rate_per_img
 
 
 @populationwise
 def object_detection_misclassification_rate(
-    y_list,
-    y_pred_list,
-    iou_threshold=0.5,
-    score_threshold=0.5,
-    class_list=None,
-    mean=True,
-    per_image=True,
+    y_list, y_pred_list, iou_threshold=0.5, score_threshold=0.5, class_list=None
 ):
     """
     Computes object detection misclassification rate: the percent of ground-truth boxes which
@@ -1181,30 +1157,12 @@ def object_detection_misclassification_rate(
         score_threshold=score_threshold,
         class_list=class_list,
     )
-    if not mean and not per_image:
-        raise ValueError("At least one of 'mean' and 'per_image' must be true")
-    if mean and per_image:
-        return {
-            "mean": np.mean(np.array(misclassification_rate_per_image)),
-            "per_image": misclassification_rate_per_image,
-        }
-
-    return (
-        np.mean(np.array(misclassification_rate_per_image))
-        if mean
-        else misclassification_rate_per_image
-    )
+    return misclassification_rate_per_image
 
 
 @populationwise
 def object_detection_disappearance_rate(
-    y_list,
-    y_pred_list,
-    iou_threshold=0.5,
-    score_threshold=0.5,
-    class_list=None,
-    mean=True,
-    per_image=True,
+    y_list, y_pred_list, iou_threshold=0.5, score_threshold=0.5, class_list=None
 ):
     """
     Computes object detection disappearance rate: the percent of ground-truth boxes for which
@@ -1231,30 +1189,12 @@ def object_detection_disappearance_rate(
         score_threshold=score_threshold,
         class_list=class_list,
     )
-    if not mean and not per_image:
-        raise ValueError("At least one of 'mean' and 'per_image' must be true")
-    if mean and per_image:
-        return {
-            "mean": np.mean(np.array(disappearance_rate_per_img)),
-            "per_image": disappearance_rate_per_img,
-        }
-
-    return (
-        np.mean(np.array(disappearance_rate_per_img))
-        if mean
-        else disappearance_rate_per_img
-    )
+    return disappearance_rate_per_img
 
 
 @populationwise
 def object_detection_hallucinations_per_image(
-    y_list,
-    y_pred_list,
-    iou_threshold=0.5,
-    score_threshold=0.5,
-    class_list=None,
-    mean=True,
-    per_image=True,
+    y_list, y_pred_list, iou_threshold=0.5, score_threshold=0.5, class_list=None
 ):
     """
     Computes object detection hallucinations per image: the number of predicted boxes per image
@@ -1280,29 +1220,12 @@ def object_detection_hallucinations_per_image(
         score_threshold=score_threshold,
         class_list=class_list,
     )
-    if not mean and not per_image:
-        raise ValueError("At least one of 'mean' and 'per_image' must be true")
-    if mean and per_image:
-        return {
-            "mean": np.mean(np.array(hallucinations_per_image)),
-            "per_image": hallucinations_per_image,
-        }
-
-    return (
-        np.mean(np.array(hallucinations_per_image))
-        if mean
-        else hallucinations_per_image
-    )
+    return hallucinations_per_image
 
 
 @populationwise
 def carla_od_hallucinations_per_image(
-    y_list,
-    y_pred_list,
-    iou_threshold=0.5,
-    score_threshold=0.5,
-    mean=True,
-    per_image=True,
+    y_list, y_pred_list, iou_threshold=0.5, score_threshold=0.5
 ):
     """
     CARLA object detection datasets contains class labels 1-4, with class 4 representing
@@ -1315,19 +1238,12 @@ def carla_od_hallucinations_per_image(
         iou_threshold=iou_threshold,
         score_threshold=score_threshold,
         class_list=class_list,
-        mean=mean,
-        per_image=per_image,
     )
 
 
 @populationwise
 def carla_od_disappearance_rate(
-    y_list,
-    y_pred_list,
-    iou_threshold=0.5,
-    score_threshold=0.5,
-    mean=True,
-    per_image=True,
+    y_list, y_pred_list, iou_threshold=0.5, score_threshold=0.5
 ):
     """
     CARLA object detection datasets contains class labels 1-4, with class 4 representing
@@ -1340,19 +1256,12 @@ def carla_od_disappearance_rate(
         iou_threshold=iou_threshold,
         score_threshold=score_threshold,
         class_list=class_list,
-        mean=mean,
-        per_image=per_image,
     )
 
 
 @populationwise
 def carla_od_true_positive_rate(
-    y_list,
-    y_pred_list,
-    iou_threshold=0.5,
-    score_threshold=0.5,
-    mean=True,
-    per_image=True,
+    y_list, y_pred_list, iou_threshold=0.5, score_threshold=0.5
 ):
     """
     CARLA object detection datasets contains class labels 1-4, with class 4 representing
@@ -1365,19 +1274,12 @@ def carla_od_true_positive_rate(
         iou_threshold=iou_threshold,
         score_threshold=score_threshold,
         class_list=class_list,
-        mean=mean,
-        per_image=per_image,
     )
 
 
 @populationwise
 def carla_od_misclassification_rate(
-    y_list,
-    y_pred_list,
-    iou_threshold=0.5,
-    score_threshold=0.5,
-    mean=True,
-    per_image=True,
+    y_list, y_pred_list, iou_threshold=0.5, score_threshold=0.5
 ):
     """
     CARLA object detection datasets contains class labels 1-4, with class 4 representing
@@ -1390,8 +1292,6 @@ def carla_od_misclassification_rate(
         iou_threshold=iou_threshold,
         score_threshold=score_threshold,
         class_list=class_list,
-        mean=mean,
-        per_image=per_image,
     )
 
 

--- a/armory/metrics/task.py
+++ b/armory/metrics/task.py
@@ -1098,7 +1098,7 @@ def _object_detection_get_tpr_mr_dr_hr(
     )
 
 
-@populationwise
+@batchwise
 def object_detection_true_positive_rate(
     y_list, y_pred_list, iou_threshold=0.5, score_threshold=0.5, class_list=None
 ):
@@ -1129,7 +1129,7 @@ def object_detection_true_positive_rate(
     return true_positive_rate_per_img
 
 
-@populationwise
+@batchwise
 def object_detection_misclassification_rate(
     y_list, y_pred_list, iou_threshold=0.5, score_threshold=0.5, class_list=None
 ):
@@ -1160,7 +1160,7 @@ def object_detection_misclassification_rate(
     return misclassification_rate_per_image
 
 
-@populationwise
+@batchwise
 def object_detection_disappearance_rate(
     y_list, y_pred_list, iou_threshold=0.5, score_threshold=0.5, class_list=None
 ):
@@ -1192,7 +1192,7 @@ def object_detection_disappearance_rate(
     return disappearance_rate_per_img
 
 
-@populationwise
+@batchwise
 def object_detection_hallucinations_per_image(
     y_list, y_pred_list, iou_threshold=0.5, score_threshold=0.5, class_list=None
 ):

--- a/armory/scenarios/carla_object_detection.py
+++ b/armory/scenarios/carla_object_detection.py
@@ -72,11 +72,6 @@ class CarlaObjectDetectionTask(ObjectDetectionTask):
 
         self.x_adv, self.y_target, self.y_pred_adv = x_adv, y_target, y_pred_adv
 
-    def load_metrics(self):
-        super().load_metrics()
-        # measure adversarial results using benign predictions as labels
-        self.metrics_logger.add_tasks_wrt_benign_predictions()
-
     def _load_sample_exporter_with_boxes(self):
         return ObjectDetectionExporter(
             self.export_dir,

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -149,17 +149,17 @@ def load_metrics(self):
 | `video_tracking_mean_iou` | `task.batch.video_tracking_mean_iou` | Mean IOU between ground-truth and predicted boxes, averaged over all frames for a video |
 | `video_tracking_mean_success_rate` | `task.batch.video_tracking_mean_success_rate` | Mean success rate averaged over all multiple IOU thresholds and all frames |
 | `object_detection_AP_per_class` | `task.population.object_detection_AP_per_class` | Object Detection average precision per class |
-| `object_detection_disappearance_rate` | `task.population.object_detection_disappearance_rate` | Object Detection Disappearance Rate |
-| `object_detection_hallucinations_per_image` | `task.population.object_detection_hallucinations_per_image` | Object Detection Hallucinations Per Image |
+| `object_detection_disappearance_rate` | `task.batch.object_detection_disappearance_rate` | Object Detection Disappearance Rate |
+| `object_detection_hallucinations_per_image` | `task.batch.object_detection_hallucinations_per_image` | Object Detection Hallucinations Per Image |
 | `object_detection_mAP` | `task.population.object_detection_mAP` | Object Detection mean average precision |
-| `object_detection_misclassification_rate` | `task.population.object_detection_misclassification_rate` | Object Detection Misclassification Rate |
-| `object_detection_true_positive_rate` | `task.population.object_detection_true_positive_rate` | Object Detection True Positive Rate | 
+| `object_detection_misclassification_rate` | `task.batch.object_detection_misclassification_rate` | Object Detection Misclassification Rate |
+| `object_detection_true_positive_rate` | `task.batch.object_detection_true_positive_rate` | Object Detection True Positive Rate | 
 | `apricot_patch_targeted_AP_per_class` | `task.population.apricot_patch_targeted_AP_per_class` | OD metric applied to apricot scenario |
 | `carla_od_AP_per_class` | `task.population.carla_od_AP_per_class` | OD metric applied to carla scenario |
-| `carla_od_disappearance_rate`  | `task.population.carla_od_disappearance_rate` | OD metric applied to carla scenario |
-| `carla_od_hallucinations_per_image` | `task.population.carla_od_hallucinations_per_image` | OD metric applied to carla scenario |
-| `carla_od_misclassification_rate` | `task.population.carla_od_misclassification_rate` | OD metric applied to carla scenario |
-| `carla_od_true_positive_rate` | `task.population.carla_od_true_positive_rate` | OD metric applied to carla scenario |
+| `carla_od_disappearance_rate`  | `task.batch.carla_od_disappearance_rate` | OD metric applied to carla scenario |
+| `carla_od_hallucinations_per_image` | `task.batch.carla_od_hallucinations_per_image` | OD metric applied to carla scenario |
+| `carla_od_misclassification_rate` | `task.batch.carla_od_misclassification_rate` | OD metric applied to carla scenario |
+| `carla_od_true_positive_rate` | `task.batch.carla_od_true_positive_rate` | OD metric applied to carla scenario |
 | `dapricot_patch_target_success` | `task.population.dapricot_patch_target_success` | OD metric applied to dapricot scenario |
 | `dapricot_patch_targeted_AP_per_class` | `task.population.dapricot_patch_targeted_AP_per_class` | OD metric applied to dapricot scenario |
 | `abstains` | `task.batch.abstains` | Takes a batch matrix of inputs and returns 1 for each row that are all 0 (abstention) |

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -128,6 +128,13 @@ These metrics typically take a list or array of results as their single argument
 
 The `apricot`, `carla`, and `dapricot` metrics are effectively the `object_detection` metrics with parameters adapted to those respective scenarios.
 
+As mentioned, these functions generally compare `y_pred` against `y`, that is, the metric compares a benign or adversarial prediction to the ground truth.  It is also possible to use these metrics to compare adversarial predictions against benign predictions.  This is not enabled in off-the-shelf Armory code, but can be easily implemented through one small code modification, by simply adding ```self.metrics_logger.add_tasks_wrt_benign_predictions()``` to the ```load_metrics()``` function of the scenario.  For example, if you create a new scenario inheriting ```scenario.py```, you can implement ```load_metrics()``` this way:
+```
+def load_metrics(self):
+    super().load_metrics()
+    self.metrics_logger.add_tasks_wrt_benign_predictions()
+```
+
 | Name | Namespace | Description |
 |-------|-------|-------|
 | `categorical_accuracy` | `task.batch.categorical_accuracy` | Categorical Accuracy |


### PR DESCRIPTION
Mike's description of the error from slack:

> it seems that per example metrics are always collected for OD scenarios even if ```metric -> record_metric_per_sample``` is ```False```. In addition, with the exception of ```AP_per_class```, the other metrics no longer report the mean statistic even if ```metric -> mean``` is ```True```.

This is essentially because the ```GlobalMeter``` class used for ```@populationwise``` metric functions assumes that the functions already return the mean over all samples.  This is true for ```AP_per_class```, but not the others.

Easy fix: just have the metric functions return the mean over all samples.  This seems to be what the writer of this code (David) expected.

But that leaves questions about why the carla OD functions are marked @populationwise in the first place and whether a user would ever want to see per-image results.  In that case, should this be controllable from the config, or should we just return both?
