### PR TITLE
avoid tfds version 4.9.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -114,7 +114,7 @@ math = [
 
 datasets = [
     "armory-testbed[tensorflow]",
-    "tensorflow-datasets >= 4.6.0",
+    "tensorflow-datasets >= 4.6.0, != 4.9.0",
     "protobuf",
 ]
 


### PR DESCRIPTION
Tfds version 4.9.0 has trouble importing on macos apparently, causing problems with our github tests.  See this [issue](https://github.com/tensorflow/datasets/issues/4852) for some context. 

We should be able to dodge this problem by not using that tfds version