### PR TITLE
Add support for patch_base_image when not running locally

### DIFF
--- a/armory/art_experimental/attacks/carla_obj_det_adversarial_patch.py
+++ b/armory/art_experimental/attacks/carla_obj_det_adversarial_patch.py
@@ -54,19 +54,11 @@ class CARLAAdversarialPatchPyTorch(AdversarialPatchPyTorch):
         patch_base_image_path = os.path.abspath(
             os.path.join(module_folder, self.patch_base_image)
         )
-        # if the image does not exist, check paths.DockerPaths().cwd
+        # if the image does not exist, check cwd
         if not os.path.exists(patch_base_image_path):
-            # TODO: determine if in docker mode smartly
-            docker_cwd = paths.DockerPaths().cwd
-            host_cwd = paths.HostPaths().cwd
             patch_base_image_path = os.path.abspath(
-                os.path.join(docker_cwd, self.patch_base_image)
+                os.path.join(paths.runtime_paths().cwd, self.patch_base_image)
             )
-            # check host cwd if docker cwd does not exist
-            if not os.path.exists(patch_base_image_path):
-                patch_base_image_path = os.path.abspath(
-                    os.path.join(host_cwd, self.patch_base_image)
-                )
         # image not in cwd or module, check if it is a url to an image
         if not os.path.exists(patch_base_image_path):
             import requests

--- a/armory/art_experimental/attacks/carla_obj_det_adversarial_patch.py
+++ b/armory/art_experimental/attacks/carla_obj_det_adversarial_patch.py
@@ -6,6 +6,7 @@ from art.attacks.evasion.adversarial_patch.adversarial_patch_pytorch import (
 )
 import cv2
 import numpy as np
+import requests
 import torch
 
 from armory import paths
@@ -16,6 +17,8 @@ from armory.art_experimental.attacks.carla_obj_det_utils import (
     rgb_depth_to_linear,
 )
 from armory.logs import log
+
+VALID_IMAGE_TYPES = ["image/png", "image/jpeg", "image/jpg"]
 
 
 class CARLAAdversarialPatchPyTorch(AdversarialPatchPyTorch):
@@ -61,19 +64,28 @@ class CARLAAdversarialPatchPyTorch(AdversarialPatchPyTorch):
             )
         # image not in cwd or module, check if it is a url to an image
         if not os.path.exists(patch_base_image_path):
-            import requests
+            # Send a HEAD request
+            response = requests.head(self.patch_base_image, allow_redirects=True)
 
-            try:
-                response = requests.get(self.patch_base_image, allow_redirects=True)
-                im = cv2.imdecode(
-                    np.frombuffer(response.content, np.uint8), cv2.IMREAD_COLOR
-                )
-            except Exception as e:
-                log.exception(e)
+            # Check the status code
+            if response.status_code != 200:
                 raise FileNotFoundError(
                     f"Cannot find patch base image at {self.patch_base_image}. "
                     f"Make sure it is in your cwd or {module_folder} or provide a valid url."
                 )
+            # If the status code is 200, check the content type
+            content_type = response.headers.get("content-type")
+            if content_type not in VALID_IMAGE_TYPES:
+                raise ValueError(
+                    f"Returned content at {self.patch_base_image} is not a valid image type. "
+                    f"Expected types are {VALID_IMAGE_TYPES}, but received {content_type}"
+                )
+
+            # If content type is valid, download the image
+            response = requests.get(self.patch_base_image, allow_redirects=True)
+            im = cv2.imdecode(
+                np.frombuffer(response.content, np.uint8), cv2.IMREAD_COLOR
+            )
         else:
             im = cv2.imread(patch_base_image_path)
 


### PR DESCRIPTION
Addresses #1930 

Searches for `patch_base_image` in more than one place:
1. Check if file exists in module path
2. Check if file exists in `armory.paths.runtime_paths().cwd`
3. Check if supplied `patch_base_image` is actually a url to an image we can download
Else fail