### PR TITLE
Add verbose error message when importing armory.metrics without the proper dependencies installed.

### DIFF
--- a/armory/metrics/__init__.py
+++ b/armory/metrics/__init__.py
@@ -1,7 +1,13 @@
 import importlib
 from typing import Callable
 
-from armory.metrics import compute, perturbation, statistical, task
+try:
+    from armory.metrics import compute, perturbation, statistical, task
+except ImportError as e:
+    raise ImportError(
+        "armory engine dependencies are not installed. "
+        "Please install armory-testbed[engine] to use metrics."
+    )
 from armory.metrics.common import get_result_formatter, result_formatter, supported
 
 

--- a/armory/metrics/__init__.py
+++ b/armory/metrics/__init__.py
@@ -3,7 +3,7 @@ from typing import Callable
 
 try:
     from armory.metrics import compute, perturbation, statistical, task
-except ImportError as e:
+except ImportError:
     raise ImportError(
         "armory engine dependencies are not installed. "
         "Please install armory-testbed[engine] to use metrics."


### PR DESCRIPTION
See https://github.com/twosixlabs/armory/issues/1895.