### PR TITLE
set cuda devices for no-docker mode

### DIFF
--- a/armory/eval/evaluator.py
+++ b/armory/eval/evaluator.py
@@ -95,7 +95,15 @@ class Evaluator(object):
         if self.config["sysconfig"].get("use_gpu", None):
             gpus = self.config["sysconfig"].get("gpus")
             if gpus is not None:
-                self.extra_env_vars["NVIDIA_VISIBLE_DEVICES"] = gpus
+                if self.no_docker:
+                    self.extra_env_vars["CUDA_VISIBLE_DEVICES"] = gpus
+                else:
+                    self.extra_env_vars["NVIDIA_VISIBLE_DEVICES"] = gpus
+        else:
+            if self.no_docker:
+                # Must be explicitly set for no-docker
+                self.extra_env_vars["CUDA_VISIBLE_DEVICES"] = "-1"
+
         if self.config["sysconfig"].get("set_pythonhashseed"):
             self.extra_env_vars["PYTHONHASHSEED"] = "0"
 

--- a/armory/eval/evaluator.py
+++ b/armory/eval/evaluator.py
@@ -96,10 +96,10 @@ class Evaluator(object):
             True if os.getenv("CUDA_VISIBLE_DEVICES") is not None else False
         )
         if cuda_var_exists and self.no_docker:
+            # Existing value should override armory flags
             log.warning(
                 "CUDA_VISIBLE_DEVICES is set; any Armoy gpu instructions will be ignored"
             )
-            # Existing value should override armory flags
 
         # Set visible gpus
         if self.config["sysconfig"].get("use_gpu", None):

--- a/armory/eval/evaluator.py
+++ b/armory/eval/evaluator.py
@@ -95,7 +95,9 @@ class Evaluator(object):
         cuda_var_exists = (
             True if os.getenv("CUDA_VISIBLE_DEVICES") is not None else False
         )
-        # Existing value should override armory flags
+        if cuda_var_exists and self.no_docker:
+            log.warning("CUDA_VISIBLE_DEVICES is set; any Armoy gpu instructions will be ignored")
+            # Existing value should override armory flags
 
         # Set visible gpus
         if self.config["sysconfig"].get("use_gpu", None):
@@ -107,7 +109,7 @@ class Evaluator(object):
                     self.extra_env_vars["NVIDIA_VISIBLE_DEVICES"] = gpus
         else:
             if self.no_docker and not cuda_var_exists:
-                # Must be explicitly set for no-docker
+                # Block gpus for no-docker mode
                 self.extra_env_vars["CUDA_VISIBLE_DEVICES"] = "-1"
 
         if self.config["sysconfig"].get("set_pythonhashseed"):

--- a/armory/eval/evaluator.py
+++ b/armory/eval/evaluator.py
@@ -92,7 +92,9 @@ class Evaluator(object):
         if not self.armory_global_config["verify_ssl"]:
             self.extra_env_vars["VERIFY_SSL"] = "false"
 
-        cuda_var_exists = True if os.getenv("CUDA_VISIBLE_DEVICES") is not None else False
+        cuda_var_exists = (
+            True if os.getenv("CUDA_VISIBLE_DEVICES") is not None else False
+        )
         # Existing value should override armory flags
 
         # Set visible gpus

--- a/armory/eval/evaluator.py
+++ b/armory/eval/evaluator.py
@@ -96,7 +96,9 @@ class Evaluator(object):
             True if os.getenv("CUDA_VISIBLE_DEVICES") is not None else False
         )
         if cuda_var_exists and self.no_docker:
-            log.warning("CUDA_VISIBLE_DEVICES is set; any Armoy gpu instructions will be ignored")
+            log.warning(
+                "CUDA_VISIBLE_DEVICES is set; any Armoy gpu instructions will be ignored"
+            )
             # Existing value should override armory flags
 
         # Set visible gpus

--- a/armory/eval/evaluator.py
+++ b/armory/eval/evaluator.py
@@ -92,15 +92,19 @@ class Evaluator(object):
         if not self.armory_global_config["verify_ssl"]:
             self.extra_env_vars["VERIFY_SSL"] = "false"
 
+        cuda_var_exists = True if os.getenv("CUDA_VISIBLE_DEVICES") is not None else False
+        # Existing value should override armory flags
+
+        # Set visible gpus
         if self.config["sysconfig"].get("use_gpu", None):
             gpus = self.config["sysconfig"].get("gpus")
             if gpus is not None:
-                if self.no_docker:
+                if self.no_docker and not cuda_var_exists:
                     self.extra_env_vars["CUDA_VISIBLE_DEVICES"] = gpus
-                else:
+                if not self.no_docker:
                     self.extra_env_vars["NVIDIA_VISIBLE_DEVICES"] = gpus
         else:
-            if self.no_docker:
+            if self.no_docker and not cuda_var_exists:
                 # Must be explicitly set for no-docker
                 self.extra_env_vars["CUDA_VISIBLE_DEVICES"] = "-1"
 


### PR DESCRIPTION
I believe this retains the existing behavior when using docker.
For no-docker mode, this sets CUDA_VISIBLE_DEVICES to the list of gpus, if specified, or to -1 if the gpu is not to be used.  
It still defaults to using all gpus if use_gpu is True but no gpus are specified.

@christopherwoodall @jprokos26 Do you have any comments about this approach?  Any cases I'm overlooking?

Should fix #1923 and #1902.  Does not address #1922.