### PR TITLE
Remove np.object references

### DIFF
--- a/armory/art_experimental/attacks/sweep.py
+++ b/armory/art_experimental/attacks/sweep.py
@@ -142,7 +142,7 @@ class SweepAttack(EvasionAttack):
             return metric_result > self.metric_threshold
 
     def _get_metric_result(self, y, y_pred):
-        if isinstance(y, np.ndarray) and y.dtype == np.object:
+        if isinstance(y, np.ndarray) and y.dtype == object:
             # convert np object array to list of dicts
             metric_result = self.metric_fn([y[0]], y_pred)
         else:

--- a/armory/data/datasets.py
+++ b/armory/data/datasets.py
@@ -698,14 +698,14 @@ def canonical_variable_image_preprocess(context, batch):
     """
     Preprocessing when images are of variable size
     """
-    if batch.dtype == np.object:
+    if batch.dtype == object:
         for x in batch:
             check_shapes(x.shape, context.x_shape)
             assert x.dtype == context.input_type
             assert x.min() >= context.input_min
             assert x.max() <= context.input_max
 
-        quantized_batch = np.zeros_like(batch, dtype=np.object)
+        quantized_batch = np.zeros_like(batch, dtype=object)
         for i in range(len(batch)):
             quantized_batch[i] = (
                 batch[i].astype(context.output_type) / context.quantization


### PR DESCRIPTION
To fix #1971, the three references to ```np.object``` are replaced with ```object```, as advised by the error statement:

> To avoid this error in existing code, use `object` by itself. Doing this will not modify any behavior and is safe.