### PR TITLE
OD poison update

### DIFF
--- a/armory/scenarios/poisoning_obj_det.py
+++ b/armory/scenarios/poisoning_obj_det.py
@@ -104,9 +104,8 @@ class ObjectDetectionPoisoningScenario(Poison):
         y = y[0]
         for box, label in zip(y["boxes"], y["labels"]):
             if (
-                box[2] - box[0] > self.patch_x_dim + 1
-                and box[3] - box[1] > self.patch_y_dim + 1
-                # TODO: remove +1 after ART 1.15.0 fixes a bug
+                box[2] - box[0] > self.patch_x_dim
+                and box[3] - box[1] > self.patch_y_dim
             ):
                 new_y["boxes"].append(box)
                 new_y["labels"].append(label)


### PR DESCRIPTION
ART has [corrected](https://github.com/Trusted-AI/adversarial-robustness-toolbox/pull/2143) an off-by-1 situation so it no longer needs to be accounted for here.