### PR TITLE
simplify release process

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,6 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
-          ref: ${{ github.event.client_payload.branch }}
 
       - name: 🔨 Build wheel
         run: |
@@ -86,7 +85,6 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
-          ref: ${{ github.event.client_payload.branch }}
 
       - name: 🌎 Setup Build Environment
         run: |

--- a/tools/trigger-release.sh
+++ b/tools/trigger-release.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+# conveience script to trigger a build and release of Armory
+# requires the environment variable ARMORY_GITHUB_TOKEN to be set
+
+
+if [ -z "$ARMORY_GITHUB_TOKEN" ] ; then
+    echo "environment variable ARMORY_GITHUB_TOKEN is not set"
+    exit 1
+fi
+
+
+read -e -p  "Are you sure you want to trigger a Armory build and release (y/n) " choice
+if [[ "$choice" != [Yy]* ]] ; then
+    echo "aborted."
+    exit 2
+fi
+
+echo "sending request to trigger build and release"
+
+curl \
+    -H "Accept: application/vnd.github.everest-preview+json"  \
+    -H "Authorization: token $ARMORY_GITHUB_TOKEN"  \
+    --request POST \
+    --data '{"event_type": "build-and-release"}' \
+    https://api.github.com/repos/twosixlabs/armory/dispatches
+
+echo sent.


### PR DESCRIPTION
release only from `master` instead of requiring a version branch like
`r0.17.2`
add convenience script for triggering release