### PR TITLE
allow min/max size kwargs for carla multimodal frcnn

### DIFF
--- a/armory/baseline_models/pytorch/carla_multimodality_object_detection_frcnn.py
+++ b/armory/baseline_models/pytorch/carla_multimodality_object_detection_frcnn.py
@@ -108,6 +108,11 @@ def get_art_model_mm(
 ) -> PyTorchFasterRCNN:
 
     num_classes = model_kwargs.pop("num_classes", 3)
+    frcnn_kwargs = {
+        arg: model_kwargs.pop(arg)
+        for arg in ["min_size", "max_size"]
+        if arg in model_kwargs
+    }
 
     backbone = MultimodalNaive(**model_kwargs)
 
@@ -116,6 +121,7 @@ def get_art_model_mm(
         num_classes=num_classes,
         image_mean=[0.485, 0.456, 0.406, 0.0, 0.0, 0.0],
         image_std=[0.229, 0.224, 0.225, 1.0, 1.0, 1.0],
+        **frcnn_kwargs,
     )
     model.to(DEVICE)
 

--- a/armory/baseline_models/pytorch/carla_multimodality_object_detection_frcnn_robust_fusion.py
+++ b/armory/baseline_models/pytorch/carla_multimodality_object_detection_frcnn_robust_fusion.py
@@ -182,6 +182,11 @@ def get_art_model_mm_robust(
 ) -> PyTorchFasterRCNN:
 
     num_classes = model_kwargs.pop("num_classes", 3)
+    frcnn_kwargs = {
+        arg: model_kwargs.pop(arg)
+        for arg in ["min_size", "max_size"]
+        if arg in model_kwargs
+    }
 
     backbone = MultimodalRobust(**model_kwargs)
 
@@ -190,6 +195,7 @@ def get_art_model_mm_robust(
         num_classes=num_classes,
         image_mean=[0.485, 0.456, 0.406, 0.0, 0.0, 0.0],
         image_std=[0.229, 0.224, 0.225, 1.0, 1.0, 1.0],
+        **frcnn_kwargs,
     )
     model.to(DEVICE)
 


### PR DESCRIPTION
You can get better benign carla performance if you pass ```"min_size":960, "max_size":1280``` through to the underlying FRCNN model.  This works automatically for the unimodal model but requires this minor fix for multimodal.

To test/use, set the specified parameters under ```"model_kwargs"``` in the config.

For reference, here are my results without and with these kwargs.
```
(mAP, disappearance, hallucination, misclass, tpr)

Single Modal Undefended
        Benign                    Adv
w/out	65; 29; 3.1; 3; 68        12; 81; 67; 1; 18
with    78; 15; 6.2; 4; 81         3; 91; 92; 0;  9

Multimodal undefended
        Benign                    Adv
w/out   66; 29; 2.9; 3; 68        27; 48; 26; 3; 49
with    79; 13; 4.5; 4; 83        35; 32; 29; 3; 65

Multimodal defended
        Benign                    Adv
w/out   70; 28; 1.9; 3; 69        35; 46; 8.7; 3; 51
with    80; 14; 2.8; 3; 83        40; 33; 12.3; 3; 64

```