### PR TITLE
Resort imports after merge

### DIFF
--- a/armory/art_experimental/attacks/carla_obj_det_patch.py
+++ b/armory/art_experimental/attacks/carla_obj_det_patch.py
@@ -10,9 +10,9 @@ from tqdm.auto import trange
 
 from armory.art_experimental.attacks.carla_obj_det_utils import (
     linear_depth_to_rgb,
-    rgb_depth_to_linear,
     linear_to_log,
     log_to_linear,
+    rgb_depth_to_linear,
 )
 from armory.logs import log
 from armory.utils.external_repo import ExternalRepoImport

--- a/armory/baseline_models/pytorch/yolov3.py
+++ b/armory/baseline_models/pytorch/yolov3.py
@@ -1,11 +1,9 @@
 from typing import Optional
 
-import torch
-
 from art.estimators.object_detection import PyTorchYolo
-from pytorchyolo.utils.loss import compute_loss
 from pytorchyolo.models import load_model
-
+from pytorchyolo.utils.loss import compute_loss
+import torch
 
 DEVICE = torch.device("cuda" if torch.cuda.is_available() else "cpu")
 

--- a/armory/data/adversarial_datasets.py
+++ b/armory/data/adversarial_datasets.py
@@ -17,8 +17,8 @@ from armory.data.adversarial import (  # noqa: F401
     resisc45_densenet121_univpatch_and_univperturbation_adversarial_224x224,
     ucf101_mars_perturbation_and_patch_adversarial_112x112,
 )
-from armory.data.adversarial import carla_mot_dev as cmotd  # noqa: F401
 from armory.data.adversarial import apricot_dev, apricot_test  # noqa: F401
+from armory.data.adversarial import carla_mot_dev as cmotd  # noqa: F401
 from armory.data.adversarial import carla_mot_test as cmott  # noqa: F401
 from armory.data.adversarial import carla_obj_det_dev as codd  # noqa: F401
 from armory.data.adversarial import carla_obj_det_test as codt  # noqa: F401

--- a/armory/data/datasets.py
+++ b/armory/data/datasets.py
@@ -28,10 +28,10 @@ from armory.data.digit import digit as digit_tfds  # noqa: F401
 from armory.data.german_traffic_sign import german_traffic_sign as gtsrb  # noqa: F401
 from armory.data.librispeech import librispeech_dev_clean_split  # noqa: F401
 from armory.data.librispeech import librispeech_full as lf  # noqa: F401
+from armory.data.minicoco import minicoco as mc  # noqa: F401
 from armory.data.resisc10 import resisc10_poison  # noqa: F401
 from armory.data.resisc45 import resisc45_split  # noqa: F401
 from armory.data.ucf101 import ucf101_clean as uc  # noqa: F401
-from armory.data.minicoco import minicoco as mc  # noqa: F401
 from armory.data.utils import (
     _read_validate_scenario_config,
     add_checksums_dir,

--- a/armory/data/datasets.py
+++ b/armory/data/datasets.py
@@ -644,9 +644,9 @@ def check_shapes(actual, target):
     actual and target should be tuples
         actual should not have None values
     """
-    if type(actual) != tuple:
+    if type(actual) != tuple: # noqa
         raise ValueError(f"actual shape {actual} is not a tuple")
-    if type(target) != tuple:
+    if type(target) != tuple: # noqa
         raise ValueError(f"target shape {target} is not a tuple")
     if None in actual:
         raise ValueError(f"None should not be in actual shape {actual}")

--- a/armory/data/datasets.py
+++ b/armory/data/datasets.py
@@ -644,9 +644,9 @@ def check_shapes(actual, target):
     actual and target should be tuples
         actual should not have None values
     """
-    if type(actual) != tuple: # noqa
+    if type(actual) != tuple:  # noqa
         raise ValueError(f"actual shape {actual} is not a tuple")
-    if type(target) != tuple: # noqa
+    if type(target) != tuple:  # noqa
         raise ValueError(f"target shape {target} is not a tuple")
     if None in actual:
         raise ValueError(f"None should not be in actual shape {actual}")

--- a/armory/metrics/poisoning.py
+++ b/armory/metrics/poisoning.py
@@ -3,8 +3,8 @@ from importlib import import_module
 
 from PIL import Image
 import numpy as np
-import torch
 import tensorflow as tf
+import torch
 
 from armory.data.utils import maybe_download_weights_from_s3
 

--- a/armory/scenarios/poison.py
+++ b/armory/scenarios/poison.py
@@ -11,6 +11,7 @@ import numpy as np
 from tensorflow.random import set_seed as tf_set_seed
 
 from armory import metrics
+from armory.data import majority_masks as majority_mask_dir
 from armory.data.datasets import NumpyDataGenerator
 from armory.instrument import GlobalMeter, LogWriter, Meter, ResultsWriter
 from armory.instrument.export import ImageClassificationExporter
@@ -19,7 +20,6 @@ from armory.metrics.poisoning import ExplanatoryModel
 from armory.scenarios.scenario import Scenario
 from armory.scenarios.utils import to_categorical
 from armory.utils import config_loading
-from armory.data import majority_masks as majority_mask_dir
 
 
 class DatasetPoisoner:

--- a/armory/scenarios/poisoning_obj_det.py
+++ b/armory/scenarios/poisoning_obj_det.py
@@ -1,21 +1,18 @@
 import copy
 
-import imgaug.augmenters as iaa
 from imgaug.augmentables.bbs import BoundingBox, BoundingBoxesOnImage
+import imgaug.augmenters as iaa
 import numpy as np
 import torch
 from torchvision.ops import nms
 from tqdm import tqdm
 
-from armory.logs import log
 from armory import metrics
-from armory.instrument import LogWriter, Meter, ResultsWriter, GlobalMeter
+from armory.instrument import GlobalMeter, LogWriter, Meter, ResultsWriter
+from armory.instrument.export import ExportMeter, ObjectDetectionExporter
+from armory.logs import log
 from armory.scenarios.poison import Poison
 from armory.utils import config_loading
-from armory.instrument.export import (
-    ExportMeter,
-    ObjectDetectionExporter,
-)
 
 """
 Paper link: https://arxiv.org/pdf/2205.14497.pdf

--- a/armory/utils/labels.py
+++ b/armory/utils/labels.py
@@ -266,6 +266,6 @@ class MatchedTranscriptLengthTargeter:
 
     def generate(self, y):
         y_target = [self._generate(y_i) for y_i in y]
-        if type(y) != list: # noqa
+        if type(y) != list:  # noqa
             y_target = np.array(y_target)
         return y_target

--- a/armory/utils/labels.py
+++ b/armory/utils/labels.py
@@ -266,6 +266,6 @@ class MatchedTranscriptLengthTargeter:
 
     def generate(self, y):
         y_target = [self._generate(y_i) for y_i in y]
-        if type(y) != list:
+        if type(y) != list: # noqa
             y_target = np.array(y_target)
         return y_target


### PR DESCRIPTION
This pull request serves to address both `isort` errors and `E721` errors that surfaced following a recent merge into the `develop` branch. 

**Details of Changes:**

1. **Resorting Imports:** To eliminate `isort` errors, the imports have been resorted.

2. **Refining Type Checks:** The `E721` errors were resolved by refining our type checks.


Please review the changes and provide your feedback.