### PR TITLE
clarify local repo path in config documentation

### DIFF
--- a/docs/configuration_files.md
+++ b/docs/configuration_files.md
@@ -70,7 +70,7 @@ All configuration files are verified against the jsonschema definition at run ti
     external_github_repo: [String or null or Object] External github repository(s) to download and place on PYTHONPATH within container
     external_github_repo_pythonpath: [String or null or Object] Relative path(s) in the repo directory to add to PYTHONPATH within container
     gpus: [String]: Which GPUs should the docker container have access to. "all" or comma sperated list (e.g. "1,3")
-    local_repo_path: [String or null or Object] Local github repository path(s) to place on PYTHONPATH within container
+    local_repo_path: [String or null or Object] Local github repository path(s) to place on PYTHONPATH within container (relative to the "local_git_dir" variable specified in ~/.armory/config.json)
     output_dir: [Optional String]:  Add an optional output directory prefix to the default output directory name.
     output_filename: [Optional String]: Optionally change the output filename prefix (from default of scenario name)  
     use_gpu: [Boolean]: Boolean to run container as nvidia-docker with GPU access


### PR DESCRIPTION
At least one performer experienced confusion about the ```local_repo_path``` variable; I think this should help.