### PR TITLE
Yet another sleeper agent bug fix

### DIFF
--- a/armory/scenarios/poison.py
+++ b/armory/scenarios/poison.py
@@ -340,7 +340,7 @@ class Poison(Scenario):
                 log.info(f"Training with {type(self.trainer)} Trainer defense...")
                 if self.fit_generator:
                     self.trainer.fit_generator(
-                        self.data_generator, np_epochs=self.train_epochs
+                        data_generator, np_epochs=self.train_epochs
                     )
                 else:
                     self.trainer.fit(
@@ -392,7 +392,8 @@ class Poison(Scenario):
         if explanatory_config:
             self.explanatory_model = ExplanatoryModel.from_config(explanatory_config)
         else:
-            log.warning(
+            # compute_fairness_metrics was true, but there is no explanatory config
+            raise ValueError(
                 "If computing fairness metrics, must specify 'explanatory_model' under 'adhoc'"
             )
 

--- a/armory/scenarios/poisoning_sleeper_agent.py
+++ b/armory/scenarios/poisoning_sleeper_agent.py
@@ -159,18 +159,14 @@ class SleeperAgentScenario(Poison):
 
             # Manually find the poison indices.  Although the attack can return them, they
             # will be the index within the target class, not the whole dataset.
-            # In addition, they may include images that aren't actually perturbed.
             poison_index = np.array(
                 [
                     i
                     for i in range(len(self.x_clean))
-                    if (self.x_clean[i] != self.x_poison[i]).all()
+                    if (self.x_clean[i] != self.x_poison[i]).any()
                 ]
             )
             n_target = (self.y_clean == self.target_class).sum()
-            log.info(
-                f"Actual amount of poison returned by attack: {len(poison_index)} samples or {len(poison_index)/n_target} percent"
-            )
 
         else:
             self.x_poison, self.y_poison, poison_index = (

--- a/scenario_configs/eval6/poisoning/audio_dlbd/baseline_defenses/audio_p10_dpinstahide.json
+++ b/scenario_configs/eval6/poisoning/audio_dlbd/baseline_defenses/audio_p10_dpinstahide.json
@@ -51,7 +51,7 @@
                 1
             ],
             "noise": "laplacian",
-            "scale": 0.1
+            "scale": 0.015
         },
         "module": "art.defences.trainer",
         "name": "DPInstaHideTrainer",

--- a/scenario_configs/eval6/poisoning/sleeper_agent/baseline_defenses/cifar10_sleeper_agent_p10_dpinstahide.json
+++ b/scenario_configs/eval6/poisoning/sleeper_agent/baseline_defenses/cifar10_sleeper_agent_p10_dpinstahide.json
@@ -72,7 +72,7 @@
                 1
             ],
             "noise": "laplacian",
-            "scale": 0.1
+            "scale": 0.03
         },
         "module": "art.defences.trainer",
         "name": "DPInstaHideTrainer",


### PR DESCRIPTION
Fixes bug in sleeper agent scenario where it was incorrectly finding the indices of poisoned data.

Also includes a couple less crucial improvements (invalid variable name in infrequently-reached code; improved parameter values for dp-instahide baseline configs)